### PR TITLE
Mark `InstructionVisitor` as `~Copyable`

### DIFF
--- a/Sources/WasmParser/BinaryInstructionDecoder.swift
+++ b/Sources/WasmParser/BinaryInstructionDecoder.swift
@@ -213,7 +213,10 @@ protocol BinaryInstructionDecoder {
 }
 
 @inlinable
-func parseBinaryInstruction(visitor: inout some InstructionVisitor, decoder: inout some BinaryInstructionDecoder) throws -> Bool {
+func parseBinaryInstruction(
+    visitor: inout some InstructionVisitor & ~Copyable,
+    decoder: inout some BinaryInstructionDecoder
+) throws -> Bool {
     visitor.binaryOffset = decoder.offset
     let opcode0 = try decoder.claimNextByte()
     switch opcode0 {

--- a/Sources/WasmParser/InstructionVisitor.swift
+++ b/Sources/WasmParser/InstructionVisitor.swift
@@ -673,7 +673,7 @@ extension AnyInstructionVisitor {
 ///
 /// The visitor pattern is used while parsing WebAssembly expressions to allow for easy extensibility.
 /// See the expression parsing method ``Code/parseExpression(visitor:)``
-public protocol InstructionVisitor {
+public protocol InstructionVisitor: ~Copyable {
     associatedtype VisitorError: Error
     /// Current offset in visitor's instruction stream.
     var binaryOffset: Int { get set }
@@ -912,7 +912,7 @@ public protocol InstructionVisitor {
     mutating func visitUnknown(_ opcode: [UInt8]) throws(VisitorError) -> Bool
 }
 
-extension InstructionVisitor {
+extension InstructionVisitor where Self: ~Copyable {
     /// Visits an instruction.
     public mutating func visit(_ instruction: Instruction) throws(VisitorError) {
         switch instruction {
@@ -1036,7 +1036,7 @@ extension InstructionVisitor {
 }
 
 // MARK: - Placeholder implementations
-extension InstructionVisitor {
+extension InstructionVisitor where Self: ~Copyable {
     public mutating func visitUnreachable() throws(VisitorError) {}
     public mutating func visitNop() throws(VisitorError) {}
     public mutating func visitBlock(blockType: BlockType) throws(VisitorError) {}

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -121,7 +121,7 @@ extension Code {
     /// }
     /// ````
     @inlinable
-    public func parseExpression<V: InstructionVisitor>(visitor: inout V) throws {
+    public func parseExpression(visitor: inout some InstructionVisitor & ~Copyable) throws {
         var parser = Parser(stream: StaticByteStream(bytes: self.expression), features: self.features)
         var lastIsEnd: Bool?
         while try !parser.stream.hasReachedEnd() {
@@ -920,7 +920,7 @@ extension Parser: BinaryInstructionDecoder {
     /// Returns: `true` if the parsed instruction is the block end instruction.
     @inline(__always)
     @inlinable
-    mutating func parseInstruction<V: InstructionVisitor>(visitor v: inout V) throws -> Bool {
+    mutating func parseInstruction(visitor v: inout some InstructionVisitor & ~Copyable) throws -> Bool {
         return try parseBinaryInstruction(visitor: &v, decoder: &self)
     }
 

--- a/Utilities/Sources/WasmGen.swift
+++ b/Utilities/Sources/WasmGen.swift
@@ -95,7 +95,7 @@ enum WasmGen {
             ///
             /// The visitor pattern is used while parsing WebAssembly expressions to allow for easy extensibility.
             /// See the expression parsing method ``Code/parseExpression(visitor:)``
-            public protocol InstructionVisitor {
+            public protocol InstructionVisitor: ~Copyable {
                 associatedtype VisitorError: Error
                 /// Current offset in visitor's instruction stream.
                 var binaryOffset: Int { get set }
@@ -122,7 +122,7 @@ enum WasmGen {
         code += """
 
 
-            extension InstructionVisitor {
+            extension InstructionVisitor where Self: ~Copyable {
                 /// Visits an instruction.
                 public mutating func visit(_ instruction: Instruction) throws(VisitorError) {
                     switch instruction {
@@ -154,7 +154,7 @@ enum WasmGen {
         code += """
 
             // MARK: - Placeholder implementations
-            extension InstructionVisitor {
+            extension InstructionVisitor where Self: ~Copyable {
 
             """
         for instruction in instructions.categorized {
@@ -573,7 +573,10 @@ enum WasmGen {
         code += """
 
         @inlinable
-        func parseBinaryInstruction(visitor: inout some InstructionVisitor, decoder: inout some BinaryInstructionDecoder) throws -> Bool {
+        func parseBinaryInstruction(
+            visitor: inout some InstructionVisitor & ~Copyable,
+            decoder: inout some BinaryInstructionDecoder
+        ) throws -> Bool {
             visitor.binaryOffset = decoder.offset
         """
 


### PR DESCRIPTION
Separates a small change out of a bigger PR: https://github.com/swiftwasm/WasmKit/pull/248