### PR TITLE
Make `InstructionTranslator` non-copyable

### DIFF
--- a/Sources/WasmKit/Execution/Function.swift
+++ b/Sources/WasmKit/Execution/Function.swift
@@ -258,19 +258,18 @@ struct WasmFunctionEntity {
         let store = store.value
         let engine = store.engine
         let type = self.type
-        var translator = try InstructionTranslator(
-            allocator: store.allocator.iseqAllocator,
-            engineConfiguration: engine.configuration,
-            funcTypeInterner: engine.funcTypeInterner,
-            module: instance,
-            type: engine.resolveType(type),
-            locals: code.locals,
-            functionIndex: index,
-            codeSize: code.expression.count,
-            isIntercepting: engine.interceptor != nil
-        )
         let iseq = try code.withValue { code in
-            try translator.translate(code: code)
+            try InstructionTranslator(
+                allocator: store.allocator.iseqAllocator,
+                engineConfiguration: engine.configuration,
+                funcTypeInterner: engine.funcTypeInterner,
+                module: instance,
+                type: engine.resolveType(type),
+                locals: code.locals,
+                functionIndex: index,
+                codeSize: code.expression.count,
+                isIntercepting: engine.interceptor != nil
+            ).translate(code: code)
         }
         self.code = .compiled(iseq)
         return iseq

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -343,7 +343,7 @@ struct StackLayout {
     }
 }
 
-struct InstructionTranslator: InstructionVisitor {
+struct InstructionTranslator: ~Copyable, InstructionVisitor {
     typealias VisitorError = WasmKitError
     typealias Output = Void
 
@@ -620,15 +620,15 @@ struct InstructionTranslator: InstructionVisitor {
         }
     }
 
-    fileprivate struct ISeqBuilder {
+    fileprivate struct ISeqBuilder: ~Copyable {
         typealias InstructionFactoryWithLabel = (
-            ISeqBuilder,
+            borrowing ISeqBuilder,
             // The position of the next slot of the creating instruction
             _ source: MetaProgramCounter,
             // The position of the resolved label
             _ target: MetaProgramCounter
         ) -> (WasmKit.Instruction)
-        typealias BrTableEntryFactory = (ISeqBuilder, MetaProgramCounter) -> Instruction.BrTableOperand.Entry
+        typealias BrTableEntryFactory = (borrowing ISeqBuilder, MetaProgramCounter) -> Instruction.BrTableOperand.Entry
         typealias BuildingBrTable = UnsafeMutableBufferPointer<Instruction.BrTableOperand.Entry>
         typealias BuildingCatchTable = UnsafeMutableBufferPointer<CatchTableEntry>
 
@@ -740,7 +740,7 @@ struct InstructionTranslator: InstructionVisitor {
             }
         }
 
-        func finalize() -> [UInt64] {
+        consuming func finalize() -> [UInt64] {
             return instructions
         }
 
@@ -811,7 +811,7 @@ struct InstructionTranslator: InstructionVisitor {
             line: UInt = #line,
             make:
                 @escaping (
-                    ISeqBuilder,
+                    borrowing ISeqBuilder,
                     // The position of the next slot of the creating instruction
                     _ source: MetaProgramCounter,
                     // The position of the resolved label
@@ -1256,7 +1256,7 @@ struct InstructionTranslator: InstructionVisitor {
         try valueStack.truncate(height: currentFrame.valueStackHeight)
     }
 
-    private mutating func finalize() throws(WasmKitError) -> InstructionSequence {
+    private consuming func finalize() throws(WasmKitError) -> InstructionSequence {
         if controlStack.numberOfFrames > 1 {
             throw WasmKitError(message: .expectedMoreEndInstructions(count: controlStack.numberOfFrames - 1))
         }
@@ -1299,7 +1299,7 @@ struct InstructionTranslator: InstructionVisitor {
     // MARK: Main entry point
 
     /// Translate a Wasm expression into a sequence of instructions.
-    mutating func translate(code: Code) throws(WasmKitError) -> InstructionSequence {
+    consuming func translate(code: Code) throws(WasmKitError) -> InstructionSequence {
         if isIntercepting {
             // Emit `onEnter` instruction at the beginning of the function
             emit(.onEnter(functionIndex))


### PR DESCRIPTION
This avoids unintentional possible ARC traffic if `InstructionTranslator` is accidentally copied, as it stores references to classes like `ISeqAllocator`.