### PR TITLE
Fix all warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         .testTarget(
             name: "WasmKitTests",
             dependencies: ["WasmKit", "WAT", "WasmKitFuzzing"],
-            exclude: ["ExtraSuite"]
+            exclude: ["ExtraSuite", "CMakeLists.txt"]
         ),
 
         .target(
@@ -134,9 +134,14 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOCore", package: "swift-nio"),
-            ]
+            ],
+            exclude: ["LICENSE.txt"]
         ),
-        .testTarget(name: "GDBRemoteProtocolTests", dependencies: ["GDBRemoteProtocol"]),
+        .testTarget(
+            name: "GDBRemoteProtocolTests",
+            dependencies: ["GDBRemoteProtocol"],
+            exclude: ["LICENSE.txt"]
+        ),
     ]
 )
 
@@ -194,7 +199,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
                 "WasmKit",
                 "WasmKitWASI",
                 "GDBRemoteProtocol",
-            ]
+            ],
+            exclude: ["LICENSE.txt"]
         ),
     ])
 

--- a/Plugins/GenerateOverlayForTesting/Plugin.swift
+++ b/Plugins/GenerateOverlayForTesting/Plugin.swift
@@ -4,23 +4,23 @@ import Foundation
 @main
 struct Plugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
-        let witTool = try context.tool(named: "WITTool").path
-        let fixturesDir = target.directory.appending("Fixtures")
-        let hostOverlayDir = context.pluginWorkDirectory.appending("GeneratedHostOverlay")
-        return try FileManager.default.contentsOfDirectory(atPath: fixturesDir.string).compactMap { singleFixture in
-            let outputFile = hostOverlayDir.appending(singleFixture + "HostOverlay.swift")
-            let inputFileDir = fixturesDir.appending(singleFixture, "wit")
-            guard FileManager.default.isDirectory(filePath: inputFileDir.string) else { return nil }
+        let witTool = try context.tool(named: "WITTool").url
+        let fixturesDir = target.directoryURL.appendingPathComponent("Fixtures")
+        let hostOverlayDir = context.pluginWorkDirectoryURL.appendingPathComponent("GeneratedHostOverlay")
+        return try FileManager.default.contentsOfDirectory(atPath: fixturesDir.path).compactMap { singleFixture in
+            let outputFile = hostOverlayDir.appendingPathComponent(singleFixture + "HostOverlay.swift")
+            let inputFileDir = fixturesDir.appendingPathComponent(singleFixture).appendingPathComponent("wit")
+            guard FileManager.default.isDirectory(filePath: inputFileDir.path) else { return nil }
 
-            let inputFiles = try FileManager.default.subpathsOfDirectory(atPath: inputFileDir.string).map {
-                inputFileDir.appending(subpath: $0)
+            let inputFiles = try FileManager.default.subpathsOfDirectory(atPath: inputFileDir.path).map {
+                inputFileDir.appendingPathComponent($0)
             }
             return Command.buildCommand(
                 displayName: "Generating host overlay for \(singleFixture)",
                 executable: witTool,
                 arguments: [
                     "generate-overlay", "--target", "host",
-                    inputFileDir, "-o", outputFile
+                    inputFileDir.path, "-o", outputFile.path
                 ],
                 inputFiles: inputFiles,
                 outputFiles: [outputFile]

--- a/Plugins/WITOverlayPlugin/Plugin.swift
+++ b/Plugins/WITOverlayPlugin/Plugin.swift
@@ -7,18 +7,18 @@ struct Plugin: BuildToolPlugin {
         if !target.recursiveTargetDependencies.contains(where: { $0.name == "_CabiShims" }) {
             Diagnostics.emit(.error, "\"_CabiShims\" must be included as a dependency")
         }
-        let witTool = try context.tool(named: "WITTool").path
-        let witDir = target.directory.appending("wit")
-        let inputFiles = try FileManager.default.subpathsOfDirectory(atPath: witDir.string).map {
-            witDir.appending(subpath: $0)
+        let witTool = try context.tool(named: "WITTool").url
+        let witDir = target.directoryURL.appendingPathComponent("wit")
+        let inputFiles = try FileManager.default.subpathsOfDirectory(atPath: witDir.path).map {
+            witDir.appendingPathComponent($0)
         }
-        let outputFile = context.pluginWorkDirectory.appending("GeneratedOverlay", "\(target.name)Overlay.swift")
+        let outputFile = context.pluginWorkDirectoryURL.appendingPathComponent("GeneratedOverlay").appendingPathComponent("\(target.name)Overlay.swift")
         let command = Command.buildCommand(
             displayName: "Generating WIT overlay for \(target.name)",
             executable: witTool,
             arguments: [
                 "generate-overlay", "--target", "guest",
-                witDir, "-o", outputFile
+                witDir.path, "-o", outputFile.path
             ],
             inputFiles: inputFiles,
             outputFiles: [outputFile]

--- a/Sources/SystemExtras/Vendor/Exports.swift
+++ b/Sources/SystemExtras/Vendor/Exports.swift
@@ -142,7 +142,7 @@ extension String {
     return
 
     #else
-    self.init(validatingUTF8: platformString)
+    self.init(validatingCString: platformString)
     #endif
   }
 

--- a/Sources/WASI/Platform/SandboxPrimitives/Open.swift
+++ b/Sources/WASI/Platform/SandboxPrimitives/Open.swift
@@ -180,7 +180,9 @@ struct PathResolution {
                 guard length >= 0 else {
                     throw try WASIAbi.Errno(platformErrno: errno)
                 }
-                return FilePath(String(cString: buffer))
+                // Ensure null termination for platformString initializer
+                buffer[length] = 0
+                return buffer.withUnsafeBufferPointer { FilePath(platformString: $0.baseAddress!) }
             }
 
             guard resolvedSymlinks < Self.MAX_SYMLINKS else {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1614,10 +1614,10 @@ final class WASIImplementation {
         let linkBytes = try dirEntry.readlink(atPath: path)
         let bytesWritten = min(Int(buffer.count), linkBytes.count)
         if bytesWritten > 0 {
-            try buffer.withHostPointer { hostBuffer in
+            buffer.withHostPointer { hostBuffer in
                 linkBytes.withUnsafeBytes { linkBytes in
                     guard let source = linkBytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
-                    hostBuffer.baseAddress?.assign(from: source, count: bytesWritten)
+                    hostBuffer.baseAddress?.update(from: source, count: bytesWritten)
                 }
             }
         }

--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -459,7 +459,9 @@ extension Execution {
         #else
             var pc = pc
             let handler = pc.read(wasmkit_tc_exec.self)
-            wasmkit_tc_start(handler, sp, pc, md, ms, &self)
+            withUnsafeMutablePointer(to: &self) { selfPtr in
+                wasmkit_tc_start(handler, sp, pc, md, ms, selfPtr)
+            }
             if let (rawError, trappingSp) = self.trap {
                 let error = unsafeBitCast(rawError, to: Error.self)
                 // Manually release the error object because the trap is caught in C and


### PR DESCRIPTION
This PR fixes all compiler warnings in the codebase:

- Fixed unhandled file warnings by adding exclusions for LICENSE.txt and CMakeLists.txt files
- Updated plugin files to use URL instead of deprecated Path API
- Fixed deprecated String.init(validatingUTF8:) to use String.init(validatingCString:)
- Removed unreachable code in FileOperations.swift
- Fixed deprecated String.init(cString:) to use String(decoding:as: UTF8.self)
- Fixed deprecated assign(from:count:) to use update(from:count:) and removed unnecessary try
- Fixed unsafe pointer warning by using withUnsafeMutablePointer
- Fixed FilePath initialization to use platformString initializer
- Fixed dev_t conversion to preserve bit pattern for both signed and unsigned types