### PR TITLE
Support building CLI via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,13 @@ endif()
 # The subdirectory into which host libraries will be installed.
 set(SWIFT_HOST_LIBRARIES_SUBDIRECTORY "swift/host")
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 set(CMAKE_MACOSX_RPATH YES)
+
+set(BUILD_SHARED_LIBS OFF)
 
 include(AddSwiftHostLibrary)
 
@@ -51,6 +53,21 @@ if(NOT SwiftSystem_FOUND)
     GIT_TAG 1.1.1
   )
   FetchContent_MakeAvailable(SwiftSystem)
+endif()
+
+option(WASMKIT_BUILD_CLI "Build wasmkit-cli" ON)
+
+if(WASMKIT_BUILD_CLI)
+  set(BUILD_TESTING OFF) # disable ArgumentParser tests
+  find_package(ArgumentParser CONFIG)
+  if(NOT ArgumentParser_FOUND)
+    message("-- Vending ArgumentParser")
+    FetchContent_Declare(ArgumentParser
+            GIT_REPOSITORY https://github.com/apple/swift-argument-parser
+            GIT_TAG 1.2.2
+    )
+    FetchContent_MakeAvailable(ArgumentParser)
+  endif()
 endif()
 
 add_subdirectory(Sources)

--- a/Sources/CLI/CMakeLists.txt
+++ b/Sources/CLI/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(wasmkit-cli
+    Run/Run.swift
+    CLI.swift
+)
+
+target_link_wasmkit_libraries(wasmkit-cli PUBLIC
+  ArgumentParser WasmKitWASI)
+
+install(TARGETS wasmkit-cli
+  RUNTIME DESTINATION bin)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -4,3 +4,7 @@ add_subdirectory(SystemExtras)
 add_subdirectory(WASI)
 add_subdirectory(WasmTypes)
 add_subdirectory(WasmParser)
+
+if(WASMKIT_BUILD_CLI)
+  add_subdirectory(CLI)
+endif()

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -139,7 +139,7 @@ function(add_wasmkit_library name)
     install(
       DIRECTORY ${module_base}
       DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
-      FILES_MATCHING PATTERN "*.swiftinterface"
+      FILES_MATCHING PATTERN "*.swiftmodule"
     )
   else()
     set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})


### PR DESCRIPTION
This enables building and installing wasmkit-cli with CMake. At some point we might want to update the `wasmkit.py` product in the Swift repo to use this instead of `swift build`, since we're already building WasmKit via CMake for swift-wasm-plugin-server.