### PR TITLE
Android support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,14 @@ jobs:
     strategy:
       matrix:
         include:
+          # Swift 5.8.1
+          - os: macos-13
+            xcode: Xcode_14.3.1
+            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2024-10-08-a
+            wasi-swift-sdk-download: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi.artifactbundle.zip"
+            wasi-swift-sdk-id: DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi
+            wasi-swift-sdk-checksum: "229cd9d3b0ed582c7ef7c3064888ad78764e4743b5a770df92554a94513f53fb"
+            test-args: ""
           # Swift 5.9.0
           - os: macos-13
             xcode: Xcode_15.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # Swift 5.8.1
-          - os: macos-13
-            xcode: Xcode_14.3.1
-            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2024-10-08-a
-            wasi-swift-sdk-download: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi.artifactbundle.zip"
-            wasi-swift-sdk-id: DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi
-            wasi-swift-sdk-checksum: "229cd9d3b0ed582c7ef7c3064888ad78764e4743b5a770df92554a94513f53fb"
-            test-args: ""
           # Swift 5.9.0
           - os: macos-13
             xcode: Xcode_15.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,6 +188,13 @@ jobs:
       - name: Build (aarch64-swift-linux-musl)
         run: ./build-exec swift build --swift-sdk aarch64-swift-linux-musl
 
+  build-android:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Tests on Android emulator
+        uses: skiptools/swift-android-action@v2
+
   build-windows:
     runs-on: windows-latest
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-system", .upToNextMinor(from: "1.3.0")),
+        .package(url: "https://github.com/apple/swift-system", .upToNextMinor(from: "1.5.0")),
     ]
 } else {
     package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-system", .upToNextMinor(from: "1.5.0")),
+        .package(url: "https://github.com/apple/swift-system", from: "1.3.0"),
     ]
 } else {
     package.dependencies += [

--- a/Sources/SystemExtras/Clock.swift
+++ b/Sources/SystemExtras/Clock.swift
@@ -6,6 +6,9 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
+#elseif canImport(Android)
+import CSystem
+import Android
 #elseif os(Windows)
 import CSystem
 import ucrt
@@ -28,7 +31,7 @@ public struct Clock: RawRepresentable {
 }
 
 extension Clock {
-  #if os(Linux)
+  #if os(Linux) || os(Android)
   @_alwaysEmitIntoClient
   public static var boottime: Clock { Clock(rawValue: CLOCK_BOOTTIME) }
   #endif
@@ -38,7 +41,7 @@ extension Clock {
   public static var rawMonotonic: Clock { Clock(rawValue: _CLOCK_MONOTONIC_RAW) }
   #endif
 
-  #if SYSTEM_PACKAGE_DARWIN || os(Linux) || os(OpenBSD) || os(FreeBSD) || os(WASI)
+  #if SYSTEM_PACKAGE_DARWIN || os(Linux) || os(Android) || os(OpenBSD) || os(FreeBSD) || os(WASI)
   @_alwaysEmitIntoClient
   public static var monotonic: Clock { Clock(rawValue: _CLOCK_MONOTONIC) }
   #endif

--- a/Sources/SystemExtras/Constants.swift
+++ b/Sources/SystemExtras/Constants.swift
@@ -6,6 +6,9 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
+#elseif canImport(Android)
+import CSystem
+import Android
 #elseif os(Windows)
 import CSystem
 import ucrt
@@ -34,7 +37,7 @@ internal var _AT_FDONLY: CInt { AT_FDONLY }
 internal var _AT_SYMLINK_NOFOLLOW_ANY: CInt { AT_SYMLINK_NOFOLLOW_ANY }
 #endif
 /* FIXME: Disabled until CSystem will include "linux/fcntl.h"
-#if os(Linux)
+#if os(Linux) || os(Android)
 @_alwaysEmitIntoClient
 internal var _AT_NO_AUTOMOUNT: CInt { AT_NO_AUTOMOUNT }
 #endif
@@ -45,8 +48,13 @@ internal var _AT_NO_AUTOMOUNT: CInt { AT_NO_AUTOMOUNT }
 internal var _F_GETFL: CInt { F_GETFL }
 @_alwaysEmitIntoClient
 internal var _O_DSYNC: CInt { O_DSYNC }
+#if os(Android)
+@_alwaysEmitIntoClient
+internal var _O_SYNC: CInt { __O_SYNC | O_DSYNC }
+#else
 @_alwaysEmitIntoClient
 internal var _O_SYNC: CInt { O_SYNC }
+#endif
 #endif
 #if os(Linux)
 @_alwaysEmitIntoClient
@@ -56,7 +64,7 @@ internal var _O_RSYNC: CInt { O_RSYNC }
 #if !os(Windows)
 @_alwaysEmitIntoClient
 internal var _UTIME_NOW: CInt {
-    #if os(Linux)
+    #if os(Linux) || os(Android)
     // Hard-code constants because it's defined in glibc in a form that
     // ClangImporter cannot interpret as constants.
     // https://github.com/torvalds/linux/blob/92901222f83d988617aee37680cb29e1a743b5e4/include/linux/stat.h#L15
@@ -67,7 +75,7 @@ internal var _UTIME_NOW: CInt {
 }
 @_alwaysEmitIntoClient
 internal var _UTIME_OMIT: CInt {
-    #if os(Linux)
+    #if os(Linux) || os(Android)
     // Hard-code constants because it's defined in glibc in a form that
     // ClangImporter cannot interpret as constants.
     // https://github.com/torvalds/linux/blob/92901222f83d988617aee37680cb29e1a743b5e4/include/linux/stat.h#L16
@@ -116,7 +124,7 @@ internal var _S_IFLNK: CInterop.Mode { S_IFLNK }
 internal var _S_IFSOCK: CInterop.Mode { S_IFSOCK }
 #endif
 
-#if os(Linux)
+#if os(Linux) || os(Android)
 @_alwaysEmitIntoClient
 internal var _CLOCK_BOOTTIME: CInterop.ClockId { CLOCK_BOOTTIME }
 #endif
@@ -124,7 +132,7 @@ internal var _CLOCK_BOOTTIME: CInterop.ClockId { CLOCK_BOOTTIME }
 @_alwaysEmitIntoClient
 internal var _CLOCK_MONOTONIC_RAW: CInterop.ClockId { CLOCK_MONOTONIC_RAW }
 #endif
-#if SYSTEM_PACKAGE_DARWIN || os(Linux) || os(OpenBSD) || os(FreeBSD) || os(WASI)
+#if SYSTEM_PACKAGE_DARWIN || os(Linux) || os(Android) || os(OpenBSD) || os(FreeBSD) || os(WASI)
 @_alwaysEmitIntoClient
 internal var _CLOCK_MONOTONIC: CInterop.ClockId { CLOCK_MONOTONIC }
 #endif

--- a/Sources/SystemExtras/FileAtOperations.swift
+++ b/Sources/SystemExtras/FileAtOperations.swift
@@ -6,6 +6,9 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
+#elseif canImport(Android)
+import CSystem
+import Android
 #elseif os(Windows)
 import ucrt
 import WinSDK
@@ -44,7 +47,7 @@ extension FileDescriptor {
     #endif
 
     /* FIXME: Disabled until CSystem will include "linux/fcntl.h"
-    #if os(Linux)
+    #if os(Linux) || os(Android)
     /// Indicates the operation does't mount the basename component automatically
     ///
     /// If you specify this option and the file you pass to

--- a/Sources/SystemExtras/FileOperations.swift
+++ b/Sources/SystemExtras/FileOperations.swift
@@ -6,6 +6,9 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
+#elseif canImport(Android)
+import CSystem
+import Android
 #elseif os(Windows)
 import ucrt
 import WinSDK
@@ -50,7 +53,7 @@ extension FileDescriptor {
     @_alwaysEmitIntoClient
     public init(rawValue: CInt) { self.rawValue = rawValue }
 
-    #if os(Linux)
+    #if os(Linux) || os(Android)
     /// Access the specified data in the near future.
     ///
     /// The corresponding C constant is `POSIX_FADV_WILLNEED`.
@@ -59,7 +62,7 @@ extension FileDescriptor {
     #endif
   }
 
-  #if os(Linux)
+  #if os(Linux) || os(Android)
   /// Announces an intention to access specific region of file data.
   ///
   /// - Parameters:

--- a/Sources/SystemExtras/Syscalls.swift
+++ b/Sources/SystemExtras/Syscalls.swift
@@ -6,6 +6,9 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
+#elseif canImport(Android)
+import CSystem
+import Android
 #elseif os(Windows)
 import ucrt
 import WinSDK
@@ -61,12 +64,12 @@ internal func system_fdatasync(_ fd: Int32) -> CInt {
 }
 #endif
 
-#if os(Linux)
+#if os(Linux) || os(Android)
 // posix_fadvise
 internal func system_posix_fadvise(
   _ fd: Int32, _ offset: Int, _ length: Int, _ advice: CInt
 ) -> CInt {
-  return posix_fadvise(fd, offset, length, advice)
+  return posix_fadvise(fd, .init(offset), .init(length), advice)
 }
 #endif
 
@@ -116,7 +119,7 @@ internal func system_symlinkat(
 extension CInterop {
   #if SYSTEM_PACKAGE_DARWIN
   public typealias DirP = UnsafeMutablePointer<DIR>
-  #elseif os(Linux)
+  #elseif os(Linux) || os(Android)
   public typealias DirP = OpaquePointer
   #else
   #error("Unsupported Platform")

--- a/Sources/SystemExtras/Vendor/Exports.swift
+++ b/Sources/SystemExtras/Vendor/Exports.swift
@@ -23,11 +23,11 @@ import Glibc
 #elseif canImport(Musl)
 import CSystem
 import Musl
-#elseif canImport(WASILibc)
-import WASILibc
 #elseif canImport(Android)
 import CSystem
 import Android
+#elseif canImport(WASILibc)
+import WASILibc
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/WASI/Clock.swift
+++ b/Sources/WASI/Clock.swift
@@ -92,7 +92,7 @@ public protocol MonotonicClock {
     /// A monotonic clock that uses the system's monotonic clock.
     public struct SystemMonotonicClock: MonotonicClock {
         private var underlying: SystemExtras.Clock {
-            #if os(Linux)
+            #if os(Linux) || os(Android)
                 return .monotonic
             #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
                 return .rawUptime
@@ -125,7 +125,7 @@ public protocol MonotonicClock {
     /// A wall clock that uses the system's wall clock.
     public struct SystemWallClock: WallClock {
         private var underlying: SystemExtras.Clock {
-            #if os(Linux)
+            #if os(Linux) || os(Android)
                 return .boottime
             #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
                 return .rawMonotonic

--- a/Sources/WASI/Platform/Entry.swift
+++ b/Sources/WASI/Platform/Entry.swift
@@ -23,7 +23,7 @@ extension FdWASIEntry {
             try WASIAbi.Errno.translatingPlatformErrno {
                 try self.fd.adviseRead(offset: offset, length: length)
             }
-        #elseif os(Linux)
+        #elseif os(Linux) || os(Android)
             guard let offset = Int(exactly: offset),
                 let length = Int(exactly: length)
             else {

--- a/Sources/WASI/Platform/SandboxPrimitives/Open.swift
+++ b/Sources/WASI/Platform/SandboxPrimitives/Open.swift
@@ -9,6 +9,9 @@ import SystemPackage
 #elseif canImport(Musl)
     import CSystem
     import Musl
+#elseif canImport(Android)
+    import CSystem
+    import Android
 #elseif os(Windows)
     import CSystem
     import ucrt

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -8,6 +8,8 @@ import WasmTypes
     import Glibc
 #elseif canImport(Musl)
     import Musl
+#elseif canImport(Android)
+    import Android
 #elseif os(Windows)
     import ucrt
 #else

--- a/Sources/WasmKit/Execution/Profiler.swift
+++ b/Sources/WasmKit/Execution/Profiler.swift
@@ -46,7 +46,7 @@ public class GuestTimeProfiler: EngineInterceptor {
 
         private static func getTimestamp() -> UInt64 {
             let clock: SystemExtras.Clock
-            #if os(Linux)
+            #if os(Linux) || os(Android)
                 clock = .boottime
             #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
                 clock = .rawMonotonic

--- a/Tests/WASITests/IntegrationTests.swift
+++ b/Tests/WASITests/IntegrationTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class IntegrationTests: XCTestCase {
     func testRunAll() throws {
         #if os(Android)
-        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+            throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
         #endif
         let testDir = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()

--- a/Tests/WASITests/IntegrationTests.swift
+++ b/Tests/WASITests/IntegrationTests.swift
@@ -6,6 +6,9 @@ import XCTest
 
 final class IntegrationTests: XCTestCase {
     func testRunAll() throws {
+        #if os(Android)
+        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+        #endif
         let testDir = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
             .appendingPathComponent("Vendor/wasi-testsuite")

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -32,9 +32,9 @@ enum TestSupport {
             #else
                 if mkdtemp(&template) == nil {
                     #if os(Android)
-                    throw Error(errno: __errno().pointee)
+                        throw Error(errno: __errno().pointee)
                     #else
-                    throw Error(errno: errno)
+                        throw Error(errno: errno)
                     #endif
                 }
             #endif

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -31,7 +31,11 @@ enum TestSupport {
                 }
             #else
                 if mkdtemp(&template) == nil {
+                    #if os(Android)
+                    throw Error(errno: __errno().pointee)
+                    #else
                     throw Error(errno: errno)
+                    #endif
                 }
             #endif
 

--- a/Tests/WATTests/TestSupport.swift
+++ b/Tests/WATTests/TestSupport.swift
@@ -30,9 +30,9 @@ enum TestSupport {
         #else
             if mkdtemp(&template) == nil {
                 #if os(Android)
-                throw Error(errno: __errno().pointee)
+                    throw Error(errno: __errno().pointee)
                 #else
-                throw Error(errno: errno)
+                    throw Error(errno: errno)
                 #endif
             }
         #endif

--- a/Tests/WATTests/TestSupport.swift
+++ b/Tests/WATTests/TestSupport.swift
@@ -29,7 +29,11 @@ enum TestSupport {
             }
         #else
             if mkdtemp(&template) == nil {
+                #if os(Android)
+                throw Error(errno: __errno().pointee)
+                #else
                 throw Error(errno: errno)
+                #endif
             }
         #endif
 

--- a/Tests/WITExtractorPluginTests/TestSupport.swift
+++ b/Tests/WITExtractorPluginTests/TestSupport.swift
@@ -25,7 +25,11 @@ struct TestSupport {
         var template = [UInt8](templatePath.path.utf8).map({ Int8($0) }) + [Int8(0)]
 
         if mkdtemp(&template) == nil {
+            #if os(Android)
+            throw Error(errno: __errno().pointee)
+            #else
             throw Error(errno: errno)
+            #endif
         }
 
         let path = String(cString: template)

--- a/Tests/WITExtractorPluginTests/TestSupport.swift
+++ b/Tests/WITExtractorPluginTests/TestSupport.swift
@@ -26,9 +26,9 @@ struct TestSupport {
 
         if mkdtemp(&template) == nil {
             #if os(Android)
-            throw Error(errno: __errno().pointee)
+                throw Error(errno: __errno().pointee)
             #else
-            throw Error(errno: errno)
+                throw Error(errno: errno)
             #endif
         }
 

--- a/Tests/WITExtractorTests/TestSupport.swift
+++ b/Tests/WITExtractorTests/TestSupport.swift
@@ -57,9 +57,9 @@ struct TestSupport {
         #else
             if mkdtemp(&template) == nil {
                 #if os(Android)
-                throw Error(errno: __errno().pointee)
+                    throw Error(errno: __errno().pointee)
                 #else
-                throw Error(errno: errno)
+                    throw Error(errno: errno)
                 #endif
             }
         #endif

--- a/Tests/WITExtractorTests/TestSupport.swift
+++ b/Tests/WITExtractorTests/TestSupport.swift
@@ -56,7 +56,11 @@ struct TestSupport {
             }
         #else
             if mkdtemp(&template) == nil {
+                #if os(Android)
+                throw Error(errno: __errno().pointee)
+                #else
                 throw Error(errno: errno)
+                #endif
             }
         #endif
 

--- a/Tests/WITOverlayGeneratorTests/HostGeneratorTests.swift
+++ b/Tests/WITOverlayGeneratorTests/HostGeneratorTests.swift
@@ -8,7 +8,7 @@ class HostGeneratorTests: XCTestCase {
     // but execute again here to collect coverage data.
     func testGenerateFromFixtures() throws {
         #if os(Android)
-        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+            throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
         #endif
         let fixturesDir = RuntimeTestHarness.testsDirectory.appendingPathComponent("Fixtures")
         for fixture in try FileManager.default.contentsOfDirectory(atPath: fixturesDir.path) {

--- a/Tests/WITOverlayGeneratorTests/HostGeneratorTests.swift
+++ b/Tests/WITOverlayGeneratorTests/HostGeneratorTests.swift
@@ -7,6 +7,9 @@ class HostGeneratorTests: XCTestCase {
     // Host generators are already executed before running this test suite by SwiftPM build tool plugin,
     // but execute again here to collect coverage data.
     func testGenerateFromFixtures() throws {
+        #if os(Android)
+        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+        #endif
         let fixturesDir = RuntimeTestHarness.testsDirectory.appendingPathComponent("Fixtures")
         for fixture in try FileManager.default.contentsOfDirectory(atPath: fixturesDir.path) {
             let inputFileDir = fixturesDir.appendingPathComponent(fixture).appendingPathComponent("wit")

--- a/Tests/WasmKitTests/FuzzTranslatorRegressionTests.swift
+++ b/Tests/WasmKitTests/FuzzTranslatorRegressionTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class FuzzTranslatorRegressionTests: XCTestCase {
     func testRunAll() throws {
         #if os(Android)
-        throw XCTSkip("Test skipped due to absolute path #filePath unavailable on emulator")
+            throw XCTSkip("Test skipped due to absolute path #filePath unavailable on emulator")
         #endif
         let sourceRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()

--- a/Tests/WasmKitTests/FuzzTranslatorRegressionTests.swift
+++ b/Tests/WasmKitTests/FuzzTranslatorRegressionTests.swift
@@ -4,6 +4,9 @@ import XCTest
 
 final class FuzzTranslatorRegressionTests: XCTestCase {
     func testRunAll() throws {
+        #if os(Android)
+        throw XCTSkip("Test skipped due to absolute path #filePath unavailable on emulator")
+        #endif
         let sourceRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
         let failCasesDir =

--- a/Tests/WasmKitTests/SpectestTests.swift
+++ b/Tests/WasmKitTests/SpectestTests.swift
@@ -19,6 +19,9 @@ final class SpectestTests: XCTestCase {
 
     /// Run all the tests in the spectest suite.
     func testRunAll() async throws {
+        #if os(Android)
+        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+        #endif
         let defaultConfig = EngineConfiguration()
         let ok = try await spectest(
             path: Self.testPaths,
@@ -31,6 +34,9 @@ final class SpectestTests: XCTestCase {
     }
 
     func testRunAllWithTokenThreading() async throws {
+        #if os(Android)
+        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+        #endif
         let defaultConfig = EngineConfiguration()
         guard defaultConfig.threadingModel != .token else { return }
         // Sanity check that non-default threading models work.

--- a/Tests/WasmKitTests/SpectestTests.swift
+++ b/Tests/WasmKitTests/SpectestTests.swift
@@ -20,7 +20,7 @@ final class SpectestTests: XCTestCase {
     /// Run all the tests in the spectest suite.
     func testRunAll() async throws {
         #if os(Android)
-        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+            throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
         #endif
         let defaultConfig = EngineConfiguration()
         let ok = try await spectest(
@@ -35,7 +35,7 @@ final class SpectestTests: XCTestCase {
 
     func testRunAllWithTokenThreading() async throws {
         #if os(Android)
-        throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
+            throw XCTSkip("unable to run spectest on Android due to missing files on emulator")
         #endif
         let defaultConfig = EngineConfiguration()
         guard defaultConfig.threadingModel != .token else { return }


### PR DESCRIPTION
This PR adds support for building and testing on Android. It mostly just adds `#if os(Android)` checks and some Android-specific fixes for things like `errno` and `O_SYNC`, which are implemented differently in Bionic than Linux/Musl.

Android does require swift-system 1.5+, so I made the dependency `upToNextMajor` from "1.3.0" rather than `upToNextMinor`. If that presents an issue, we could probably finagle some mechanism for having different swift-system version requirements based on the platform.

Test cases are run with [swift-android-action](https://github.com/marketplace/actions/swift-android-action), which installs the Android SDK and runs the test cases on an Android emulator. Some of the tests that expect hard-coded file paths had to be disabled because the Android emulator doesn't have access to the local filesystem. This could potentially be resolved by [copying](https://github.com/marketplace/actions/swift-android-action#test-resources-and-environment-variables) the necessary files, but would require re-working all the `#filePath` references to use either relative paths, or accept some sort of override file root (perhaps based on an environment variable), and seemed like it would be a more intrusive change than would be warranted.