### PR TITLE
Minimal SIMD types support

### DIFF
--- a/Sources/WAT/Encoder.swift
+++ b/Sources/WAT/Encoder.swift
@@ -119,6 +119,7 @@ extension ValueType: WasmEncodable {
         case .i64: encoder.output.append(0x7E)
         case .f32: encoder.output.append(0x7D)
         case .f64: encoder.output.append(0x7C)
+        case .v128: encoder.output.append(0x7B)
         case .ref(let refType): refType.encode(to: &encoder)
         }
     }

--- a/Sources/WasmKit/Execution/UntypedValue.swift
+++ b/Sources/WasmKit/Execution/UntypedValue.swift
@@ -142,6 +142,8 @@ struct UntypedValue: Equatable, Hashable {
         case .i64: return .i64(i64)
         case .f32: return .f32(rawF32)
         case .f64: return .f64(rawF64)
+        case .v128:
+            fatalError("v128 value type is not supported yet.")
         case .ref(let referenceType):
             return .ref(asReference(referenceType))
         }

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -430,6 +430,7 @@ extension Parser {
         case 0x7E: return .i64
         case 0x7D: return .f32
         case 0x7C: return .f64
+        case 0x7B: return .f64
         case 0x70: return .ref(.funcRef)
         case 0x6F: return .ref(.externRef)
         default:

--- a/Sources/WasmTypes/WasmTypes.swift
+++ b/Sources/WasmTypes/WasmTypes.swift
@@ -31,6 +31,8 @@ public enum ValueType: Equatable, Hashable {
     case f32
     /// 64-bit IEEE 754 floating-point number.
     case f64
+    /// 128-bit vector of packed integer or floating-point data.
+    case v128
     /// Reference value type.
     case ref(ReferenceType)
 }


### PR DESCRIPTION
Nothing is implemented yet but just not to prevent parsing a name section of a module with SIMD types.