### PR TITLE
Add broader matrix for Android job `main.yml` GHA workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,10 +230,19 @@ jobs:
 
   build-android:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - swift-version: "6.2"
+          - swift-version: nightly-main
+
     steps:
       - uses: actions/checkout@v4
       - name: Run Tests on Android emulator
         uses: skiptools/swift-android-action@v2
+        with:
+          android-api-level: 30
+          swift-version: "${{ matrix.swift-version }}"
 
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
Bumping Android API Level to 30 to work around the issue reported in https://github.com/swiftwasm/WasmKit/pull/214. `README.md` updated in https://github.com/swiftwasm/WasmKit/pull/203/commits/5542e3c26e9d04bc807d672554dc06644cc4919b