### PR TITLE
Expose a way to allocate a memory from host

### DIFF
--- a/Tests/WasmKitTests/Execution/HostModuleTests.swift
+++ b/Tests/WasmKitTests/Execution/HostModuleTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+@testable import WasmKit
+
+final class HostModuleTests: XCTestCase {
+    func testImportMemory() throws {
+        let runtime = Runtime()
+        let memoryType = MemoryType(min: 1, max: nil)
+        let memoryAddr = runtime.store.allocate(memoryType: memoryType)
+        try runtime.store.register(HostModule(memories: ["memory": memoryAddr]), as: "env")
+
+        let module = Module(
+            imports: [
+                Import(module: "env", name: "memory", descriptor: .memory(memoryType))
+            ]
+        )
+        XCTAssertNoThrow(try runtime.instantiate(module: module))
+        // Ensure the allocated address is valid
+        _ = runtime.store.memory(at: memoryAddr)
+    }
+}


### PR DESCRIPTION
When using WasmKit, in certain cases we need `HostModule` to provide a host memory instance, as opposed to an already supported case, where a parsed module has its own guest memory.