### PR TITLE
Add CI build configuration for Swift 6.2.3 on macOS 26

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,14 @@ jobs:
             wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
             wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
             test-args: "--sanitize address --traits WasmDebuggingSupport"
+          # Swift 6.2.3
+          - os: macos-26
+            xcode: Xcode_26.2
+            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a
+            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
+            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
+            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
+            test-args: "--sanitize address --traits WasmDebuggingSupport"
 
     runs-on: ${{ matrix.os }}
     name: "build-macos (${{ matrix.xcode }})"


### PR DESCRIPTION
Linux `main` failures are known and unrelated.