### PR TITLE
Add `nightly-6.3` to Swift SDK for Android version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,6 +242,7 @@ jobs:
       matrix:
         include:
           - swift-version: "6.2"
+          - swift-version: "nightly-6.3"
           - swift-version: nightly-main
 
     steps:


### PR DESCRIPTION
Linux container images for 6.3 development snapshots were addressed separately in https://github.com/swiftwasm/WasmKit/pull/236.