### PR TITLE
Make MemoryEntity ~Copyable and store bytes in UnsafeBufferPointer

### DIFF
--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -375,8 +375,8 @@ extension Execution {
         /// Assigns the current memory to the given memory entity.
         @inline(__always)
         static func assign(md: inout Md, ms: inout Ms, memory: inout MemoryEntity) {
-            md = UnsafeMutableRawPointer(memory.data._baseAddressIfContiguous)
-            ms = memory.data.count
+            md = memory.baseAddress
+            ms = memory.byteCount
         }
 
         /// Assigns the current memory to nil.

--- a/Sources/WasmKit/Module.swift
+++ b/Sources/WasmKit/Module.swift
@@ -210,15 +210,16 @@ public struct Module {
 
         // Step 16.
         for case .active(let data) in data {
-            let memory = try instance.memories[validating: Int(data.index)]
+            let memory = try instance.memories[validating: Int(data.index), MemoryEntity.createOutOfBoundsError]
+            let isMemory64 = memory.withValue { $0.limit.isMemory64 }
             let offsetValue = try data.offset.evaluate(
                 context: constEvalContext,
-                expectedType: .addressType(isMemory64: memory.limit.isMemory64)
+                expectedType: .addressType(isMemory64: isMemory64)
             )
             try memory.withValue { memory in
-                guard let offset = offsetValue.maybeAddressOffset(memory.limit.isMemory64) else {
+                guard let offset = offsetValue.maybeAddressOffset(isMemory64) else {
                     throw ValidationError(
-                        .unexpectedOffsetInitializer(expected: .addressType(isMemory64: memory.limit.isMemory64), got: offsetValue)
+                        .unexpectedOffsetInitializer(expected: .addressType(isMemory64: isMemory64), got: offsetValue)
                     )
                 }
                 try memory.write(offset: Int(offset), bytes: data.initializer)

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -60,7 +60,8 @@ extension InternalInstance {
         return try self.globals[validating: Int(index)].globalType.valueType
     }
     func isMemory64(memoryIndex index: MemoryIndex) throws -> Bool {
-        return try self.memories[validating: Int(index)].limit.isMemory64
+        let memory = try self.memories[validating: Int(index), MemoryEntity.createOutOfBoundsError]
+        return memory.withValue { $0.limit.isMemory64 }
     }
     func isMemory64(tableIndex index: TableIndex) throws -> Bool {
         return try self.tables[validating: Int(index)].limits.isMemory64


### PR DESCRIPTION
Changes:
- Convert internal `MemoryEntity` storage from `[UInt8]` to an owned `UnsafeMutableBufferPointer<UInt8>` and make it `~Copyable` (deallocates in `deinit`).
- Update execution/runtime call sites to use `baseAddress`/`byteCount` and add a move-safe memory copy implementation.
- Deprecate `Memory.data` (copying) and add `Memory.withUnsafeBufferPointer(offset:count:_:)` for read access.