### PR TITLE
Fix wasm-tools path in `WasmTools.swift`

### DIFF
--- a/Sources/WasmTools/WasmTools.swift
+++ b/Sources/WasmTools/WasmTools.swift
@@ -15,7 +15,7 @@ package let defaultWasmToolsPath: String = {
     let vendorPath = rootPath.appendingPathComponent("Vendor")
     return
         vendorPath
-        .appendingPathComponent("wasm-tools/wasm-tools-1.244.0-wasm32-wasip1/wasm-tools.wasm")
+        .appendingPathComponent("wasm-tools-prebuilt/wasm-tools-1.244.0-wasm32-wasip1/wasm-tools.wasm")
         .path
 }()
 


### PR DESCRIPTION
The directory was renamed to `wasm-tools-prebuilt` in `dependencies.json`, but `WasmTools.swift` had an outdated path.