### PR TITLE
Add CI job to check auto-generated code is committed

### DIFF
--- a/Utilities/Instructions.json
+++ b/Utilities/Instructions.json
@@ -216,6 +216,5 @@
   ["threads"             , "i32.atomic.store16"       , ["0xFE", "0x1A"], [["memarg", "MemArg"]]                             , "store"     ],
   ["threads"             , "i64.atomic.store8"        , ["0xFE", "0x1B"], [["memarg", "MemArg"]]                             , "store"     ],
   ["threads"             , "i64.atomic.store16"       , ["0xFE", "0x1C"], [["memarg", "MemArg"]]                             , "store"     ],
-  ["threads"             , "i64.atomic.store32"       , ["0xFE", "0x1D"], [["memarg", "MemArg"]]                             , "store"     ],
-  ["threads"             , "i32.atomic.rmw.add"       , ["0xFE", "0x1E"], []                             , "binary"     ]
+  ["threads"             , "i64.atomic.store32"       , ["0xFE", "0x1D"], [["memarg", "MemArg"]]                             , "store"     ]
 ]


### PR DESCRIPTION
Added a job to verify that auto-generated code is committed after making changes to a corresponding source of truth.

This should prevent problems, like the recent missing atomic store instructions were committed, but missing in `instructions.json` and vice versa.