### PR TITLE
Add toolchain snapshots macOS matrix to `main.yml`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: setup-development
         run: |
+          brew install wabt
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
             installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
 


### PR DESCRIPTION
We currently test toolchain snapshots on Linux only, but not macOS. As behaviour and implementation between platforms is sufficiently different, we should be able to catch regressions in development snapshots on both platforms.