### PR TITLE
Update `Benchmarks/README.md` for library benchmarks

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -2,11 +2,35 @@
 
 This directory contains a set of benchmarks that can be used to compare the performance of the WasmKit runtime with other WebAssembly runtimes.
 
-## Prerequisites
+The benchmarks are divided in two types:
 
-To build benchmarks, you need to install [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) and set the `WASI_SDK_PATH` environment variable to the installation directory.
+* Bencmarking WasmKit library via [`package-benchmark`](https://github.com/ordo-one/package-benchmark) harness;
+* Benchmarking Wasm runtime executables end-to-end, implemented with a `bench.py` script.
 
-## Running the Benchmarks
+Setup and running instructions depend on the type of benchmarking you're interested.
+
+## WasmKit Library Benchmarks
+
+### Prerequisites
+
+Check out benchmark dependencies with this terminal invocation in the root of WasmKit repository clone:
+
+```sh
+./Vendor/checkout-dependency --category benchmark
+```
+## Running Libary Benchmarks
+
+After `Vendor/checkout-dependency` invocation listed above completed successfully, navigate back to the `Benchmarks` directory and start benchmarks:
+
+```sh
+swift package benchmark
+```
+
+### Prerequisites
+
+To build executable benchmarks, you need to install [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) and set the `WASI_SDK_PATH` environment variable to the installation directory.
+
+### Running the Benchmarks
 
 Run all benchmarks:
 


### PR DESCRIPTION
Previous instructions only described the Python script, but not the library benchmarks that require different setup and running instructions.