### PR TITLE
Extract `ExecutionState` from the `Runtime` type

### DIFF
--- a/Sources/Spectest/TestCase.swift
+++ b/Sources/Spectest/TestCase.swift
@@ -192,7 +192,6 @@ extension TestCase {
             ) { command, result in
                 handler(self, command, result)
             }
-            assert(runtime.isStackEmpty)
         }
     }
 }

--- a/Sources/WasmKit/Component/CanonicalCall.swift
+++ b/Sources/WasmKit/Component/CanonicalCall.swift
@@ -35,7 +35,9 @@ public struct CanonicalCallContext {
         guard let realloc = options.realloc else {
             throw CanonicalABIError(description: "Missing required \"cabi_realloc\" export")
         }
-        let results = try runtime.invoke(realloc, with: [.i32(old), .i32(oldSize), .i32(oldAlign), .i32(newSize)])
+        let results = try realloc.invoke(
+            [.i32(old), .i32(oldSize), .i32(oldAlign), .i32(newSize)], runtime: runtime
+        )
         guard results.count == 1 else {
             throw CanonicalABIError(description: "\"cabi_realloc\" export should return a single value")
         }

--- a/Sources/WasmKit/Component/CanonicalOptions.swift
+++ b/Sources/WasmKit/Component/CanonicalOptions.swift
@@ -18,13 +18,13 @@ public struct CanonicalOptions {
     /// The string encoding used for lifting or lowering string values.
     public let stringEncoding: StringEncoding
     /// The realloc function address used for lifting or lowering values.
-    public let realloc: FunctionAddress?
+    public let realloc: Function?
     /// The function address called when a lifted/lowered function returns.
-    public let postReturn: FunctionAddress?
+    public let postReturn: Function?
 
     public init(
         memory: MemoryAddress, stringEncoding: StringEncoding,
-        realloc: FunctionAddress?, postReturn: FunctionAddress?
+        realloc: Function?, postReturn: Function?
     ) {
         self.memory = memory
         self.stringEncoding = stringEncoding

--- a/Sources/WasmKit/Execution/Runtime/ExecutionState.swift
+++ b/Sources/WasmKit/Execution/Runtime/ExecutionState.swift
@@ -1,0 +1,130 @@
+/// An execution state of an invocation of exported function.
+///
+/// Each new invocation through exported function has a separate ``ExecutionState``
+/// even though the invocation happens during another invocation.
+struct ExecutionState {
+    var stack = Stack()
+    /// Index of an instruction to be executed in the current function.
+    var programCounter = 0
+
+    var isStackEmpty: Bool {
+        stack.top == nil
+    }
+}
+
+extension ExecutionState {
+    mutating func execute(_ instruction: Instruction, runtime: Runtime) throws {
+        switch instruction {
+        case let .control(instruction):
+            return try instruction.execute(runtime: runtime, execution: &self)
+
+        case let .memory(instruction):
+            try instruction.execute(&stack, runtime.store)
+
+        case let .numeric(instruction):
+            try instruction.execute(&stack)
+
+        case let .parametric(instruction):
+            try instruction.execute(&stack)
+
+        case let .reference(instruction):
+            try instruction.execute(&stack)
+
+        case let .table(instruction):
+            try instruction.execute(runtime: runtime, execution: &self)
+
+        case let .variable(instruction):
+            try instruction.execute(&stack, &runtime.store.globals)
+        case .pseudo:
+            // Structured pseudo instructions (end/else) should not appear at runtime
+            throw Trap.unreachable
+        }
+
+        programCounter += 1
+    }
+
+    mutating func branch(labelIndex: Int) throws {
+        let label = try stack.getLabel(index: Int(labelIndex))
+        let values = try stack.popValues(count: label.arity)
+
+        var lastLabel: Label?
+        for _ in 0...labelIndex {
+            stack.discardTopValues()
+            lastLabel = try stack.popLabel()
+        }
+
+        stack.push(values: values)
+        programCounter = lastLabel!.continuation
+    }
+
+    /// > Note:
+    /// <https://webassembly.github.io/spec/core/exec/instructions.html#entering-xref-syntax-instructions-syntax-instr-mathit-instr-ast-with-label-l>
+    mutating func enter(_ expression: Expression, continuation: Int, arity: Int) {
+        let exit = programCounter + 1
+        let label = Label(arity: arity, expression: expression, continuation: continuation, exit: exit)
+        stack.push(label: label)
+        programCounter = label.expression.instructions.startIndex
+    }
+
+    /// > Note:
+    /// <https://webassembly.github.io/spec/core/exec/instructions.html#exiting-xref-syntax-instructions-syntax-instr-mathit-instr-ast-with-label-l>
+    mutating func exit(label: Label) throws {
+        let values = try stack.popTopValues()
+        let lastLabel = try stack.popLabel()
+        assert(lastLabel == label)
+        stack.push(values: values)
+        programCounter = label.exit
+    }
+
+    /// > Note:
+    /// <https://webassembly.github.io/spec/core/exec/instructions.html#invocation-of-function-address>
+    mutating func invoke(functionAddress address: FunctionAddress, runtime: Runtime) throws {
+        runtime.interceptor?.onEnterFunction(address, store: runtime.store)
+
+        switch try runtime.store.function(at: address) {
+        case let .host(function):
+            let parameters = try stack.popValues(count: function.type.parameters.count)
+            let caller = Caller(store: runtime.store, instance: stack.currentFrame.module)
+            stack.push(values: try function.implementation(caller, parameters))
+
+            programCounter += 1
+
+        case let .wasm(function, body: body):
+            let locals = function.code.locals.map { $0.defaultValue }
+            let expression = body
+
+            let arguments = try stack.popValues(count: function.type.parameters.count)
+
+            let arity = function.type.results.count
+            try stack.push(frame: .init(arity: arity, module: function.module, locals: arguments + locals, address: address))
+
+            self.enter(
+                expression, continuation: programCounter + 1,
+                arity: arity
+            )
+        }
+    }
+
+    public mutating func step(runtime: Runtime) throws {
+        if let label = stack.currentLabel {
+            if programCounter < label.expression.instructions.count {
+                try execute(stack.currentLabel.expression.instructions[programCounter], runtime: runtime)
+            } else {
+                try self.exit(label: label)
+            }
+        } else {
+            if let address = stack.currentFrame.address {
+                runtime.interceptor?.onExitFunction(address, store: runtime.store)
+            }
+            let values = try stack.popValues(count: stack.currentFrame.arity)
+            try stack.popFrame()
+            stack.push(values: values)
+        }
+    }
+
+    public mutating func run(runtime: Runtime) throws {
+        while stack.currentFrame != nil {
+            try step(runtime: runtime)
+        }
+    }
+}

--- a/Sources/WasmKit/Execution/Runtime/Function.swift
+++ b/Sources/WasmKit/Execution/Runtime/Function.swift
@@ -1,0 +1,47 @@
+public struct Function: Equatable {
+    internal let address: FunctionAddress
+
+    /// Invokes a function of the given address with the given parameters.
+    public func invoke(_ arguments: [Value] = [], runtime: Runtime) throws -> [Value] {
+        var execution = ExecutionState()
+        try invoke(execution: &execution, with: arguments, runtime: runtime)
+        try execution.run(runtime: runtime)
+        return try execution.stack.popTopValues()
+    }
+
+    private func invoke(execution: inout ExecutionState, with arguments: [Value], runtime: Runtime) throws {
+        switch try runtime.store.function(at: address) {
+        case let .host(function):
+            try check(functionType: function.type, parameters: arguments)
+
+            let parameters = try execution.stack.popValues(count: function.type.parameters.count)
+
+            let caller = Caller(store: runtime.store, instance: execution.stack.currentFrame.module)
+            let results = try function.implementation(caller, parameters)
+            try check(functionType: function.type, results: results)
+            execution.stack.push(values: results)
+
+        case let .wasm(function, _):
+            try check(functionType: function.type, parameters: arguments)
+            execution.stack.push(values: arguments)
+
+            try execution.invoke(functionAddress: address, runtime: runtime)
+        }
+    }
+
+    private func check(functionType: FunctionType, parameters: [Value]) throws {
+        let parameterTypes = parameters.map { $0.type }
+
+        guard parameterTypes == functionType.parameters else {
+            throw Trap._raw("parameters types don't match, expected \(functionType.parameters), got \(parameterTypes)")
+        }
+    }
+
+    private func check(functionType: FunctionType, results: [Value]) throws {
+        let resultTypes = results.map { $0.type }
+
+        guard resultTypes == functionType.results else {
+            throw Trap._raw("result types don't match, expected \(functionType.results), got \(resultTypes)")
+        }
+    }
+}

--- a/Sources/WasmKit/Execution/Runtime/Store.swift
+++ b/Sources/WasmKit/Execution/Runtime/Store.swift
@@ -34,7 +34,7 @@ public struct HostModule {
 /// > Note:
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#store>
 public final class Store {
-    private var hostFunctions: [HostFunction] = []
+    var hostFunctions: [HostFunction] = []
     private var hostGlobals: [GlobalInstance] = []
     var nameRegistry = NameRegistry()
 
@@ -140,7 +140,7 @@ extension Store {
         }
 
         for (functionName, function) in hostModule.functions {
-            moduleExports[functionName] = .function(-hostFunctions.count - 1)
+            moduleExports[functionName] = .function(Function(address: -hostFunctions.count - 1))
             hostFunctions.append(function)
         }
 
@@ -177,9 +177,9 @@ extension Store {
             }
 
             switch (i.descriptor, external) {
-            case let (.function(typeIndex), .function(functionAddress)):
+            case let (.function(typeIndex), .function(externalFunc)):
                 let type: FunctionType
-                switch try function(at: functionAddress) {
+                switch try function(at: externalFunc.address) {
                 case let .host(function):
                     type = function.type
 
@@ -234,7 +234,7 @@ extension Store {
             switch external {
             case let .function(address):
                 // Step 14.
-                moduleInstance.functionAddresses.append(address)
+                moduleInstance.functionAddresses.append(address.address)
             case let .table(address):
                 // Step 15.
                 moduleInstance.tableAddresses.append(address)

--- a/Sources/WasmKit/Execution/Types/Instances.swift
+++ b/Sources/WasmKit/Execution/Types/Instances.swift
@@ -4,7 +4,7 @@
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#module-instances>
 public final class ModuleInstance {
     public internal(set) var types: [FunctionType] = []
-    public internal(set) var functionAddresses: [FunctionAddress] = []
+    var functionAddresses: [FunctionAddress] = []
     public internal(set) var tableAddresses: [TableAddress] = []
     public internal(set) var memoryAddresses: [MemoryAddress] = []
     public internal(set) var globalAddresses: [GlobalAddress] = []
@@ -24,9 +24,9 @@ public final class ModuleInstance {
     ///
     /// - Parameter name: The name of the exported function.
     /// - Returns: The address of the exported function if found, otherwise `nil`.
-    func exportedFunction(name: String) -> FunctionAddress? {
+    func exportedFunction(name: String) -> Function? {
         switch exports[name] {
-        case .function(let address): return address
+        case .function(let function): return function
         default: return nil
         }
     }
@@ -170,7 +170,7 @@ public struct DataInstance {
 /// > Note:
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval>
 public enum ExternalValue: Equatable {
-    case function(FunctionAddress)
+    case function(Function)
     case table(TableAddress)
     case memory(MemoryAddress)
     case global(GlobalAddress)
@@ -186,7 +186,9 @@ public struct ExportInstance: Equatable {
         name = export.name
         switch export.descriptor {
         case let .function(index):
-            value = ExternalValue.function(moduleInstance.functionAddresses[Int(index)])
+            value = ExternalValue.function(
+                Function(address: moduleInstance.functionAddresses[Int(index)])
+            )
         case let .table(index):
             value = ExternalValue.table(moduleInstance.tableAddresses[Int(index)])
         case let .memory(index):

--- a/Tests/WasmKitTests/Execution/Instructions/VariableInstructionTests.swift
+++ b/Tests/WasmKitTests/Execution/Instructions/VariableInstructionTests.swift
@@ -18,17 +18,18 @@ final class VariableInstructionTests: XCTestCase {
             ]
         )
 
+        var execution = ExecutionState()
         let runtime = Runtime()
 
         _ = try runtime.instantiate(module: module)
 
-        try runtime.invoke(functionAddress: 0)
+        try execution.invoke(functionAddress: 0, runtime: runtime)
 
-        try runtime.step()
-        try runtime.step()
+        try execution.step(runtime: runtime)
+        try execution.step(runtime: runtime)
 
-        XCTAssertEqual(runtime.stack.top, .label(.init(arity: 1, expression: expression, continuation: 1, exit: 1)))
-        XCTAssertEqual(runtime.stack.currentFrame.locals, [.i32(42)])
+        XCTAssertEqual(execution.stack.top, .label(.init(arity: 1, expression: expression, continuation: 1, exit: 1)))
+        XCTAssertEqual(execution.stack.currentFrame.locals, [.i32(42)])
     }
 
     func testLocalGet() throws {
@@ -47,18 +48,19 @@ final class VariableInstructionTests: XCTestCase {
             ]
         )
 
+        var execution = ExecutionState()
         let runtime = Runtime()
 
         _ = try runtime.instantiate(module: module)
 
-        try runtime.invoke(functionAddress: 0)
+        try execution.invoke(functionAddress: 0, runtime: runtime)
 
-        try runtime.step()
-        try runtime.step()
-        try runtime.step()
+        try execution.step(runtime: runtime)
+        try execution.step(runtime: runtime)
+        try execution.step(runtime: runtime)
 
-        XCTAssertEqual(runtime.stack.top, .value(.i32(42)))
-        XCTAssertEqual(runtime.stack.currentFrame.locals, [.i32(42)])
+        XCTAssertEqual(execution.stack.top, .value(.i32(42)))
+        XCTAssertEqual(execution.stack.currentFrame.locals, [.i32(42)])
     }
 
     func testLocalTee() throws {
@@ -76,16 +78,17 @@ final class VariableInstructionTests: XCTestCase {
             ]
         )
 
+        var execution = ExecutionState()
         let runtime = Runtime()
 
         _ = try runtime.instantiate(module: module)
 
-        try runtime.invoke(functionAddress: 0)
+        try execution.invoke(functionAddress: 0, runtime: runtime)
 
-        try runtime.step()
-        try runtime.step()
+        try execution.step(runtime: runtime)
+        try execution.step(runtime: runtime)
 
-        XCTAssertEqual(runtime.stack.top, .value(.i32(42)))
-        XCTAssertEqual(runtime.stack.currentFrame.locals, [.i32(42)])
+        XCTAssertEqual(execution.stack.top, .value(.i32(42)))
+        XCTAssertEqual(execution.stack.currentFrame.locals, [.i32(42)])
     }
 }


### PR DESCRIPTION
`Runtime` no longer manages the execution state of a guest program. Separating the execution state makes it easier to have a fresh stack for each invocation of an exported function. Also it's now safe to provide a way to access `Runtime` during `HostFunction` execution since no mutable execution state is exposed.

Additionally, tests were added to verify the new API surface.