### PR TITLE
Add `WallClock` and `MonotonicClock` protocols

### DIFF
--- a/Sources/WASI/Clock.swift
+++ b/Sources/WASI/Clock.swift
@@ -1,0 +1,101 @@
+import SystemExtras
+
+/// WASI wall clock interface based on WASI Preview 2 `wall-clock` interface.
+///
+/// See also https://github.com/WebAssembly/wasi-clocks/blob/v0.2.0/wit/wall-clock.wit
+public protocol WallClock {
+    /// An instant in time, in seconds and nanoseconds.
+    typealias Duration = (
+        seconds: UInt64,
+        nanoseconds: UInt32
+    )
+
+    /// Read the current value of the clock.
+    func now() throws -> Duration
+
+    /// Query the resolution of the clock.
+    ///
+    /// The nanoseconds field of the output is always less than 1000000000.
+    func resolution() throws -> Duration
+}
+
+/// A wall clock that uses the system's wall clock.
+public struct SystemWallClock: WallClock {
+    private var underlying: SystemExtras.Clock {
+    #if os(Linux)
+        return .boottime
+    #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return .rawMonotonic
+    #elseif os(OpenBSD) || os(FreeBSD) || os(WASI)
+        return .monotonic
+    #else
+        #error("Unsupported platform")
+    #endif
+    }
+
+    public init() {}
+
+    public func now() throws -> WallClock.Duration {
+        let timeSpec = try WASIAbi.Errno.translatingPlatformErrno {
+            try underlying.currentTime()
+        }
+        return (seconds: UInt64(timeSpec.seconds), nanoseconds: UInt32(timeSpec.nanoseconds))
+    }
+
+    public func resolution() throws -> WallClock.Duration {
+        let timeSpec = try WASIAbi.Errno.translatingPlatformErrno {
+            try underlying.resolution()
+        }
+        return (seconds: UInt64(timeSpec.seconds), nanoseconds: UInt32(timeSpec.nanoseconds))
+    }
+}
+
+/// WASI monotonic clock interface based on WASI Preview 2 `monotonic-clock` interface.
+///
+/// See also https://github.com/WebAssembly/wasi-clocks/blob/v0.2.0/wit/monotonic-clock.wit
+public protocol MonotonicClock {
+    /// An instant in time, in nanoseconds.
+    typealias Instant = UInt64
+    /// A duration of time, in nanoseconds.
+    typealias Duration = UInt64
+
+    /// Read the current value of the clock.
+    func now() throws -> Instant
+
+    /// Query the resolution of the clock. Returns the duration of time
+    /// corresponding to a clock tick.
+    func resolution() throws -> Duration
+}
+
+/// A monotonic clock that uses the system's monotonic clock.
+public struct SystemMonotonicClock: MonotonicClock {
+    private var underlying: SystemExtras.Clock {
+    #if os(Linux)
+        return .monotonic
+    #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return .rawUptime
+    #elseif os(WASI)
+        return .monotonic
+    #elseif os(OpenBSD) || os(FreeBSD)
+        return .uptime
+    #else
+        #error("Unsupported platform")
+    #endif
+    }
+
+    public init() {}
+
+    public func now() throws -> MonotonicClock.Instant {
+        let timeSpec = try WASIAbi.Errno.translatingPlatformErrno {
+            try underlying.currentTime()
+        }
+        return WASIAbi.Timestamp(platformTimeSpec: timeSpec)
+    }
+
+    public func resolution() throws -> MonotonicClock.Duration {
+        let timeSpec = try WASIAbi.Errno.translatingPlatformErrno {
+            try underlying.resolution()
+        }
+        return WASIAbi.Timestamp(platformTimeSpec: timeSpec)
+    }
+}

--- a/Sources/WASI/Platform/PlatformTypes.swift
+++ b/Sources/WASI/Platform/PlatformTypes.swift
@@ -115,12 +115,17 @@ extension WASIAbi.Filestat {
 
 extension WASIAbi.Timestamp {
 
-    fileprivate init(seconds: Int, nanoseconds: Int) {
-        self = UInt64(nanoseconds + seconds * 1_000_000_000)
+    fileprivate init(seconds: UInt64, nanoseconds: UInt64) {
+        self = nanoseconds + seconds * 1_000_000_000
     }
 
     init(platformTimeSpec timespec: Clock.TimeSpec) {
-        self.init(seconds: timespec.rawValue.tv_sec, nanoseconds: timespec.rawValue.tv_nsec)
+        self.init(seconds: UInt64(timespec.rawValue.tv_sec),
+                  nanoseconds: UInt64(timespec.rawValue.tv_nsec))
+    }
+
+    init(wallClockDuration duration: WallClock.Duration) {
+        self.init(seconds: duration.seconds, nanoseconds: UInt64(duration.nanoseconds))
     }
 }
 


### PR DESCRIPTION
This commit adds `WallClock` and `MononicClock` protocols to the WASI module. These protocols are used to abstract clocks in WASI implementations. This is useful when we want fully deterministic behavior like for build systems or tests.

Resolve a part of https://github.com/swiftwasm/WasmKit/issues/84