### PR TITLE
Function References Draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ and should work on the following platforms:
 |                      | [Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md) | ✅ Implemented |
 |                      | [Memory64](https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md) | ✅ Implemented |
 |                      | [Threads and atomics](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md) | 🚧 Parser implemented |
+|                      | [Typed Function References](https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md) | 📋 Todo  |
+|                      | [Garbage Collection](https://github.com/WebAssembly/gc/blob/main/proposals/gc/Overview.md) |  📋 Todo |
 | WASI | WASI Preview 1 | ✅ Implemented |
 
 

--- a/Sources/WAT/BinaryInstructionEncoder.swift
+++ b/Sources/WAT/BinaryInstructionEncoder.swift
@@ -384,4 +384,8 @@ extension BinaryInstructionEncoder {
         try encodeInstruction([0xFC, 0x10])
         try encodeImmediates(table: table)
     }
+    mutating func visitCallRef(functionIndex: UInt32) throws {
+        try encodeInstruction([0x14])
+        try encodeImmediates(functionIndex: functionIndex)
+    }
 }

--- a/Sources/WAT/Encoder.swift
+++ b/Sources/WAT/Encoder.swift
@@ -129,7 +129,9 @@ extension ReferenceType: WasmEncodable {
     func encode(to encoder: inout Encoder) {
         switch self {
         case .funcRef: encoder.output.append(0x70)
+        case .funcRefNonNull: encoder.output.append(0x71)
         case .externRef: encoder.output.append(0x6F)
+        case .externRefNonNull: encoder.output.append(0x6E) // Is this correct
         }
     }
 }

--- a/Sources/WAT/ParseTextInstruction.swift
+++ b/Sources/WAT/ParseTextInstruction.swift
@@ -326,6 +326,9 @@ func parseTextInstruction<V: InstructionVisitor>(keyword: String, expressionPars
     case "i64.trunc_sat_f32_u": return { return try $0.visitConversion(.i64TruncSatF32U) }
     case "i64.trunc_sat_f64_s": return { return try $0.visitConversion(.i64TruncSatF64S) }
     case "i64.trunc_sat_f64_u": return { return try $0.visitConversion(.i64TruncSatF64U) }
+    case "call_ref":
+        let (functionIndex) = try expressionParser.visitCallRef(wat: &wat)
+        return { return try $0.visitCallRef(functionIndex: functionIndex) }
     default: return nil
     }
 }

--- a/Sources/WAT/Parser/ExpressionParser.swift
+++ b/Sources/WAT/Parser/ExpressionParser.swift
@@ -362,7 +362,9 @@ struct ExpressionParser<Visitor: InstructionVisitor> {
     }
 
     private mutating func refKind() throws -> ReferenceType {
-        if try parser.takeKeyword("func") {
+        if try parser.take(.id) {
+            return .funcRef // not sure about this.
+        } else if try parser.takeKeyword("func") {
             return .funcRef
         } else if try parser.takeKeyword("extern") {
             return .externRef
@@ -438,6 +440,10 @@ extension ExpressionParser {
     mutating func visitCall(wat: inout Wat) throws -> UInt32 {
         let use = try parser.expectIndexOrId()
         return UInt32(try wat.functionsMap.resolve(use: use).index)
+    }
+    mutating func visitCallRef(wat: inout Wat) throws -> UInt32 {
+        let use = try parser.expectIndexOrId()
+        return UInt32(try wat.types.resolve(use: use).index)
     }
     mutating func visitCallIndirect(wat: inout Wat) throws -> (typeIndex: UInt32, tableIndex: UInt32) {
         let tableIndex: UInt32

--- a/Sources/WAT/Parser/WastParser.swift
+++ b/Sources/WAT/Parser/WastParser.swift
@@ -67,7 +67,9 @@ struct WastParser {
             let value: Reference
             switch type {
             case .externRef: value = .extern(nil)
+            case .externRefNonNull: value = .function(nil) // non null
             case .funcRef: value = .function(nil)
+            case .funcRefNonNull: value = .function(nil) // non null
             }
             addValue(.ref(value))
         }

--- a/Sources/WasmKit/Execution/ConstEvaluation.swift
+++ b/Sources/WasmKit/Execution/ConstEvaluation.swift
@@ -62,8 +62,8 @@ extension ConstExpression {
             return try context.globalValue(globalIndex)
         case .refNull(let type):
             switch type {
-            case .externRef: return .ref(.extern(nil))
-            case .funcRef: return .ref(.function(nil))
+            case .externRef, .externRefNonNull: return .ref(.extern(nil))
+            case .funcRef, .funcRefNonNull: return .ref(.function(nil))
             }
         case .refFunc(let functionIndex):
             return try .ref(context.functionRef(functionIndex))

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -277,8 +277,12 @@ struct TableEntity /* : ~Copyable */ {
         switch tableType.elementType {
         case .funcRef:
             emptyElement = .function(nil)
+        case .funcRefNonNull:
+            emptyElement = .function(nil) // shouldn't be null
         case .externRef:
             emptyElement = .extern(nil)
+        case .externRefNonNull:
+            emptyElement = .extern(nil) // shouldn't be null
         }
 
         let numberOfElements = Int(tableType.limits.min)

--- a/Sources/WasmKit/Execution/Instructions/Misc.swift
+++ b/Sources/WasmKit/Execution/Instructions/Misc.swift
@@ -22,9 +22,9 @@ extension Execution {
     mutating func refNull(sp: Sp, immediate: Instruction.RefNullOperand) {
         let value: Value
         switch immediate.type {
-        case .externRef:
+        case .externRef, .externRefNonNull:
             value = .ref(.extern(nil))
-        case .funcRef:
+        case .funcRef, .funcRefNonNull:
             value = .ref(.function(nil))
         }
         sp[immediate.result] = UntypedValue(value)

--- a/Sources/WasmKit/Execution/UntypedValue.swift
+++ b/Sources/WasmKit/Execution/UntypedValue.swift
@@ -117,7 +117,13 @@ struct UntypedValue: Equatable, Hashable {
         switch type {
         case .funcRef:
             return .function(decodeOptionalInt())
+        case .funcRefNonNull:
+            // can skip optional check
+            return .function(decodeOptionalInt())
         case .externRef:
+            return .extern(decodeOptionalInt())
+        case .externRefNonNull:
+            // can skip optional check
             return .extern(decodeOptionalInt())
         }
     }

--- a/Sources/WasmKit/Validator.swift
+++ b/Sources/WasmKit/Validator.swift
@@ -318,9 +318,13 @@ struct ModuleValidator {
 extension WasmTypes.Reference {
     /// Checks if the reference type matches the expected type.
     func checkType(_ type: WasmTypes.ReferenceType) throws {
+
+        // Should we validate nonNull variants have associated values present?
         switch (self, type) {
         case (.function, .funcRef): return
+        case (.function, .funcRefNonNull): return
         case (.extern, .externRef): return
+        case (.extern, .externRefNonNull): return
         default:
             throw ValidationError(.expectTypeButGot(expected: "\(type)", got: "\(self)"))
         }

--- a/Sources/WasmParser/BinaryInstructionDecoder.swift
+++ b/Sources/WasmParser/BinaryInstructionDecoder.swift
@@ -82,6 +82,8 @@ protocol BinaryInstructionDecoder {
     @inlinable mutating func visitTableGrow() throws -> UInt32
     /// Decode `table.size` immediates
     @inlinable mutating func visitTableSize() throws -> UInt32
+    /// Decode `call_ref` immediates
+    @inlinable mutating func visitCallRef() throws -> UInt32
 }
 @inlinable
 func parseBinaryInstruction<V: InstructionVisitor, D: BinaryInstructionDecoder>(visitor: inout V, decoder: inout D) throws -> Bool {
@@ -122,6 +124,9 @@ func parseBinaryInstruction<V: InstructionVisitor, D: BinaryInstructionDecoder>(
     case 0x11:
         let (typeIndex, tableIndex) = try decoder.visitCallIndirect()
         try visitor.visitCallIndirect(typeIndex: typeIndex, tableIndex: tableIndex)
+    case 0x14:
+        let (functionIndex) = try decoder.visitCallRef()
+        try visitor.visitCallRef(functionIndex: functionIndex)
     case 0x1A:
         try visitor.visitDrop()
     case 0x1B:

--- a/Sources/WasmParser/InstructionVisitor.swift
+++ b/Sources/WasmParser/InstructionVisitor.swift
@@ -224,6 +224,7 @@ public enum Instruction: Equatable {
     case `tableSet`(table: UInt32)
     case `tableGrow`(table: UInt32)
     case `tableSize`(table: UInt32)
+    case `callRef`(functionIndex: UInt32)
 }
 
 /// A visitor that visits all instructions by a single visit method.
@@ -283,6 +284,7 @@ extension AnyInstructionVisitor {
     public mutating func visitTableSet(table: UInt32) throws { return try self.visit(.tableSet(table: table)) }
     public mutating func visitTableGrow(table: UInt32) throws { return try self.visit(.tableGrow(table: table)) }
     public mutating func visitTableSize(table: UInt32) throws { return try self.visit(.tableSize(table: table)) }
+    public mutating func visitCallRef(functionIndex: UInt32) throws { return try self.visit(.callRef(functionIndex: functionIndex)) }
 }
 
 /// A visitor for WebAssembly instructions.
@@ -390,6 +392,8 @@ public protocol InstructionVisitor {
     mutating func visitTableGrow(table: UInt32) throws
     /// Visiting `table.size` instruction.
     mutating func visitTableSize(table: UInt32) throws
+    /// Visiting `call_ref` instruction.
+    mutating func visitCallRef(functionIndex: UInt32) throws
 }
 
 extension InstructionVisitor {
@@ -446,6 +450,7 @@ extension InstructionVisitor {
         case let .tableSet(table): return try visitTableSet(table: table)
         case let .tableGrow(table): return try visitTableGrow(table: table)
         case let .tableSize(table): return try visitTableSize(table: table)
+        case let .callRef(functionIndex): return try visitCallRef(functionIndex: functionIndex)
         }
     }
 }
@@ -502,5 +507,6 @@ extension InstructionVisitor {
     public mutating func visitTableSet(table: UInt32) throws {}
     public mutating func visitTableGrow(table: UInt32) throws {}
     public mutating func visitTableSize(table: UInt32) throws {}
+    public mutating func visitCallRef(functionIndex: UInt32) throws {}
 }
 

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -432,6 +432,7 @@ extension Parser {
         case 0x7C: return .f64
         case 0x7B: return .f64
         case 0x70: return .ref(.funcRef)
+        case 0x71: return .ref(.funcRefNonNull)
         case 0x6F: return .ref(.externRef)
         default:
             throw StreamError<Stream.Element>.unexpected(b, index: offset, expected: Set(0x7C...0x7F))
@@ -605,6 +606,10 @@ extension Parser: BinaryInstructionDecoder {
         return BrTable(labelIndices: labelIndices, defaultIndex: labelIndex)
     }
     @inlinable mutating func visitCall() throws -> UInt32 { try parseUnsigned() }
+    @inlinable mutating func visitCallRef() throws -> UInt32 {
+        // TODO reference types checks
+        try parseUnsigned()
+    }
 
     @inlinable mutating func visitCallIndirect() throws -> (typeIndex: UInt32, tableIndex: UInt32) {
         let typeIndex: TypeIndex = try parseUnsigned()

--- a/Sources/WasmTypes/WasmTypes.swift
+++ b/Sources/WasmTypes/WasmTypes.swift
@@ -18,8 +18,15 @@ public struct FunctionType: Equatable, Hashable {
 public enum ReferenceType: UInt8, Equatable, Hashable {
     /// A nullable reference type to a function.
     case funcRef
+
+    /// A non-nullable reference type to a function
+    case funcRefNonNull
+
     /// A nullable external reference type.
     case externRef
+
+    /// A non-nullable external reference type.
+    case externRefNonNull
 }
 
 public enum ValueType: Equatable, Hashable {

--- a/Tests/WasmKitTests/Spectest/Spectest.swift
+++ b/Tests/WasmKitTests/Spectest/Spectest.swift
@@ -30,6 +30,10 @@ public struct SpectestResult {
         "\(Int(Double(numerator) / Double(denominator) * 100))%"
     }
 
+    func sortedFailedCases() -> [String] {
+        failedCases.map { URL(filePath: $0).pathComponents.suffix(2).joined(separator: "/") }.sorted()
+    }
+
     func dump() {
         print(
             "\(passed)/\(total) (\(percentage(passed, total)) passing, \(percentage(skipped, total)) skipped, \(percentage(failed, total)) failed)"

--- a/Tests/WasmKitTests/Spectest/Spectest.swift
+++ b/Tests/WasmKitTests/Spectest/Spectest.swift
@@ -7,6 +7,41 @@ private func loadStringArrayFromEnvironment(_ key: String) -> [String] {
     ProcessInfo.processInfo.environment[key]?.split(separator: ",").map(String.init) ?? []
 }
 
+public struct SpectestResult {
+    var passed = 0
+    var skipped = 0
+    var failed = 0
+    var total: Int { passed + skipped + failed }
+    var failedCases: Set<String> = []
+
+    mutating func append(_ testCase: TestCase, _ result: Result) {
+        switch result {
+        case .passed:
+            passed += 1
+        case .skipped:
+            skipped += 1
+        case .failed:
+            failed += 1
+            failedCases.insert(testCase.path)
+        }
+    }
+
+    func percentage(_ numerator: Int, _ denominator: Int) -> String {
+        "\(Int(Double(numerator) / Double(denominator) * 100))%"
+    }
+
+    func dump() {
+        print(
+            "\(passed)/\(total) (\(percentage(passed, total)) passing, \(percentage(skipped, total)) skipped, \(percentage(failed, total)) failed)"
+        )
+        guard !failedCases.isEmpty else { return }
+        print("Failed cases:")
+        for testCase in failedCases.sorted() {
+            print("  \(testCase)")
+        }
+    }
+}
+
 @available(macOS 11, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 public func spectest(
     path: [String],
@@ -16,6 +51,18 @@ public func spectest(
     parallel: Bool = true,
     configuration: EngineConfiguration = .init()
 ) async throws -> Bool {
+    try await spectestResult(path: path, include: include, exclude: exclude, verbose: verbose, parallel: parallel, configuration: configuration).failed == 0
+}
+
+@available(macOS 11, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+public func spectestResult(
+    path: [String],
+    include: [String]? = nil,
+    exclude: [String]? = nil,
+    verbose: Bool = false,
+    parallel: Bool = true,
+    configuration: EngineConfiguration = .init()
+) async throws -> SpectestResult {
     let printVerbose = verbose
     @Sendable func log(_ message: String, verbose: Bool = false) {
         if !verbose || printVerbose {
@@ -28,10 +75,6 @@ public func spectest(
             fputs("\(path):\(line): " + message + "\n", stderr)
         }
     }
-    func percentage(_ numerator: Int, _ denominator: Int) -> String {
-        "\(Int(Double(numerator) / Double(denominator) * 100))%"
-    }
-
     let include = include ?? loadStringArrayFromEnvironment("WASMKIT_SPECTEST_INCLUDE")
     let exclude = exclude ?? loadStringArrayFromEnvironment("WASMKIT_SPECTEST_EXCLUDE")
 
@@ -44,7 +87,7 @@ public func spectest(
 
     guard !testCases.isEmpty else {
         log("No test found")
-        return true
+        return SpectestResult()
     }
 
     // https://github.com/WebAssembly/spec/tree/8a352708cffeb71206ca49a0f743bdc57269fb1a/interpreter#spectest-host-module
@@ -103,37 +146,6 @@ public func spectest(
         return testCaseResults
     }
 
-    struct SpectestResult {
-        var passed = 0
-        var skipped = 0
-        var failed = 0
-        var total: Int { passed + skipped + failed }
-        var failedCases: Set<String> = []
-
-        mutating func append(_ testCase: TestCase, _ result: Result) {
-            switch result {
-            case .passed:
-                passed += 1
-            case .skipped:
-                skipped += 1
-            case .failed:
-                failed += 1
-                failedCases.insert(testCase.path)
-            }
-        }
-
-        func dump() {
-            print(
-                "\(passed)/\(total) (\(percentage(passed, total)) passing, \(percentage(skipped, total)) skipped, \(percentage(failed, total)) failed)"
-            )
-            guard !failedCases.isEmpty else { return }
-            print("Failed cases:")
-            for testCase in failedCases.sorted() {
-                print("  \(testCase)")
-            }
-        }
-    }
-
     let result: SpectestResult
 
     if parallel {
@@ -168,5 +180,5 @@ public func spectest(
 
     result.dump()
 
-    return result.failed == 0
+    return result
 }

--- a/Tests/WasmKitTests/SpectestTests.swift
+++ b/Tests/WasmKitTests/SpectestTests.swift
@@ -16,12 +16,8 @@ final class SpectestTests: XCTestCase {
         ]
     }
 
-    static var gcPath: [String] {
-        [
-            Self.testsuite.appendingPathComponent("proposals/function-references").path,
-            Self.testsuite.appendingPathComponent("proposals/gc").path
-        ]
-    }
+    static var functionReferences: [String] { [Self.testsuite.appendingPathComponent("proposals/function-references").path] }
+    static var gcPath: [String] { [Self.testsuite.appendingPathComponent("proposals/gc").path] }
 
     /// Run all the tests in the spectest suite.
     func testRunAll() async throws {
@@ -50,7 +46,21 @@ final class SpectestTests: XCTestCase {
         XCTAssertTrue(ok)
     }
 
-    /// Run the function-references & garbage collection proposal tests
+    func testFunctionReferencesProposals() async throws {
+        let defaultConfig = EngineConfiguration()
+        let result = try await spectestResult(
+            path: Self.functionReferences,
+            include: ["function-references/call_ref.wast"], // focusing on call_ref for now, but will update to run all function-references tests.
+            exclude: [],
+            parallel: false,
+            configuration: defaultConfig
+        )
+
+        XCTAssertEqual(result.passed, 8)
+        XCTAssertEqual(result.failed, 26)
+    }
+
+    /// Run the garbage collection proposal tests
     /// As we add support, we can increase the passed count and delete entries from the failed array.
     func testFunctionReferencesAndGarbageCollectionProposals() async throws {
         let defaultConfig = EngineConfiguration()
@@ -62,72 +72,53 @@ final class SpectestTests: XCTestCase {
             configuration: defaultConfig
         )
 
-        let failed = result.failedCases.map {
-            URL(filePath: $0).pathComponents.suffix(2).joined(separator: "/")
-        }.sorted()
-
-        XCTAssertEqual(result.passed, 1975)
-        XCTAssertEqual(failed, [
-            "function-references/br_on_non_null.wast",
-            "function-references/br_on_null.wast",
-            "function-references/br_table.wast",
-            "function-references/call_ref.wast",
-            "function-references/elem.wast",
-            "function-references/func.wast",
-            "function-references/linking.wast",
-            "function-references/local_init.wast",
-            "function-references/ref.wast",
-            "function-references/ref_as_non_null.wast",
-            "function-references/ref_is_null.wast",
-            "function-references/ref_null.wast",
-            "function-references/return_call.wast",
-            "function-references/return_call_indirect.wast",
-            "function-references/return_call_ref.wast",
-            "function-references/select.wast",
-            "function-references/table-sub.wast",
-            "function-references/table.wast",
-            "function-references/type-equivalence.wast",
-            "function-references/unreached-valid.wast",
-            "gc/array.wast",
-            "gc/array_copy.wast",
-            "gc/array_fill.wast",
-            "gc/array_init_data.wast",
-            "gc/array_init_elem.wast",
-            "gc/br_if.wast",
-            "gc/br_on_cast.wast",
-            "gc/br_on_cast_fail.wast",
-            "gc/br_on_non_null.wast",
-            "gc/br_on_null.wast",
-            "gc/br_table.wast",
-            "gc/call_ref.wast",
-            "gc/data.wast",
-            "gc/elem.wast",
-            "gc/extern.wast",
-            "gc/func.wast",
-            "gc/global.wast",
-            "gc/i31.wast",
-            "gc/linking.wast",
-            "gc/local_init.wast",
-            "gc/local_tee.wast",
-            "gc/ref.wast",
-            "gc/ref_as_non_null.wast",
-            "gc/ref_cast.wast",
-            "gc/ref_eq.wast",
-            "gc/ref_is_null.wast",
-            "gc/ref_null.wast",
-            "gc/ref_test.wast",
-            "gc/return_call.wast",
-            "gc/return_call_indirect.wast",
-            "gc/return_call_ref.wast",
-            "gc/select.wast",
-            "gc/struct.wast",
-            "gc/table-sub.wast",
-            "gc/table.wast",
-            "gc/type-canon.wast",
-            "gc/type-equivalence.wast",
-            "gc/type-rec.wast",
-            "gc/type-subtyping.wast",
-            "gc/unreached-valid.wast"
-        ])
+        XCTAssertEqual(result.passed, 1316)
+        XCTAssertEqual(result.failed, 218)
+        XCTAssertEqual(
+            result.sortedFailedCases(),
+            [
+                "gc/array.wast",
+                "gc/array_copy.wast",
+                "gc/array_fill.wast",
+                "gc/array_init_data.wast",
+                "gc/array_init_elem.wast",
+                "gc/br_if.wast",
+                "gc/br_on_cast.wast",
+                "gc/br_on_cast_fail.wast",
+                "gc/br_on_non_null.wast",
+                "gc/br_on_null.wast",
+                "gc/br_table.wast",
+                "gc/call_ref.wast",
+                "gc/data.wast",
+                "gc/elem.wast",
+                "gc/extern.wast",
+                "gc/func.wast",
+                "gc/global.wast",
+                "gc/i31.wast",
+                "gc/linking.wast",
+                "gc/local_init.wast",
+                "gc/local_tee.wast",
+                "gc/ref.wast",
+                "gc/ref_as_non_null.wast",
+                "gc/ref_cast.wast",
+                "gc/ref_eq.wast",
+                "gc/ref_is_null.wast",
+                "gc/ref_null.wast",
+                "gc/ref_test.wast",
+                "gc/return_call.wast",
+                "gc/return_call_indirect.wast",
+                "gc/return_call_ref.wast",
+                "gc/select.wast",
+                "gc/struct.wast",
+                "gc/table-sub.wast",
+                "gc/table.wast",
+                "gc/type-canon.wast",
+                "gc/type-equivalence.wast",
+                "gc/type-rec.wast",
+                "gc/type-subtyping.wast",
+                "gc/unreached-invalid.wast",
+                "gc/unreached-valid.wast"
+            ]
+        )
     }
 }

--- a/Tests/WasmKitTests/SpectestTests.swift
+++ b/Tests/WasmKitTests/SpectestTests.swift
@@ -16,6 +16,13 @@ final class SpectestTests: XCTestCase {
         ]
     }
 
+    static var gcPath: [String] {
+        [
+            Self.testsuite.appendingPathComponent("proposals/function-references").path,
+            Self.testsuite.appendingPathComponent("proposals/gc").path
+        ]
+    }
+
     /// Run all the tests in the spectest suite.
     func testRunAll() async throws {
         let defaultConfig = EngineConfiguration()
@@ -41,5 +48,86 @@ final class SpectestTests: XCTestCase {
             configuration: config
         )
         XCTAssertTrue(ok)
+    }
+
+    /// Run the function-references & garbage collection proposal tests
+    /// As we add support, we can increase the passed count and delete entries from the failed array.
+    func testFunctionReferencesAndGarbageCollectionProposals() async throws {
+        let defaultConfig = EngineConfiguration()
+        let result = try await spectestResult(
+            path: Self.gcPath,
+            include: [],
+            exclude: [],
+            parallel: true,
+            configuration: defaultConfig
+        )
+
+        let failed = result.failedCases.map {
+            URL(filePath: $0).pathComponents.suffix(2).joined(separator: "/")
+        }.sorted()
+
+        XCTAssertEqual(result.passed, 1975)
+        XCTAssertEqual(failed, [
+            "function-references/br_on_non_null.wast",
+            "function-references/br_on_null.wast",
+            "function-references/br_table.wast",
+            "function-references/call_ref.wast",
+            "function-references/elem.wast",
+            "function-references/func.wast",
+            "function-references/linking.wast",
+            "function-references/local_init.wast",
+            "function-references/ref.wast",
+            "function-references/ref_as_non_null.wast",
+            "function-references/ref_is_null.wast",
+            "function-references/ref_null.wast",
+            "function-references/return_call.wast",
+            "function-references/return_call_indirect.wast",
+            "function-references/return_call_ref.wast",
+            "function-references/select.wast",
+            "function-references/table-sub.wast",
+            "function-references/table.wast",
+            "function-references/type-equivalence.wast",
+            "function-references/unreached-valid.wast",
+            "gc/array.wast",
+            "gc/array_copy.wast",
+            "gc/array_fill.wast",
+            "gc/array_init_data.wast",
+            "gc/array_init_elem.wast",
+            "gc/br_if.wast",
+            "gc/br_on_cast.wast",
+            "gc/br_on_cast_fail.wast",
+            "gc/br_on_non_null.wast",
+            "gc/br_on_null.wast",
+            "gc/br_table.wast",
+            "gc/call_ref.wast",
+            "gc/data.wast",
+            "gc/elem.wast",
+            "gc/extern.wast",
+            "gc/func.wast",
+            "gc/global.wast",
+            "gc/i31.wast",
+            "gc/linking.wast",
+            "gc/local_init.wast",
+            "gc/local_tee.wast",
+            "gc/ref.wast",
+            "gc/ref_as_non_null.wast",
+            "gc/ref_cast.wast",
+            "gc/ref_eq.wast",
+            "gc/ref_is_null.wast",
+            "gc/ref_null.wast",
+            "gc/ref_test.wast",
+            "gc/return_call.wast",
+            "gc/return_call_indirect.wast",
+            "gc/return_call_ref.wast",
+            "gc/select.wast",
+            "gc/struct.wast",
+            "gc/table-sub.wast",
+            "gc/table.wast",
+            "gc/type-canon.wast",
+            "gc/type-equivalence.wast",
+            "gc/type-rec.wast",
+            "gc/type-subtyping.wast",
+            "gc/unreached-valid.wast"
+        ])
     }
 }

--- a/Utilities/Instructions.json
+++ b/Utilities/Instructions.json
@@ -199,5 +199,6 @@
   ["saturatingFloatToInt", "i64.trunc_sat_f32_s"      , ["0xFC", "0x04"], []                                                 , "conversion"],
   ["saturatingFloatToInt", "i64.trunc_sat_f32_u"      , ["0xFC", "0x05"], []                                                 , "conversion"],
   ["saturatingFloatToInt", "i64.trunc_sat_f64_s"      , ["0xFC", "0x06"], []                                                 , "conversion"],
-  ["saturatingFloatToInt", "i64.trunc_sat_f64_u"      , ["0xFC", "0x07"], []                                                 , "conversion"]
+  ["saturatingFloatToInt", "i64.trunc_sat_f64_u"      , ["0xFC", "0x07"], []                                                 , "conversion"],
+  ["referenceTypes"      , "call_ref"                 , ["0x14"]        , [["functionIndex", "UInt32"]]                      , null        ]
 ]


### PR DESCRIPTION
[Proposal Link](https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md)

👋 I started looking at adding support for the function-references extension. This is very much a work in progress, that I'd appreciate feedback on. I'm still building up context on the codebase, so I suspect I'm missing several fairly obvious issues. If you do check it out locally, feel free to push improvements directly to my branch, and I'll pull them in.

So far:

- [x] Updated WatParser to support `(ref null? $variable)` syntax
- [x] Configure spec tests to run the wast tests for function-references & GC 
- [x] Added an instruction for `call_ref` (that's not passing the call_ref.wast tests yet)

TODO:
- [ ] Get call_ref implemented correctly (and stop leaving functions on the stack)
- [ ] Add remaining instructions
- [ ] Get all the Function reference wast test passing
- [ ] Check the benchmarks

Questions:

I punted on separating out a `HeapType` struct/enum for now, as I wasn't sure what shape it would land up in, and how big the knock on change would be. Do you have a shape in mind for a `HeapType` or shall I keep going with the extra cases for ReferenceType for now?

I'm hoping to have more time to work on this, but it will depend on other commitments. 

---

I've got 8/34 of the initial `call_ref.wast` tests passing, while the rest are failing with `Expected i32 on the stack top but got ref(WasmTypes.ReferenceType.funcRef)` . Run `testFunctionReferencesProposals` if you want to reproduce it locally.

