### PR TITLE
Remove `TranslatorContext` protocol and related generics

### DIFF
--- a/Sources/WasmKit/Validator.swift
+++ b/Sources/WasmKit/Validator.swift
@@ -190,8 +190,8 @@ extension ValidationError.Message {
 }
 
 /// Validates instructions within a given context.
-struct InstructionValidator<Context: TranslatorContext> {
-    let context: Context
+struct InstructionValidator {
+    let context: InternalInstance
 
     func validateMemArg(_ memarg: MemArg, naturalAlignment: Int) throws {
         if memarg.align > naturalAlignment {


### PR DESCRIPTION
This protocol has a single conformance and at the moment adds generic indirection to the codebase without a clear benefit.