### PR TITLE
Add option to `wat2wasm` for including name section in output

### DIFF
--- a/Sources/CLICommands/Wat2wasm.swift
+++ b/Sources/CLICommands/Wat2wasm.swift
@@ -58,6 +58,9 @@ package struct Wat2wasm: ParsableCommand {
     )
     var output: String?
 
+    @Flag(help: "Include the name section in the output binary.")
+    var nameSection: Bool = true
+
     package init() {}
 
     package func run() throws {
@@ -80,7 +83,7 @@ package struct Wat2wasm: ParsableCommand {
             wat = String(decoding: watBuffer, as: UTF8.self)
         }
 
-        let wasm = try wat2wasm(wat)
+        let wasm = try wat2wasm(wat, options: EncodeOptions(nameSection: nameSection))
         var outputPath: FilePath
 
         if let output {


### PR DESCRIPTION
`wat2wasm` already supports and has `false` by default. Given that `wat2wasm` is mostly used for debugging, in this CLI command we're setting the default to `true`