### PR TITLE
Re-introduce guest time profiler without overhead when not used 

### DIFF
--- a/Sources/WasmKit/Execution/Instructions/Control.swift
+++ b/Sources/WasmKit/Execution/Instructions/Control.swift
@@ -125,4 +125,19 @@ extension ExecutionState {
             md: &md, ms: &ms
         )
     }
+
+    mutating func onEnter(context: inout StackContext, sp: Sp, onEnterOperand: Instruction.OnEnterOperand) {
+        let function = context.currentInstance.functions[Int(onEnterOperand)]
+        self.runtime.value.interceptor?.onEnterFunction(
+            Function(handle: function, allocator: self.runtime.store.allocator),
+            store: self.runtime.store
+        )
+    }
+    mutating func onExit(context: inout StackContext, sp: Sp, onExitOperand: Instruction.OnExitOperand) {
+        let function = context.currentInstance.functions[Int(onExitOperand)]
+        self.runtime.value.interceptor?.onExitFunction(
+            Function(handle: function, allocator: self.runtime.store.allocator),
+            store: self.runtime.store
+        )
+    }
 }

--- a/Sources/WasmKit/Execution/Instructions/Control.swift
+++ b/Sources/WasmKit/Execution/Instructions/Control.swift
@@ -45,19 +45,19 @@ extension ExecutionState {
 
         try branch(offset: entry.offset)
     }
-    mutating func `return`(context: inout StackContext, sp: Sp, md: inout Md, ms: inout Ms, returnOperand: Instruction.ReturnOperand) throws {
-        try self.endOfFunction(context: &context, sp: sp, md: &md, ms: &ms, returnOperand: returnOperand)
+    mutating func `return`(context: inout StackContext, sp: Sp, md: inout Md, ms: inout Ms) throws {
+        try self.endOfFunction(context: &context, sp: sp, md: &md, ms: &ms)
     }
 
-    mutating func endOfFunction(context: inout StackContext, sp: Sp, md: inout Md, ms: inout Ms, returnOperand: Instruction.ReturnOperand) throws {
-        try self.endOfFunction(context: &context, currentFrame: context.currentFrame, returnOperand: returnOperand, md: &md, ms: &ms)
+    mutating func endOfFunction(context: inout StackContext, sp: Sp, md: inout Md, ms: inout Ms) throws {
+        try self.endOfFunction(context: &context, currentFrame: context.currentFrame, md: &md, ms: &ms)
     }
 
     mutating func endOfExecution(context: inout StackContext, sp: Sp) throws {
         reachedEndOfExecution = true
     }
 
-    private mutating func endOfFunction(context: inout StackContext, currentFrame: Frame, returnOperand: Instruction.ReturnOperand, md: inout Md, ms: inout Ms) throws {
+    private mutating func endOfFunction(context: inout StackContext, currentFrame: Frame, md: inout Md, ms: inout Ms) throws {
         // When reached at "end" of function
         let lastInstanceAddr = context.popFrame()
         programCounter = currentFrame.returnPC

--- a/Sources/WasmKit/Execution/Instructions/Expression.swift
+++ b/Sources/WasmKit/Execution/Instructions/Expression.swift
@@ -21,17 +21,17 @@ struct InstructionSequence: Equatable {
     }
 }
 
-extension InstructionSequence {
-    func write<Target>(to target: inout Target, function: Function) where Target : TextOutputStream {
-        var hexOffsetWidth = String(self.instructions.count - 1, radix: 16).count
+extension Collection where Element == Instruction {
+    func write<Target>(to target: inout Target, context: InstructionPrintingContext) where Target : TextOutputStream {
+        var hexOffsetWidth = String(self.count - 1, radix: 16).count
         hexOffsetWidth = (hexOffsetWidth + 1) & ~1
-        for (index, instruction) in instructions.enumerated() {
+        for (index, instruction) in self.enumerated() {
             var hexOffset = String(index, radix: 16)
             while hexOffset.count < hexOffsetWidth {
                 hexOffset = "0" + hexOffset
             }
             target.write("0x\(hexOffset): ")
-            instruction.print(to: &target, function: function)
+            instruction.print(to: &target, context: context)
             target.write("\n")
         }
     }

--- a/Sources/WasmKit/Execution/Instructions/Instruction.swift
+++ b/Sources/WasmKit/Execution/Instructions/Instruction.swift
@@ -124,4 +124,6 @@ enum Instruction: Equatable {
     case tableCopy(Instruction.TableCopyOperand)
     case tableInit(Instruction.TableInitOperand)
     case tableElementDrop(ElementIndex)
+    case onEnter(Instruction.OnEnterOperand)
+    case onExit(Instruction.OnExitOperand)
 }

--- a/Sources/WasmKit/Execution/Instructions/Instruction.swift
+++ b/Sources/WasmKit/Execution/Instructions/Instruction.swift
@@ -13,8 +13,8 @@ enum Instruction: Equatable {
     case brIf(Instruction.BrIfOperand)
     case brIfNot(Instruction.BrIfOperand)
     case brTable(Instruction.BrTableOperand)
-    case `return`(Instruction.ReturnOperand)
-    case endOfFunction(Instruction.ReturnOperand)
+    case `return`
+    case endOfFunction
     case endOfExecution
     case i32Load(Instruction.LoadOperand)
     case i64Load(Instruction.LoadOperand)

--- a/Sources/WasmKit/Execution/Instructions/InstructionSupport.swift
+++ b/Sources/WasmKit/Execution/Instructions/InstructionSupport.swift
@@ -205,7 +205,10 @@ extension Instruction {
 
     struct ReturnOperand: Equatable {
     }
-    
+
+    typealias OnEnterOperand = FunctionIndex
+    typealias OnExitOperand = FunctionIndex
+
     static func f32Lt(_ op: BinaryOperand) -> Instruction { .numericFloatBinary(.lt(.f32), op) }
     static func f32Gt(_ op: BinaryOperand) -> Instruction { .numericFloatBinary(.gt(.f32), op) }
     static func f32Le(_ op: BinaryOperand) -> Instruction { .numericFloatBinary(.le(.f32), op) }

--- a/Sources/WasmKit/Execution/Instructions/InstructionSupport.swift
+++ b/Sources/WasmKit/Execution/Instructions/InstructionSupport.swift
@@ -203,9 +203,6 @@ extension Instruction {
         let callLike: CallLikeOperand
     }
 
-    struct ReturnOperand: Equatable {
-    }
-
     typealias OnEnterOperand = FunctionIndex
     typealias OnExitOperand = FunctionIndex
 

--- a/Sources/WasmKit/Execution/Instructions/InstructionSupport.swift
+++ b/Sources/WasmKit/Execution/Instructions/InstructionSupport.swift
@@ -297,13 +297,24 @@ extension Instruction {
     static func i64TruncSatF64U(_ op: UnaryOperand) -> Instruction { .numericConversion(.truncSaturatingUnsigned(.i64, .f64), op) }
 }
 
-extension Instruction {
-    func print<Target>(to target: inout Target, function: Function) where Target : TextOutputStream {
-        func reg(_ reg: Register) -> String {
-            let adjusted = Register(StackLayout.frameHeaderSize(type: function.type)) + reg
+struct InstructionPrintingContext {
+    let shouldColor: Bool
+    let function: Function
+
+    func reg(_ reg: Instruction.Register) -> String {
+        let adjusted = Instruction.Register(StackLayout.frameHeaderSize(type: function.type)) + reg
+        if shouldColor {
             let regColor = adjusted < 15 ? "\u{001B}[3\(adjusted + 1)m" : ""
             return "\(regColor)reg:\(reg)\u{001B}[0m"
+        } else {
+            return "reg:\(reg)"
         }
+    }
+}
+
+extension Instruction {
+    func print<Target>(to target: inout Target, context: InstructionPrintingContext) where Target : TextOutputStream {
+        func reg(_ reg: Instruction.Register) -> String { context.reg(reg) }
         func memarg(_ memarg: MemArg) -> String {
             "offset: \(memarg.offset)"
         }

--- a/Sources/WasmKit/Execution/Runtime/InstDispatch.swift
+++ b/Sources/WasmKit/Execution/Runtime/InstDispatch.swift
@@ -42,11 +42,11 @@ extension ExecutionState {
         case .brTable(let brTableOperand):
             try self.brTable(context: &context, sp: sp, brTableOperand: brTableOperand)
             return true
-        case .`return`(let returnOperand):
-            try self.`return`(context: &context, sp: sp, md: &md, ms: &ms, returnOperand: returnOperand)
+        case .`return`:
+            try self.`return`(context: &context, sp: sp, md: &md, ms: &ms)
             return false
-        case .endOfFunction(let returnOperand):
-            try self.endOfFunction(context: &context, sp: sp, md: &md, ms: &ms, returnOperand: returnOperand)
+        case .endOfFunction:
+            try self.endOfFunction(context: &context, sp: sp, md: &md, ms: &ms)
             return false
         case .endOfExecution:
             try self.endOfExecution(context: &context, sp: sp)

--- a/Sources/WasmKit/Execution/Runtime/InstDispatch.swift
+++ b/Sources/WasmKit/Execution/Runtime/InstDispatch.swift
@@ -267,6 +267,10 @@ extension ExecutionState {
             try self.tableInit(context: &context, sp: sp, tableInitOperand: tableInitOperand)
         case .tableElementDrop(let elementIndex):
             self.tableElementDrop(context: &context, sp: sp, elementIndex: elementIndex)
+        case .onEnter(let onEnterOperand):
+            self.onEnter(context: &context, sp: sp, onEnterOperand: onEnterOperand)
+        case .onExit(let onExitOperand):
+            self.onExit(context: &context, sp: sp, onExitOperand: onExitOperand)
         }
         programCounter += 1
         return true
@@ -401,6 +405,8 @@ extension Instruction {
         case .tableCopy: return "tableCopy"
         case .tableInit: return "tableInit"
         case .tableElementDrop: return "tableElementDrop"
+        case .onEnter: return "onEnter"
+        case .onExit: return "onExit"
         }
     }
 }

--- a/Sources/WasmKit/Execution/Runtime/NameRegistry.swift
+++ b/Sources/WasmKit/Execution/Runtime/NameRegistry.swift
@@ -40,4 +40,16 @@ struct NameRegistry {
         try materializeIfNeeded()
         return functionNames[addr]
     }
+
+    mutating func symbolicate(_ function: InternalFunction) -> String {
+        if let name = try? lookup(function) {
+            return name
+        }
+        // Fallback
+        if function.isWasm {
+            return "unknown function[\(function.wasm.index)]"
+        } else {
+            return "unknown host function"
+        }
+    }
 }

--- a/Sources/WasmKit/Execution/Runtime/Profiler.swift
+++ b/Sources/WasmKit/Execution/Runtime/Profiler.swift
@@ -1,3 +1,140 @@
+import SystemExtras
+import SystemPackage
+
+/// A simple time-profiler for guest process to emit `chrome://tracing` format
+/// This profiler works only when WasmKit is built with debug configuration (`swift build -c debug`)
 @_documentation(visibility: internal)
-@available(*, unavailable, message: "Interceptors are not supported anymore for performance reasons")
-public class GuestTimeProfiler {}
+public class GuestTimeProfiler: RuntimeInterceptor {
+    struct Event: Codable {
+        enum Phase: String, Codable {
+            case begin = "B"
+            case end = "E"
+        }
+        let ph: Phase
+        let pid: Int
+        let name: String
+        let ts: Int
+
+        var jsonLine: String {
+            #"{"ph":"\#(ph.rawValue)","pid":\#(pid),"name":\#(JSON.serialize(name)),"ts":\#(ts)}"#
+        }
+    }
+
+    private var output: (_ line: String) -> Void
+    private var hasFirstEvent: Bool = false
+
+    #if swift(>=5.7) && os(Windows)
+        // We can use ContinuousClock on platforms that doesn't ship stdlib as stable ABI
+        // Once we drop macOS 12.3, iOS 15.4, watchOS 8.5, and tvOS 15.4 support, we can remove
+        // this conditional compilation
+        private typealias Instant = ContinuousClock.Instant
+
+        private static func getTimestamp() -> Instant {
+            ContinuousClock.now
+        }
+
+        private func getDurationSinceStart() -> Int {
+            let duration = self.startTime.duration(to: .now)
+            let (seconds, attoseconds) = duration.components
+            // Convert to microseconds
+            return Int(seconds * 1_000_000 + attoseconds / 1_000_000_000_000)
+        }
+
+    #else
+
+        private typealias Instant = UInt64
+
+        private static func getTimestamp() -> UInt64 {
+            let clock: SystemExtras.Clock
+            #if os(Linux)
+                clock = .boottime
+            #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+                clock = .rawMonotonic
+            #elseif os(OpenBSD) || os(FreeBSD) || os(WASI)
+                clock = .monotonic
+            #else
+                #error("Unsupported platform")
+            #endif
+            let timeSpec = try! clock.currentTime()
+            return UInt64(timeSpec.nanoseconds / 1_000 + timeSpec.seconds * 1_000_000)
+        }
+        private func getDurationSinceStart() -> Int {
+            Int(Self.getTimestamp() - startTime)
+        }
+    #endif
+
+    private let startTime: Instant
+
+    public init(output: @escaping (_ line: String) -> Void) {
+        self.output = output
+        self.startTime = Self.getTimestamp()
+        self.output("[\n")
+    }
+
+    private func addEventLine(_ event: Event) {
+        let line = event.jsonLine
+        if !hasFirstEvent {
+            self.output(line)
+            hasFirstEvent = true
+        } else {
+            self.output(",\n")
+            self.output(line)
+        }
+    }
+
+    public func onEnterFunction(_ function: Function, store: Store) {
+        let event = Event(
+            ph: .begin, pid: 1,
+            name: store.nameRegistry.symbolicate(function.handle),
+            ts: getDurationSinceStart()
+        )
+        addEventLine(event)
+    }
+
+    public func onExitFunction(_ function: Function, store: Store) {
+        let event = Event(
+            ph: .end, pid: 1,
+            name: store.nameRegistry.symbolicate(function.handle),
+            ts: getDurationSinceStart()
+        )
+        addEventLine(event)
+    }
+
+    public func finalize() {
+        output("\n]")
+    }
+}
+
+/// Foundation-less JSON serialization
+private enum JSON {
+    static func serialize(_ value: String) -> String {
+        // https://www.ietf.org/rfc/rfc4627.txt
+        var output = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"":
+                output += "\\\""
+            case "\\":
+                output += "\\\\"
+            case "\u{08}":
+                output += "\\b"
+            case "\u{0C}":
+                output += "\\f"
+            case "\n":
+                output += "\\n"
+            case "\r":
+                output += "\\r"
+            case "\t":
+                output += "\\t"
+            case "\u{20}"..."\u{21}", "\u{23}"..."\u{5B}", "\u{5D}"..."\u{10FFFF}":
+                output.unicodeScalars.append(scalar)
+            default:
+                var hex = String(scalar.value, radix: 16, uppercase: true)
+                hex = String(repeating: "0", count: 4 - hex.count) + hex
+                output += "\\u" + hex
+            }
+        }
+        output += "\""
+        return output
+    }
+}

--- a/Sources/WasmKit/Execution/Runtime/Runtime.swift
+++ b/Sources/WasmKit/Execution/Runtime/Runtime.swift
@@ -3,13 +3,15 @@ import WasmParser
 /// A container to manage execution state of one or more module instances.
 public final class Runtime {
     public let store: Store
+    let interceptor: RuntimeInterceptor?
     let funcTypeInterner: Interner<FunctionType>
 
     /// Initializes a new instant of a WebAssembly interpreter runtime.
     /// - Parameter hostModules: Host module names mapped to their corresponding ``HostModule`` definitions.
-    public init(hostModules: [String: HostModule] = [:]) {
+    public init(hostModules: [String: HostModule] = [:], interceptor: RuntimeInterceptor? = nil) {
         self.funcTypeInterner = Interner<FunctionType>()
         store = Store(funcTypeInterner: funcTypeInterner)
+        self.interceptor = interceptor
 
         for (moduleName, hostModule) in hostModules {
             store.registerUniqueHostModule(hostModule, as: moduleName, runtime: self)
@@ -25,7 +27,6 @@ public final class Runtime {
 }
 
 @_documentation(visibility: internal)
-@available(*, unavailable, message: "Interceptors are not supported anymore for performance reasons")
 public protocol RuntimeInterceptor {
     func onEnterFunction(_ function: Function, store: Store)
     func onExitFunction(_ function: Function, store: Store)

--- a/Sources/WasmKit/Execution/Runtime/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/Runtime/StoreAllocator.swift
@@ -296,8 +296,8 @@ extension StoreAllocator {
         let functions = allocateEntities(
             imports: importedFunctions,
             internals: module.functions,
-            allocateHandle: { f, _ in
-                allocate(function: f, instance: instanceHandle, runtime: runtime)
+            allocateHandle: { f, index in
+                allocate(function: f, index: FunctionIndex(index), instance: instanceHandle, runtime: runtime)
             }
         )
 
@@ -412,13 +412,14 @@ extension StoreAllocator {
     /// TODO: Mark as private
     func allocate(
         function: GuestFunction,
+        index: FunctionIndex,
         instance: InternalInstance,
         runtime: Runtime
     ) -> InternalFunction {
         let code = InternalUncompiledCode(unsafe: codes.allocate(initializing: function.code))
         let pointer = functions.allocate(
             initializing: WasmFunctionEntity(
-                type: runtime.internType(function.type),
+                index: index, type: runtime.internType(function.type),
                 code: code,
                 instance: instance
             )

--- a/Sources/WasmKit/Execution/Runtime/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/Runtime/StoreAllocator.swift
@@ -111,6 +111,10 @@ struct ImmutableArray<T> {
         buffer[index]
     }
 
+    subscript<R>(range: R) -> Slice<UnsafeBufferPointer<Element>> where R: RangeExpression, R.Bound == Int {
+        buffer[range]
+    }
+
     /// Accesses the element at the specified position, with bounds checking.
     subscript(validating index: Int) -> T where T: ValidatableEntity {
         get throws {

--- a/Sources/WasmKit/Execution/Types/Instances.swift
+++ b/Sources/WasmKit/Execution/Types/Instances.swift
@@ -137,7 +137,11 @@ public struct Instance {
             target.write(" ====\n")
             try function.ensureCompiled(runtime: RuntimeRef(runtime))
             let (iseq, _, _) = function.assumeCompiled()
-            iseq.write(to: &target, function: Function(handle: function, allocator: allocator))
+            let context = InstructionPrintingContext(
+                shouldColor: true,
+                function: Function(handle: function, allocator: allocator)
+            )
+            iseq.instructions.write(to: &target, context: context)
         }
     }
 }

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -268,12 +268,8 @@ struct StackLayout {
         return Instruction.Register(index) - paramResultBase
     }
 
-    func isParamerterLocal(_ index: LocalIndex) -> Bool {
-        return index < type.parameters.count
-    }
-
     func localReg(_ index: LocalIndex) -> Instruction.Register {
-        if isParamerterLocal(index) {
+        if index < type.parameters.count {
             return paramReg(Int(index))
         } else {
             return Instruction.Register(index) - Instruction.Register(type.parameters.count)
@@ -385,7 +381,7 @@ struct InstructionTranslator<Context: TranslatorContext>: InstructionVisitor {
     enum ValueSource {
         case register(Instruction.Register)
         case local(LocalIndex)
-        
+
         func intoRegister(layout: StackLayout) -> Instruction.Register {
             switch self {
             case .register(let register):
@@ -402,7 +398,7 @@ struct InstructionTranslator<Context: TranslatorContext>: InstructionVisitor {
         private(set) var maxHeight: Int = 0
         var height: Int { values.count }
         let stackRegBase: Instruction.Register
-    
+
         init(stackRegBase: Instruction.Register) {
             self.stackRegBase = stackRegBase
         }
@@ -766,43 +762,11 @@ struct InstructionTranslator<Context: TranslatorContext>: InstructionVisitor {
     }
 
     private mutating func visitReturnLike() throws {
-        var copies: [(source: Instruction.Register, dest: Instruction.Register)] = []
+        preserveAllLocalsOnStack()
         for (index, resultType) in self.type.results.enumerated().reversed() {
+            let result = try valueStack.pop(resultType)
+            let source = result.intoRegister(layout: stackLayout)
             let dest = returnReg(index)
-            switch try valueStack.pop(resultType) {
-            case .local(let localIndex):
-                let source = localReg(localIndex)
-                if stackLayout.isParamerterLocal(localIndex) {
-                    if source == dest {
-                        // If the local is a parameter and the return value is placed in
-                        // the same position, no need to copy.
-                        // e.g. `(func (param i32) (result i32) (local.get 0))` is
-                        // translated to no-op
-                        continue
-                    }
-                    // For local variables originated from params, we need
-                    // two copies to avoid the value being overwritten
-                    // because parameters and results share the same stack
-                    // space.
-
-                    // 1.Copy the local variable to a temporary register
-                    // first to save the value
-                    let tmpReg = valueStack.stackRegBase + Instruction.Register(valueStack.height)
-                    emitCopyStack(from: source, to: tmpReg)
-                    // 2. Then schedule the copy from the temporary register
-                    // to the return register
-                    copies.append((tmpReg, dest))
-                } else {
-                    // For local variables not originated from params, we
-                    // can directly copy the value to the return register
-                    copies.append((source, dest))
-                }
-            case .register(let register):
-                copies.append((register, dest))
-            }
-        }
-        // Emit copy operations targeting the return registers
-        for (source, dest) in copies {
             emitCopyStack(from: source, to: dest)
         }
     }

--- a/Tests/WasmKitTests/EngineTests.swift
+++ b/Tests/WasmKitTests/EngineTests.swift
@@ -41,7 +41,6 @@ final class EngineTests: XCTestCase {
         checkSize(Instruction.CallOperand.self)
         checkSize(Instruction.InternalCallOperand.self)
         checkSize(Instruction.CallIndirectOperand.self)
-        checkSize(Instruction.ReturnOperand.self)
         checkSize(Instruction.BrTable.self)
 
     }

--- a/Tests/WasmKitTests/TranslatorTests.swift
+++ b/Tests/WasmKitTests/TranslatorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import WasmKit
+import WAT
+
+final class TranslatorTests: XCTestCase {
+    func assertTranslate(_ wat: String, _ expected: [[Instruction]], line: UInt = #line) throws {
+        let module = try parseWasm(bytes: wat2wasm(wat))
+        let runtime = Runtime()
+        let instance = try runtime.instantiate(module: module)
+        let definedFunctions = instance.handle.functions[
+            module.translatorContext.imports.numberOfFunctions..<instance.handle.functions.count
+        ]
+        for (function, expected) in zip(definedFunctions, expected) {
+            try function.ensureCompiled(runtime: RuntimeRef(runtime))
+            let (iseq, _, _) = function.assumeCompiled()
+            if Array(iseq.instructions) == expected { continue }
+
+            var out = "Actual:\n"
+            let function = Function(handle: function, allocator: runtime.store.allocator)
+            let context = InstructionPrintingContext(shouldColor: false, function: function)
+            iseq.instructions.write(to: &out, context: context)
+            out += "\n\n"
+            out += "Expected:\n"
+            expected.write(to: &out, context: context)
+            XCTFail(out, line: line)
+        }
+    }
+
+    func testParamReturn() throws {
+        try assertTranslate("""
+        (func (param i32) (result i32)
+            local.get 0
+        )
+        """, [[
+            .copyStack(Instruction.CopyStackOperand(source: -1, dest: 0)),
+            .copyStack(Instruction.CopyStackOperand(source: 0, dest: -1)),
+            .return(Instruction.ReturnOperand()),
+            .endOfFunction(Instruction.ReturnOperand())
+        ]])
+    }
+}

--- a/Tests/WasmKitTests/TranslatorTests.swift
+++ b/Tests/WasmKitTests/TranslatorTests.swift
@@ -35,8 +35,8 @@ final class TranslatorTests: XCTestCase {
         """, [[
             .copyStack(Instruction.CopyStackOperand(source: -1, dest: 0)),
             .copyStack(Instruction.CopyStackOperand(source: 0, dest: -1)),
-            .return(Instruction.ReturnOperand()),
-            .endOfFunction(Instruction.ReturnOperand())
+            .return,
+            .endOfFunction
         ]])
     }
 }

--- a/Utilities/Sources/GenerateInternalInstruction.swift
+++ b/Utilities/Sources/GenerateInternalInstruction.swift
@@ -268,12 +268,8 @@ enum GenerateInternalInstruction {
                 immediates: [
                     Immediate(name: nil, type: "Instruction.BrTableOperand")
                 ]),
-            Instruction(name: "`return`", isControl: true, mayThrow: true, mayUpdateFrame: true, useCurrentMemory: .write, immediates: [
-                Immediate(name: nil, type: "Instruction.ReturnOperand")
-            ]),
-            Instruction(name: "endOfFunction", isControl: true, mayThrow: true, mayUpdateFrame: true, useCurrentMemory: .write, immediates: [
-                Immediate(name: nil, type: "Instruction.ReturnOperand")
-            ]),
+            Instruction(name: "`return`", isControl: true, mayThrow: true, mayUpdateFrame: true, useCurrentMemory: .write, immediates: []),
+            Instruction(name: "endOfFunction", isControl: true, mayThrow: true, mayUpdateFrame: true, useCurrentMemory: .write, immediates: []),
             Instruction(name: "endOfExecution", isControl: true, mayThrow: true, mayUpdateFrame: true, immediates: []),
         ]
         + memoryLoadStoreInsts

--- a/Utilities/Sources/GenerateInternalInstruction.swift
+++ b/Utilities/Sources/GenerateInternalInstruction.swift
@@ -209,6 +209,9 @@ enum GenerateInternalInstruction {
         Instruction(name: "tableCopy", mayThrow: true, immediates: [Immediate(name: nil, type: "Instruction.TableCopyOperand")]),
         Instruction(name: "tableInit", mayThrow: true, immediates: [Immediate(name: nil, type: "Instruction.TableInitOperand")]),
         Instruction(name: "tableElementDrop", immediates: [Immediate(name: nil, type: "ElementIndex")]),
+        // Profiling
+        Instruction(name: "onEnter", immediates: [Immediate(name: nil, type: "Instruction.OnEnterOperand")]),
+        Instruction(name: "onExit", immediates: [Immediate(name: nil, type: "Instruction.OnExitOperand")]),
     ]
 
     static let instructions: [Instruction] =


### PR DESCRIPTION
The guest time profiler had been disabled by default build configuration
because the interceptor mechanism added non-negligible overhead to the
execution even when the profiler is not used due to the conditional call
to the interceptor methods on every function call.
The translation layer enables the conditional interceptor call to appear
only when the profiler is enabled. The translated ISeq will contain
`onEnter` and `onExit` instructions at the beginning and the end of each
function, respectively, if the profiler is enabled.

```
;; When profiler is enabled
i32.const 0
i32.const 1
i32.add
end

;; When profiler is disabled
on_enter
i32.const 0
i32.const 1
i32.add
on_exit
end
```