### PR TITLE
Try out `--build-system swiftbuild` w/ `main` snapshots

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,9 +149,10 @@ jobs:
             wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
             wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
             test-args: "--traits WasmDebuggingSupport -Xswiftc -DWASMKIT_CI_TOOLCHAIN_NIGHTLY --build-system swiftbuild"
+            label: " --build-system swiftbuild"
 
     runs-on: ubuntu-24.04
-    name: "build-linux (${{ matrix.swift }})"
+    name: "build-linux (${{ matrix.swift }}${{ matrix.label }})"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updated the Swift development toolchain and SDK download links in the CI workflow.