### PR TITLE
Change `swift-format` category to `formatting` in `dependencies.json`

### DIFF
--- a/Vendor/dependencies.json
+++ b/Vendor/dependencies.json
@@ -17,7 +17,7 @@
   "swift-format": {
     "repository": "https://github.com/swiftlang/swift-format.git",
     "revision": "62eaad2822b865407b8cde56c36386c00800f7ec",
-    "categories": ["default"]
+    "categories": ["formatting"]
   },
   "wish-you-were-fast": {
     "repository": "https://github.com/composablesys/wish-you-were-fast.git",


### PR DESCRIPTION
As we prefer using toolchain's version of `swift-format`, there's little sense including it in default vendored dependencies checkouts, as it isn't built on either CI, nor used by the formatting script. Let's move it to a different category.

An alternative could be to remove this vendored dependency altogether as rarely or never used.