### PR TITLE
Fix breakpoints in loops & recursive functions

### DIFF
--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -410,7 +410,9 @@ extension Execution {
     }
 
     /// An ``Error`` thrown when the execution normally ends.
-    struct EndOfExecution: Error {}
+    struct EndOfExecution: Error, @unchecked Sendable {
+        let sp: Sp
+    }
 
     /// An ``Error`` thrown when a breakpoint is triggered.
     struct Breakpoint: Error, @unchecked Sendable {

--- a/Sources/WasmKit/Execution/Instructions/Control.swift
+++ b/Sources/WasmKit/Execution/Instructions/Control.swift
@@ -52,7 +52,7 @@ extension Execution {
     }
 
     mutating func endOfExecution(sp: inout Sp, pc: Pc) throws -> (Pc, CodeSlot) {
-        throw EndOfExecution()
+        throw EndOfExecution(sp: sp)
     }
 
     @inline(__always)

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -268,13 +268,13 @@
                 case .step:
                     try self.debugger.step()
                 case .continue:
-                    try self.debugger.run()
+                    try self.debugger.runPreservingCurrentBreakpoint()
                 }
 
                 responseKind = try self.currentThreadStopInfo
 
             case .continue:
-                try self.debugger.run()
+                try self.debugger.runPreservingCurrentBreakpoint()
 
                 responseKind = try self.currentThreadStopInfo
 


### PR DESCRIPTION
Currently, when continuing from a breakpoint, the debugger needs to remove it and restore the original instruction before resuming. The conventionally expected behaviour is for the original breakpoint to be preserved. For that, we don't fully resume, but only step to the next instruction, restore the original breakpoint, and then finally resume again.

This still doesn't account for branching instructions, in the same way that the current instruction stepping does not. To be resolved in a future PR, as that requires precise instruction control flow analysis.