### PR TITLE
[WITExtractor] Stop including per-config build directory for Swift 6.0+

### DIFF
--- a/Plugins/WITExtractorPlugin/Plugin.swift
+++ b/Plugins/WITExtractorPlugin/Plugin.swift
@@ -48,11 +48,16 @@ struct Plugin: CommandPlugin {
             "--package-name", context.package.displayName,
             "--wit-output-path", witOutputPath.string,
             "--swift-output-path", swiftOutputPath.string,
-            "-I", buildPath.string,
-            // SwiftPM 6.0 and later emits swiftmodule files into a separate directory
-            // https://github.com/swiftlang/swift-package-manager/pull/7212
             "-I", buildPath.appending(["Modules"]).string,
         ]
+
+        #if compiler(<6.0)
+        // Swift 5.10 and earlier emit module files under the per-configuration build directory
+        // instead of the Modules directory.
+        arguments += [
+            "-I", buildPath.string,
+        ]
+        #endif
         if let sdk {
             arguments += ["-sdk", sdk]
         }

--- a/Tests/WITExtractorPluginTests/PluginSmokeTests.swift
+++ b/Tests/WITExtractorPluginTests/PluginSmokeTests.swift
@@ -2,9 +2,6 @@ import XCTest
 
 class PluginSmokeTests: XCTestCase {
     func testExtractPlugin() throws {
-        #if WASMKIT_CI_TOOLCHAIN_NIGHTLY
-            throw XCTSkip("XFAIL: https://github.com/swiftwasm/WasmKit/issues/184")
-        #endif
         guard ProcessInfo.processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] == nil else {
             throw XCTSkip(
                 "\"swift package resolve\" somehow fails to clone git repository only when invoking from Xcode test runner"


### PR DESCRIPTION
Close https://github.com/swiftwasm/WasmKit/issues/184