### PR TITLE
Disable `PluginSmokeTests` on macOS

### DIFF
--- a/Tests/WITExtractorPluginTests/PluginSmokeTests.swift
+++ b/Tests/WITExtractorPluginTests/PluginSmokeTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Suite struct PluginSmokeTests {
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     #else
         @Test(
             .disabled(


### PR DESCRIPTION
This test is super-flaky on macOS CI runners, especially with Xcode 16.4, but we've never seen it fail on other platforms. This seems to be a SwiftPM bug and it failing on macOS doesn't provide any useful signal other than requiring manual CI job restarts.