### PR TITLE
Disable `pathOpen` test case for Android in `WASITests`

### DIFF
--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -2,6 +2,33 @@ import Testing
 
 @testable import WASI
 
+enum TargetPlatform {
+    case android
+
+    func isCurrentPlatform() -> Bool {
+        switch self {
+        case .android:
+            #if os(Android)
+                return true
+            #else
+                return false
+            #endif
+        }
+    }
+}
+
+extension Trait where Self == ConditionTrait {
+    static func disabled(
+        _ comment: Comment? = nil,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        platforms: [TargetPlatform]
+    ) -> Self {
+        return .disabled(comment, sourceLocation: sourceLocation) {
+            platforms.contains { $0.isCurrentPlatform() }
+        }
+    }
+}
+
 @Suite
 struct WASITests {
     #if !os(Windows)


### PR DESCRIPTION
For some reason `link-secret-dir-b/secret-c.txt` started throwing `.ELOOP` instead of `.ENOTDIR` in https://github.com/swiftwasm/WasmKit/actions/runs/18847983546/job/53777014067

Disabling WASI tests for latest Android Swift SDK is an alternative to disabling CI for that Swift SDK altogether https://github.com/swiftwasm/WasmKit/pull/212/commits/e81f68e8ead8881b4e355869bd53cfdf2e03eebd
