### PR TITLE
`.github/workflows/cflite_pr.yml`: use older runner version

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder-swift:v1
 RUN apt-get update && apt-get install -y make autoconf automake libtool
+ENV SWIFT_PREFIX=/opt/swift
+RUN mkdir -p "$SWIFT_PREFIX" && \
+  curl -L https://download.swift.org/swift-6.1.3-release/ubuntu2004/swift-6.1.3-RELEASE/swift-6.1.3-RELEASE-ubuntu20.04.tar.gz | tar xz -C "$SWIFT_PREFIX" --strip-component 1
+ENV PATH="$SWIFT_PREFIX/usr/bin:$PATH"
 COPY . $SRC/wasmkit
 WORKDIR $SRC/wasmkit
 COPY .clusterfuzzlite/build.sh $SRC/


### PR DESCRIPTION
Downgraded os runner image to be compatible with `Dockerfile` used for CFLite fuzzer.