### PR TITLE
global variable initialization isn't allow with throw in swift6 compiler - adds boilerplate main() around the examples showing use of WasmKit

### DIFF
--- a/Examples/Sources/Factorial/Factorial.swift
+++ b/Examples/Sources/Factorial/Factorial.swift
@@ -4,15 +4,20 @@ import WasmKit
 import WAT
 import Foundation
 
-// Convert a WAT file to a Wasm binary, then parse it.
-let module = try parseWasm(
-    bytes: try wat2wasm(String(contentsOfFile: "wasm/factorial.wat"))
-)
+@main
+struct exampleExec {
+    static func main() throws {
+        // Convert a WAT file to a Wasm binary, then parse it.
+        let module = try parseWasm(
+            bytes: try wat2wasm(String(contentsOfFile: "wasm/factorial.wat"))
+        )
 
-// Create a module instance from the parsed module.
-let runtime = Runtime()
-let instance = try runtime.instantiate(module: module)
-let input: UInt64 = 5
-// Invoke the exported function "fac" with a single argument.
-let result = try runtime.invoke(instance, function: "fac", with: [.i64(input)])
-print("fac(\(input)) = \(result[0].i64)")
+        // Create a module instance from the parsed module.
+        let runtime = Runtime()
+        let instance = try runtime.instantiate(module: module)
+        let input: UInt64 = 5
+        // Invoke the exported function "fac" with a single argument.
+        let result = try runtime.invoke(instance, function: "fac", with: [.i64(input)])
+        print("fac(\(input)) = \(result[0].i64)")
+    }
+}

--- a/Examples/Sources/Factorial/Factorial.swift
+++ b/Examples/Sources/Factorial/Factorial.swift
@@ -5,7 +5,7 @@ import WAT
 import Foundation
 
 @main
-struct exampleExec {
+struct Example {
     static func main() throws {
         // Convert a WAT file to a Wasm binary, then parse it.
         let module = try parseWasm(

--- a/Examples/Sources/PrintAdd/PrintAdd.swift
+++ b/Examples/Sources/PrintAdd/PrintAdd.swift
@@ -3,30 +3,35 @@
 import WasmKit
 import WAT
 
-// Convert a WAT file to a Wasm binary, then parse it.
-let module = try parseWasm(
-    bytes: try wat2wasm(
-        """
-        (module
-          (import "printer" "print_i32" (func $print_i32 (param i32)))
-          (func (export "print_add") (param $x i32) (param $y i32)
-            (call $print_i32 (i32.add (local.get $x) (local.get $y)))
-          )
+@main
+struct exampleExec {
+    static func main() throws {
+        // Convert a WAT file to a Wasm binary, then parse it.
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                  (import "printer" "print_i32" (func $print_i32 (param i32)))
+                  (func (export "print_add") (param $x i32) (param $y i32)
+                    (call $print_i32 (i32.add (local.get $x) (local.get $y)))
+                  )
+                )
+                """
+            )
         )
-        """
-    )
-)
 
-// Define a host function that prints an i32 value.
-let hostPrint = HostFunction(type: FunctionType(parameters: [.i32])) { _, args in
-    // This function is called from "print_add" in the WebAssembly module.
-    print(args[0])
-    return []
+        // Define a host function that prints an i32 value.
+        let hostPrint = HostFunction(type: FunctionType(parameters: [.i32])) { _, args in
+            // This function is called from "print_add" in the WebAssembly module.
+            print(args[0])
+            return []
+        }
+        // Create a runtime importing the host function.
+        let runtime = Runtime(hostModules: [
+            "printer": HostModule(functions: ["print_i32": hostPrint])
+        ])
+        let instance = try runtime.instantiate(module: module)
+        // Invoke the exported function "print_add"
+        _ = try runtime.invoke(instance, function: "print_add", with: [.i32(42), .i32(3)])
+    }
 }
-// Create a runtime importing the host function.
-let runtime = Runtime(hostModules: [
-    "printer": HostModule(functions: ["print_i32": hostPrint])
-])
-let instance = try runtime.instantiate(module: module)
-// Invoke the exported function "print_add"
-_ = try runtime.invoke(instance, function: "print_add", with: [.i32(42), .i32(3)])

--- a/Examples/Sources/PrintAdd/PrintAdd.swift
+++ b/Examples/Sources/PrintAdd/PrintAdd.swift
@@ -4,7 +4,7 @@ import WasmKit
 import WAT
 
 @main
-struct exampleExec {
+struct Example {
     static func main() throws {
         // Convert a WAT file to a Wasm binary, then parse it.
         let module = try parseWasm(

--- a/Examples/Sources/WASI-Hello/Hello.swift
+++ b/Examples/Sources/WASI-Hello/Hello.swift
@@ -5,16 +5,21 @@ import WasmKitWASI
 import WAT
 import Foundation
 
-// Parse a WASI-compliant WebAssembly module from a file.
-let module = try parseWasm(filePath: "wasm/hello.wasm")
+@main
+struct exampleExec {
+    static func main() throws {
+        // Parse a WASI-compliant WebAssembly module from a file.
+        let module = try parseWasm(filePath: "wasm/hello.wasm")
 
-// Create a WASI instance forwarding to the host environment.
-let wasi = try WASIBridgeToHost()
-// Create a runtime with WASI host modules.
-let runtime = Runtime(hostModules: wasi.hostModules)
-let instance = try runtime.instantiate(module: module)
+        // Create a WASI instance forwarding to the host environment.
+        let wasi = try WASIBridgeToHost()
+        // Create a runtime with WASI host modules.
+        let runtime = Runtime(hostModules: wasi.hostModules)
+        let instance = try runtime.instantiate(module: module)
 
-// Start the WASI command-line application.
-let exitCode = try wasi.start(instance, runtime: runtime)
-// Exit the Swift program with the WASI exit code.
-exit(Int32(exitCode))
+        // Start the WASI command-line application.
+        let exitCode = try wasi.start(instance, runtime: runtime)
+        // Exit the Swift program with the WASI exit code.
+        exit(Int32(exitCode))
+    }
+}

--- a/Examples/Sources/WASI-Hello/Hello.swift
+++ b/Examples/Sources/WASI-Hello/Hello.swift
@@ -6,7 +6,7 @@ import WAT
 import Foundation
 
 @main
-struct exampleExec {
+struct Example {
     static func main() throws {
         // Parse a WASI-compliant WebAssembly module from a file.
         let module = try parseWasm(filePath: "wasm/hello.wasm")


### PR DESCRIPTION
I was exploring WasmKit this morning with Xcode 16 beta 5 (Swift 6 compiler), and none of the examples would compile smoothly there. I thought this PR would resolve this for others trying to do the same. 