### PR TITLE
Add `WasmTypes` to documentation targets

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -5,6 +5,7 @@ builder:
         - WasmKit
         - WasmKitWASI
         - WasmParser
+        - WasmTypes
         - WASI
         - WAT
         - WIT


### PR DESCRIPTION
Without this module, symbols like `FunctionType` are not available in documentation, as can be seen here https://swiftpackageindex.com/swiftwasm/wasmkit/0.1.6/documentation/wasmparser/externaltype/function(_:).