### PR TITLE
GDB RP: support `D` detach command

### DIFF
--- a/Sources/GDBRemoteProtocol/GDBHostCommand.swift
+++ b/Sources/GDBRemoteProtocol/GDBHostCommand.swift
@@ -49,6 +49,7 @@ package struct GDBHostCommand: Equatable {
         case removeSoftwareBreakpoint
         case wasmLocal
         case memoryRegionInfo
+        case detach
 
         case generalRegisters
 
@@ -103,6 +104,8 @@ package struct GDBHostCommand: Equatable {
                 self = .wasmLocal
             case "qMemoryRegionInfo":
                 self = .memoryRegionInfo
+            case "D":
+                self = .detach
 
             default:
                 return nil

--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -44,7 +44,8 @@
         /// Threading model of the Wasm engine configuration, cached for a potentially hot path.
         private let threadingModel: EngineConfiguration.ThreadingModel
 
-        private(set) var breakpoints = [Int: CodeSlot]()
+        /// Mapping from a Wasm address of a breakpoint to a corresponding iseq code slot.
+        package private(set) var breakpoints = [Int: UInt64]()
 
         package private(set) var state: State
 

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -281,6 +281,14 @@
             case .kill:
                 throw Error.killRequestReceived
 
+            case .detach:
+                for address in self.debugger.breakpoints.keys {
+                    try self.debugger.disableBreakpoint(address: address)
+                }
+
+                try self.debugger.run()
+                throw Error.killRequestReceived
+
             case .insertSoftwareBreakpoint:
                 try self.debugger.enableBreakpoint(
                     address: Int(


### PR DESCRIPTION
In our case it behaves similarly to the `kill` command, but finishes execution before stopping the debugger server.