### PR TITLE
CI: Free up disk space for Android CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Free up disk space
+        run: ./CI/gha-free-disk-space.sh
       - name: Run Tests on Android emulator
         uses: skiptools/swift-android-action@v2
         with:

--- a/CI/gha-free-disk-space.sh
+++ b/CI/gha-free-disk-space.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "===== Checking disk space before cleanup ====="
+
+df -h
+
+echo "===== Cleaning up unused files to free disk space ====="
+
+sudo rm -rf \
+  /usr/share/dotnet \
+  /opt/ghc \
+  /opt/hostedtoolcache/CodeQL
+
+docker image prune --all --force
+docker builder prune -a
+
+echo "===== Checking disk space after cleanup ====="
+df -h


### PR DESCRIPTION
Let's see if the flaky CI will be improved 

----
> I suspect the problem is actually due to low disk space. Looking at the recent Android CI failures ([19877954893](https://github.com/swiftwasm/WasmKit/actions/runs/19877954893/job/56969604900#step:3:2255), [19877165089](https://github.com/swiftwasm/WasmKit/actions/runs/19877165089/job/56967119798#step:3:2245), [19868624244](https://github.com/swiftwasm/WasmKit/actions/runs/19868624244/job/56938106129#step:3:2253), and [19859198948](https://github.com/swiftwasm/WasmKit/actions/runs/19859198948/job/56928880069#step:3:2257)), they are all preceded by an error when installing the Android SDK:
> 
> ```
> Warning: An error occurred while preparing SDK package Intel x86_64 Atom System Image: No space left on device.
> ```
> 
> You might want to try having the Android CI free some disk space at the beginning of the run, using either an action like [free-disk-space-ubuntu](https://github.com/marketplace/actions/free-disk-space-ubuntu) or just by manually deleting some useless junk like `/opt/hostedtoolcache/CodeQL` and `/usr/share/dotnet`.


https://github.com/swiftwasm/WasmKit/pull/231#issuecomment-3604889088