### PR TITLE
WASI: Implement `fd_datasync`

### DIFF
--- a/Sources/SystemExtras/FileOperations.swift
+++ b/Sources/SystemExtras/FileOperations.swift
@@ -598,6 +598,26 @@ extension FileDescriptor {
     }
     #endif
   }
+
+  public func datasync() throws {
+    return try _datasync().get()
+  }
+
+  internal func _datasync() -> Result<Void, Errno> {
+    #if os(Windows)
+    return self._sync()
+    #else
+    nothingOrErrno(retryOnInterrupt: false) {
+      #if SYSTEM_PACKAGE_DARWIN
+      system_fcntl(self.rawValue, F_FULLFSYNC)
+      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(Cygwin) || os(PS4)
+      system_fdatasync(self.rawValue)
+      #else
+      system_fsync(self.rawValue)
+      #endif
+    }
+    #endif
+  }
 }
 
 #if os(Windows)

--- a/Sources/SystemExtras/Syscalls.swift
+++ b/Sources/SystemExtras/Syscalls.swift
@@ -54,6 +54,13 @@ internal func system_fsync(_ fd: Int32) -> CInt {
 
 #endif
 
+#if os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(Cygwin) || os(PS4)
+// fdatasync
+internal func system_fdatasync(_ fd: Int32) -> CInt {
+  return fdatasync(fd)
+}
+#endif
+
 #if os(Linux)
 // posix_fadvise
 internal func system_posix_fadvise(

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -25,6 +25,7 @@ protocol WASIFile: WASIEntry {
     func setFdStatFlags(_ flags: WASIAbi.Fdflags) throws
     func setFilestatSize(_ size: WASIAbi.FileSize) throws
     func sync() throws
+    func datasync() throws
 
     func tell() throws -> WASIAbi.FileSize
     func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize

--- a/Sources/WASI/Platform/File.swift
+++ b/Sources/WASI/Platform/File.swift
@@ -30,6 +30,12 @@ extension FdWASIFile {
         }
     }
 
+    func datasync() throws {
+        try WASIAbi.Errno.translatingPlatformErrno {
+            try fd.datasync()
+        }
+    }
+
     @inlinable
     func write<Buffer: Sequence>(vectored buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1516,7 +1516,10 @@ public class WASIBridgeToHost: WASI {
     }
 
     func fd_datasync(fd: WASIAbi.Fd) throws {
-        throw WASIAbi.Errno.ENOTSUP
+        guard case let .file(fileEntry) = fdTable[fd] else {
+            throw WASIAbi.Errno.EBADF
+        }
+        return try fileEntry.datasync()
     }
 
     func fd_fdstat_get(fileDescriptor: UInt32) throws -> WASIAbi.FdStat {


### PR DESCRIPTION
I added implementation of `fd_datasync` following `fd_sync` #180.

- On Darwin
  - behaves exactly like `fd_sync` (`fcntl(fd, F_FULLFSYNC)`)
- On Windows
  - behaves exactly like `fd_sync` (`FlushFileBuffers`)
- On UNIX-like systems except for Darwin
  - uses `fdatasync(fd)`
- On other systems that don't have `fdatasync` (e.g. Haiku)
  - uses `fsync(fd)` instead

References:

- https://github.com/WebAssembly/WASI/blob/9df56e7b858ca9a1a47d2cf8bbcf5391e3f5d773/legacy/preview1/docs.md#-fd_datasyncfd-fd---result-errno
- https://wasix.org/docs/api-reference/wasi/fd_datasync
- Darwin
  - https://transactional.blog/blog/2022-darwins-deceptive-durability
  - https://github.com/rust-lang/rust/blob/f1bc669636023c8643602431791c7f26e5a6edef/library/std/src/sys/fs/unix.rs#L1224
- Windows
  - https://github.com/rust-lang/rust/blob/f1bc669636023c8643602431791c7f26e5a6edef/library/std/src/sys/fs/windows.rs#L348