### PR TITLE
Remove swift-log dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,15 +37,6 @@
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-system", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-format.git", from: "508.0.1"),
@@ -39,7 +38,6 @@ let package = Package(
                 "WasmKit",
                 "WASI",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Logging", package: "swift-log"),
                 .product(name: "SystemPackage", package: "swift-system"),
             ]
         ),
@@ -64,7 +62,6 @@ let package = Package(
             dependencies: [
                 "WasmKit",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Logging", package: "swift-log"),
                 .product(name: "SystemPackage", package: "swift-system"),
             ]
         ),

--- a/Sources/Spectest/TestCase.swift
+++ b/Sources/Spectest/TestCase.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Logging
 import SystemPackage
 import WasmKit
 
@@ -86,7 +85,7 @@ struct TestCase {
         return isDirectory
     }
 
-    static func load(include: [String], exclude: [String], in path: String, logger: Logger? = nil) throws -> [TestCase] {
+    static func load(include: [String], exclude: [String], in path: String, log: ((String) -> Void)? = nil) throws -> [TestCase] {
         let fileManager = FileManager.default
         let filePath = FilePath(path)
         let dirPath: String
@@ -126,7 +125,7 @@ struct TestCase {
 
         var testCases: [TestCase] = []
         for filePath in filePaths where try matchesPattern(filePath) {
-            logger?.info("loading \(filePath)")
+            log?("loading \(filePath)")
             let path = dirPath + "/" + filePath
             guard let data = fileManager.contents(atPath: path) else {
                 assertionFailure("failed to load \(filePath)")


### PR DESCRIPTION
swift-log is only used in the top-level executable targets and it means we don't need logging abstraction layer for now. Reducing the number of dependencies makes it easier to integrate in apple/swift build system.