### PR TITLE
Use lower Darwin platform versions in `Package@swift-6.1.swift`

### DIFF
--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -140,7 +140,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.1"),
         .package(url: "https://github.com/apple/swift-system", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.90.0"),
-        .package(url: "https://github.com/apple/swift-log", from: "1.6.4"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.7.1"),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
The current platform versions are set to values higher than necessary, and we should support older platforms for as long as possible with our current implementation.