### PR TITLE
CI: Update GitHub Actions runs-on to Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
             wasi-swift-sdk-id: DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi
             wasi-swift-sdk-checksum: "229cd9d3b0ed582c7ef7c3064888ad78764e4743b5a770df92554a94513f53fb"
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "build-linux (${{ matrix.swift }})"
 
     steps:
@@ -221,7 +221,7 @@ jobs:
           swift test @ExtraFlags
 
   build-cmake:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: swift:5.8-focal
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
             wasi-swift-sdk-download: "https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi.artifactbundle.zip"
             wasi-swift-sdk-id: DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi
             wasi-swift-sdk-checksum: "229cd9d3b0ed582c7ef7c3064888ad78764e4743b5a770df92554a94513f53fb"
+            test-args: "-Xswiftc -DWASMKIT_CI_TOOLCHAIN_NIGHTLY"
 
     runs-on: ubuntu-22.04
     name: "build-linux (${{ matrix.swift }})"

--- a/Tests/WITExtractorPluginTests/PluginSmokeTests.swift
+++ b/Tests/WITExtractorPluginTests/PluginSmokeTests.swift
@@ -2,6 +2,9 @@ import XCTest
 
 class PluginSmokeTests: XCTestCase {
     func testExtractPlugin() throws {
+        #if WASMKIT_CI_TOOLCHAIN_NIGHTLY
+            throw XCTSkip("XFAIL: https://github.com/swiftwasm/WasmKit/issues/184")
+        #endif
         guard ProcessInfo.processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] == nil else {
             throw XCTSkip(
                 "\"swift package resolve\" somehow fails to clone git repository only when invoking from Xcode test runner"


### PR DESCRIPTION
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101