### PR TITLE
Mark `Function` as `internal` and rename it as `GuestFunction`

### DIFF
--- a/Sources/WasmKit/Execution/Runtime/Store.swift
+++ b/Sources/WasmKit/Execution/Runtime/Store.swift
@@ -321,7 +321,7 @@ extension Store {
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/exec/modules.html#alloc-func>
-    func allocate(function: Function, module: ModuleInstance) -> FunctionAddress {
+    func allocate(function: GuestFunction, module: ModuleInstance) -> FunctionAddress {
         let address = functions.count
         let instance = FunctionInstance(function, module: module)
         functions.append(instance)

--- a/Sources/WasmKit/Execution/Types/Instances.swift
+++ b/Sources/WasmKit/Execution/Types/Instances.swift
@@ -37,9 +37,9 @@ public final class ModuleInstance {
 public struct FunctionInstance {
     public let type: FunctionType
     public let module: ModuleInstance
-    public var code: Function
+    var code: GuestFunction
 
-    init(_ function: Function, module: ModuleInstance) {
+    init(_ function: GuestFunction, module: ModuleInstance) {
         type = module.types[Int(function.type)]
         self.module = module
         code = function

--- a/Sources/WasmKit/Parser/Wasm/WasmParser.swift
+++ b/Sources/WasmKit/Parser/Wasm/WasmParser.swift
@@ -1265,7 +1265,7 @@ extension WasmParser {
         }
 
         let functions = codes.enumerated().map { [hasDataCount, features] index, code in
-            Function(
+            GuestFunction(
                 type: typeIndices[index], locals: code.locals,
                 body: {
                     let stream = StaticByteStream(bytes: Array(code.expression))

--- a/Sources/WasmKit/Types/Module.swift
+++ b/Sources/WasmKit/Types/Module.swift
@@ -4,7 +4,7 @@
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#modules>
 public struct Module {
     public internal(set) var types: [FunctionType]
-    public internal(set) var functions: [Function]
+    var functions: [GuestFunction]
     public internal(set) var tables: [Table]
     public internal(set) var memories: [Memory]
     public internal(set) var globals: [Global]
@@ -16,9 +16,9 @@ public struct Module {
     public internal(set) var exports: [Export]
     public internal(set) var customSections = [CustomSection]()
 
-    public init(
+    init(
         types: [FunctionType] = [],
-        functions: [Function] = [],
+        functions: [GuestFunction] = [],
         tables: [Table] = [],
         memories: [Memory] = [],
         globals: [Global] = [],
@@ -67,7 +67,7 @@ public typealias LabelIndex = UInt32
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#functions>
-public struct Function {
+struct GuestFunction {
     init(type: TypeIndex, locals: [ValueType], body: @escaping () throws -> Expression) {
         self.type = type
         self.locals = locals

--- a/Tests/WasmKitTests/Execution/Instructions/ControlInstructionTests.swift
+++ b/Tests/WasmKitTests/Execution/Instructions/ControlInstructionTests.swift
@@ -398,7 +398,7 @@ final class ControlInstructionTests: XCTestCase {
     }
 }
 
-extension Function {
+extension GuestFunction {
     init(type: TypeIndex, locals: [ValueType], body: Expression) {
         self.init(type: type, locals: locals, body: { body })
     }


### PR DESCRIPTION
This resolves a naming collision between the existing `Function` type declared in `Types/Module.swift` and `Runtime/Function.swift` that in a subsequent change fails the build with these errors:

```
WasmKit/Types/Module.swift:21:21: error: 'Function' is ambiguous for type lookup in this context
        functions: [Function] = [],
                    ^~~~~~~~
WasmKit/Execution/Runtime/Function.swift:1:15: note: found this candidate
public struct Function: Equatable {
              ^
WasmKit/Types/Module.swift:70:15: note: found this candidate
public struct Function {
```