### PR TITLE
Fix CMake export

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -142,6 +142,6 @@ function(add_wasmkit_library name)
       FILES_MATCHING PATTERN "*.swiftmodule"
     )
   else()
-    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+    set_property(GLOBAL APPEND PROPERTY WASMKIT_EXPORTS ${name})
   endif()
 endfunction()


### PR DESCRIPTION
We were previously appending to `SWIFT_EXPORTS` which has a special meaning for in-tree swiftc builds. This was causing us to export WasmKit to all consumers of the Swift Compiler via CMake. Specifically, this resulted in failing builds of Swift's LLDB fork: see https://github.com/swiftlang/swift/pull/73031#issuecomment-2227365165.

We can fix this by using a different property name.