### PR TITLE
Clean up sections batching in `ComponentEncoder`

### DIFF
--- a/Sources/ComponentModel/ComponentBinaryFormat.swift
+++ b/Sources/ComponentModel/ComponentBinaryFormat.swift
@@ -3,7 +3,7 @@
 /// Reference: `Vendor/component-model/design/mvp/Binary.md`
 
 /// Section IDs per Binary.md
-package enum ComponentSectionID: UInt8 {
+package enum ComponentSectionID: UInt8, Comparable {
     case custom = 0x00
     case coreModule = 0x01
     case coreInstance = 0x02
@@ -17,6 +17,10 @@ package enum ComponentSectionID: UInt8 {
     case `import` = 0x0A
     case export = 0x0B
     case value = 0x0C
+
+    package static func < (lhs: ComponentSectionID, rhs: ComponentSectionID) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
 }
 
 // MARK: - Value Type Opcodes

--- a/Sources/WAT/BinaryEncoding/ComponentEncoder.swift
+++ b/Sources/WAT/BinaryEncoding/ComponentEncoder.swift
@@ -123,16 +123,25 @@
                 try flushPendingComponentTypes()
             }
 
-            // Encode fields in order, producing interleaved sections
-            // This matches wasm-tools normalization behavior where sections follow semantic order
-            // Consecutive component types are batched into a single section
+            // Flush all pending sections except those matching the given section kind.
+            // Batchable sections (type, coreType, coreInstance, alias) keep their own
+            // pending buffer intact so consecutive same-kind items accumulate.
+            // Non-batchable sections have no pending buffer, so this flushes everything.
+            func flushPendingSectionsExcept(_ kind: ComponentSectionID) throws(WatParserError) {
+                if kind != .coreInstance { try flushPendingCoreInstances() }
+                if kind != .alias { try flushPendingAliases() }
+                if kind != .coreType { try flushPendingCoreTypes() }
+                if kind != .type { try flushPendingComponentTypes() }
+            }
+
+            // Encode fields in order, producing interleaved sections.
+            // Consecutive same-section-kind fields are batched into a single section.
+            // NormalizedDefinition.sectionKind drives which pending buffers to flush.
             for field in component.fields {
+                try flushPendingSectionsExcept(field.kind.sectionKind)
+
                 switch field.kind {
                 case .componentType(let typeIndex):
-                    // Flush other sections before component types (different section)
-                    try flushPendingCoreInstances()
-                    try flushPendingAliases()
-                    try flushPendingCoreTypes()
                     // Collect all unemitted types up to and including this type index
                     // This ensures anonymous dependency types (with lower indices) get batched
                     // with the types that reference them
@@ -144,28 +153,15 @@
                     }
 
                 case .coreModule(let index):
-                    try flushAllPending()
                     try encodeSingleCoreModule(index, component: component, options: options)
 
                 case .coreInstance(let index):
-                    // Flush non-instance sections before accumulating
-                    try flushPendingAliases()
-                    try flushPendingCoreTypes()
-                    try flushPendingComponentTypes()
-                    // Accumulate consecutive core instances for batching
                     pendingCoreInstances.append((index, field.location))
 
                 case .coreType(let index):
-                    // Flush other sections before core types (different section)
-                    try flushPendingCoreInstances()
-                    try flushPendingAliases()
-                    try flushPendingComponentTypes()
-                    // Accumulate consecutive core types for batching
                     pendingCoreTypes.append(UInt32(index))
 
                 case .canon(let canonDef):
-                    try flushAllPending()
-                    // Emit required types before the canon
                     try emitRequiredTypesForCanon(
                         canonDef,
                         component: component,
@@ -174,8 +170,6 @@
                         emittedTypes: &emittedTypes,
                         liftIndex: liftIndex
                     )
-
-                    // Canon definitions may emit both alias and canon sections
                     try encodeSingleCanon(
                         canonDef,
                         coreFuncAliases: coreFuncAliases,
@@ -193,9 +187,7 @@
                         emittedOptionCoreFuncAliases: &emittedOptionCoreFuncAliases
                     )
 
-                case .importDef(let importDef):
-                    try flushAllPending()
-                    // Emit required types before the import
+                case .componentImport(let importDef):
                     try emitRequiredTypesForImport(
                         importDef,
                         component: component,
@@ -205,8 +197,7 @@
                     )
                     try encodeSingleImport(importDef, typeIndexMapping: typeIndexMapping, location: field.location)
 
-                case .exportDef(let exportDef):
-                    try flushAllPending()
+                case .componentExport(let exportDef):
                     try encodeSingleExport(
                         exportDef,
                         typeIndexMapping: typeIndexMapping,
@@ -218,19 +209,12 @@
                     )
 
                 case .component(let index):
-                    try flushAllPending()
                     try encodeSingleComponent(index, component: component, options: options)
 
                 case .instance(let index):
-                    try flushAllPending()
                     try encodeSingleComponentInstance(index, component: component, location: field.location)
 
                 case .alias(let alias):
-                    // Flush other sections before aliases (different section)
-                    try flushPendingCoreInstances()
-                    try flushPendingCoreTypes()
-                    try flushPendingComponentTypes()
-                    // Accumulate consecutive aliases for batching
                     pendingAliases.append(alias)
                 }
             }
@@ -1286,9 +1270,9 @@
                     result.components.append((index, field.location))
                 case .canon(let canonDef):
                     result.canons.append((canonDef, field.location))
-                case .exportDef(let exportDef):
+                case .componentExport(let exportDef):
                     result.exports.append((exportDef, field.location))
-                case .importDef(let importDef):
+                case .componentImport(let importDef):
                     result.imports.append((importDef, field.location))
                 case .instance(let index):
                     result.instances.append((index, field.location))

--- a/Sources/WAT/Parser/ComponentDef.swift
+++ b/Sources/WAT/Parser/ComponentDef.swift
@@ -1,0 +1,283 @@
+#if ComponentModel
+
+    import ComponentModel
+    import WasmParser
+    import WasmTypes
+
+    extension ComponentWatParser {
+        struct ComponentDefField {
+            let location: Location
+            let kind: NormalizedDefinition
+        }
+
+        struct ValueDef: NamedFieldDecl {
+            var id: Name?
+        }
+
+        struct ComponentInstanceDef: NamedFieldDecl {
+            var id: Name?
+            var componentRef: Parser.IndexOrId?
+            var arguments: [ComponentInstanceArgument]
+        }
+
+        struct ComponentInstanceArgument {
+            enum Kind {
+                case instance(Parser.IndexOrId)
+            }
+            let name: String
+            let kind: Kind
+        }
+
+        /// A core function definition created via canon lower.
+        struct CoreFuncDef: NamedFieldDecl {
+            var id: Name?
+        }
+
+        /// A core memory definition created via alias.
+        struct CoreMemoryAliasDef: NamedFieldDecl {
+            var id: Name?
+        }
+
+        /// https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#index-spaces
+        public struct ComponentDef: NamedFieldDecl {
+            var id: Name?
+
+            // Listed in the order of section indices in binary encoding.
+            var coreModulesMap: NameMapping<ModuleDef> = .init()
+            var coreInstancesMap: NameMapping<CoreInstanceDef> = .init()
+            var coreTypesMap: CoreTypesMap = .init()
+            var coreFunctionsMap: NameMapping<CoreFuncDef> = .init()  // Core functions created by canon lower
+            var coreMemoriesMap: NameMapping<CoreMemoryAliasDef> = .init()  // Core memories created by alias
+
+            var componentFunctions: NameMapping<ComponentFuncDef> = .init()
+            var valuesMap: NameMapping<ValueDef> = .init()
+            var componentTypes: NameMapping<ComponentTypeDef> = .init()
+            var componentInstancesMap: NameMapping<ComponentInstanceDef> = .init()
+            var componentsMap: NameMapping<ComponentDef> = .init()
+
+            /// As sections in CM binaries can stay disjoint and unmerged,
+            /// we should preserve disjoint sections together with their ordering.
+            var fields = [ComponentDefField]()
+
+            /// Mapping from a component type to its unique ID in `componentTypes` name mapping storage.
+            var typesMap = [ComponentTypeDef.Kind: Int]()
+        }
+
+        struct ModuleDef: NamedFieldDecl {
+            var id: Name?
+            var wat: Wat
+        }
+
+        struct CoreInstanceDef: NamedFieldDecl {
+            struct Argument {
+                enum Kind {
+                    struct Export {
+                        let name: String
+                        let sort: CoreDefSort
+                        let index: UInt32
+                    }
+                    case instance(Parser.IndexOrId)
+                    case exports([Export])
+                }
+
+                let importName: String
+                let kind: Kind
+            }
+
+            var id: Name?
+            var moduleId: Parser.IndexOrId
+            var arguments: [Argument]
+        }
+
+        struct CoreTypeDef: NamedFieldDecl {
+            enum Kind {
+                case function(WatParser.FunctionType)
+                case module(CoreModuleTypeDef)
+            }
+            var id: Name?
+            let kind: Kind
+        }
+
+        struct CoreModuleTypeDef {
+            var declarations: [CoreModuleDecl]
+            var localTypeBindings: [String: Int] = [:]
+
+            func resolveTypeIndex(use: Parser.IndexOrId, globalResolver: CoreTypesMap) throws(WatParserError) -> Int {
+                switch use {
+                case .id(let id, _):
+                    if let localDeclIndex = localTypeBindings[id.value] {
+                        return localDeclIndex
+                    }
+                    return try globalResolver.resolveIndex(use: use)
+                case .index:
+                    return try globalResolver.resolveIndex(use: use)
+                }
+            }
+        }
+
+        enum CoreModuleDecl {
+            case alias(CoreModuleAlias)
+            case type(TypeIndex)
+            case `import`(CoreModuleImport)
+            case export(CoreModuleExport)
+        }
+
+        struct CoreModuleAlias {
+            let sort: CoreDefSort
+            let target: CoreModuleAliasTarget
+            let bindingId: Name?
+        }
+
+        enum CoreModuleAliasTarget {
+            case outer(componentId: Parser.IndexOrId, index: Parser.IndexOrId, resolvedIndex: Int, outerCount: Int)
+        }
+
+        enum CoreAliasSort: String {
+            case `func`
+            case table
+            case memory
+            case global
+            case type
+        }
+
+        /// Component-level alias definition.
+        /// Syntax: (alias core export $instance "name" (core <sort> $bindingId))
+        ///         (alias export $instance "name" (<sort> $bindingId))
+        ///         (alias outer $component $idx (<sort> $bindingId))
+        ///
+        /// This is separate from `ComponentModel.ComponentAlias` because the parser works with
+        /// unresolved symbolic references (`Parser.IndexOrId`) while the binary representation
+        /// uses resolved numeric indices (`UInt32`). The encoder resolves these during binary encoding.
+        struct ComponentAlias {
+            enum Target {
+                case export(isCore: Bool, instanceIndex: Parser.IndexOrId, exportName: String)
+                case outer(outerCount: Parser.IndexOrId, typeIndex: Parser.IndexOrId)
+            }
+
+            let sort: ComponentDefSort
+            let target: Target
+            let bindingId: Name?
+        }
+
+        struct CoreModuleImport {
+            let moduleName: String
+            let name: String
+            let descriptor: CoreImportDesc
+        }
+
+        enum CoreImportDesc {
+            case `func`(typeIndex: Parser.IndexOrId)
+        }
+
+        struct CoreModuleExport {
+            let name: String
+            let descriptor: CoreImportDesc
+        }
+
+        struct FuncIndex {
+            var instance: Parser.IndexOrId
+            var exportName: String
+        }
+
+        /// Reference to a core memory via instance export.
+        /// Used in canon options: (memory $instance "export")
+        struct MemoryRef {
+            var instance: Parser.IndexOrId
+            var exportName: String
+        }
+
+        /// Reference to a component function via instance export.
+        /// Used in canon lower: (func $instance "export")
+        struct ComponentFuncRef {
+            var instance: Parser.IndexOrId
+            var exportName: String
+        }
+
+        struct CanonDef {
+            enum Option {
+                case stringEncoding(ComponentStringEncoding)
+                case memory(MemoryRef)
+                case realloc(FuncIndex)
+                case postReturn(FuncIndex)
+                case `async`
+                case callback(FuncIndex)
+            }
+
+            enum Kind {
+                case lower(ComponentFuncRef)
+                case lift(FuncIndex)
+            }
+            let kind: Kind
+            let functionIndex: FuncIndex
+            let options: [Option]
+        }
+
+        enum ExternDesc {
+            case module(Parser.IndexOrId)
+            case function(ComponentFuncIndex)
+            case functionFromInstance(Parser.IndexOrId, String)  // (instance, exportName)
+            case value(Parser.IndexOrId)
+            case type(Parser.IndexOrId)
+            case component(Parser.IndexOrId)
+            case instance(Parser.IndexOrId)
+        }
+
+        struct ExportDef {
+            let exportName: String
+            let descriptor: ExternDesc
+        }
+
+        struct ImportDef {
+            let importModuleName: String
+            let importName: String
+            let descriptor: ExternDesc
+        }
+
+        struct ComponentFuncDef: NamedFieldDecl {
+            var id: Name?
+            let paramNames: [String]
+            let type: ComponentTypeIndex
+        }
+
+        struct ComponentTypeDef: NamedFieldDecl {
+            enum Kind: Hashable {
+                case function(ComponentFuncType)
+                case value(ComponentValueType)
+                case instance(InstanceTypeDef)
+                case component(ComponentInnerTypeDef)
+            }
+            var id: Name?
+            let kind: Kind
+        }
+
+        struct InstanceTypeDef: Hashable {
+            struct TypeDecl: Hashable {
+                let id: Name?
+                let valueType: ComponentValueType
+            }
+            struct ExportDecl: Hashable {
+                let name: String
+                // Simplified - full implementation would handle type equality constraints
+            }
+            let typeDecls: [TypeDecl]
+            let exports: [ExportDecl]
+        }
+
+        struct ComponentInnerTypeDef: Hashable {
+            struct TypeDecl: Hashable {
+                let id: Name?
+                let valueType: ComponentValueType
+            }
+            struct ImportDecl: Hashable {
+                let name: String
+            }
+            struct ExportDecl: Hashable {
+                let name: String
+            }
+            let typeDecls: [TypeDecl]
+            let imports: [ImportDecl]
+            let exports: [ExportDecl]
+        }
+    }
+
+#endif

--- a/Sources/WAT/Parser/ComponentWatParser.swift
+++ b/Sources/WAT/Parser/ComponentWatParser.swift
@@ -189,7 +189,7 @@
                 currentComponent.fields.append(
                     .init(
                         location: location,
-                        kind: .importDef(
+                        kind: .componentImport(
                             ImportDef(
                                 importModuleName: "",  // Not used for component imports
                                 importName: importName,
@@ -222,7 +222,7 @@
                 currentComponent.fields.append(
                     .init(
                         location: location,
-                        kind: .importDef(
+                        kind: .componentImport(
                             ImportDef(
                                 importModuleName: "",
                                 importName: importName,
@@ -277,7 +277,7 @@
             currentComponent.fields.append(
                 .init(
                     location: location,
-                    kind: .exportDef(
+                    kind: .componentExport(
                         ExportDef(
                             exportName: exportName,
                             descriptor: descriptor
@@ -598,7 +598,7 @@
                 self.currentComponent.fields.append(
                     .init(
                         location: inlineExport.location,
-                        kind: .exportDef(
+                        kind: .componentExport(
                             ExportDef(
                                 exportName: inlineExport.name,
                                 descriptor: .type(.index(UInt32(typeIndex), typeLocation))
@@ -1313,7 +1313,7 @@
                 self.currentComponent.fields.append(
                     .init(
                         location: exportDef.location,
-                        kind: .exportDef(ExportDef(exportName: exportDef.exportName, descriptor: .function(.init(funcIndex))))
+                        kind: .componentExport(ExportDef(exportName: exportDef.exportName, descriptor: .function(.init(funcIndex))))
                     )
                 )
             }
@@ -1322,7 +1322,7 @@
                 self.currentComponent.fields.append(
                     .init(
                         location: importDef.location,
-                        kind: .importDef(
+                        kind: .componentImport(
                             .init(
                                 importModuleName: importDef.importModule,
                                 importName: importDef.importName,
@@ -1414,295 +1414,6 @@
             try parser.expect(.rightParen)
 
             return .init(instance: instanceId, exportName: exportName)
-        }
-    }
-
-    extension ComponentWatParser {
-        struct ComponentDefField {
-            enum Kind {
-                case coreModule(CoreModuleIndex)
-                case coreInstance(CoreInstanceIndex)
-                case coreType(TypeIndex)
-                case component(ComponentIndex)
-                case instance(ComponentInstanceIndex)
-                case componentType(ComponentTypeIndex)
-                case canon(CanonDef)
-                case exportDef(ExportDef)
-                case importDef(ImportDef)
-                case alias(ComponentAlias)
-            }
-
-            let location: Location
-            let kind: Kind
-        }
-
-        struct ValueDef: NamedFieldDecl {
-            var id: Name?
-        }
-
-        struct ComponentInstanceDef: NamedFieldDecl {
-            var id: Name?
-            var componentRef: Parser.IndexOrId?
-            var arguments: [ComponentInstanceArgument]
-        }
-
-        struct ComponentInstanceArgument {
-            enum Kind {
-                case instance(Parser.IndexOrId)
-            }
-            let name: String
-            let kind: Kind
-        }
-
-        /// A core function definition created via canon lower.
-        struct CoreFuncDef: NamedFieldDecl {
-            var id: Name?
-        }
-
-        /// A core memory definition created via alias.
-        struct CoreMemoryAliasDef: NamedFieldDecl {
-            var id: Name?
-        }
-
-        /// https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#index-spaces
-        public struct ComponentDef: NamedFieldDecl {
-            var id: Name?
-
-            // Listed in the order of section indices in binary encoding.
-            var coreModulesMap: NameMapping<ModuleDef> = .init()
-            var coreInstancesMap: NameMapping<CoreInstanceDef> = .init()
-            var coreTypesMap: CoreTypesMap = .init()
-            var coreFunctionsMap: NameMapping<CoreFuncDef> = .init()  // Core functions created by canon lower
-            var coreMemoriesMap: NameMapping<CoreMemoryAliasDef> = .init()  // Core memories created by alias
-
-            var componentFunctions: NameMapping<ComponentFuncDef> = .init()
-            var valuesMap: NameMapping<ValueDef> = .init()
-            var componentTypes: NameMapping<ComponentTypeDef> = .init()
-            var componentInstancesMap: NameMapping<ComponentInstanceDef> = .init()
-            var componentsMap: NameMapping<ComponentDef> = .init()
-
-            /// As sections in CM binaries can stay disjoint and unmerged,
-            /// we should preserve disjoint sections together with their ordering.
-            var fields = [ComponentDefField]()
-
-            /// Mapping from a component type to its unique ID in `componentTypes` name mapping storage.
-            var typesMap = [ComponentTypeDef.Kind: Int]()
-        }
-
-        struct ModuleDef: NamedFieldDecl {
-            var id: Name?
-            var wat: Wat
-        }
-
-        struct CoreInstanceDef: NamedFieldDecl {
-            struct Argument {
-                enum Kind {
-                    struct Export {
-                        let name: String
-                        let sort: CoreDefSort
-                        let index: UInt32
-                    }
-                    case instance(Parser.IndexOrId)
-                    case exports([Export])
-                }
-
-                let importName: String
-                let kind: Kind
-            }
-
-            var id: Name?
-            var moduleId: Parser.IndexOrId
-            var arguments: [Argument]
-        }
-
-        struct CoreTypeDef: NamedFieldDecl {
-            enum Kind {
-                case function(WatParser.FunctionType)
-                case module(CoreModuleTypeDef)
-            }
-            var id: Name?
-            let kind: Kind
-        }
-
-        struct CoreModuleTypeDef {
-            var declarations: [CoreModuleDecl]
-            var localTypeBindings: [String: Int] = [:]
-
-            func resolveTypeIndex(use: Parser.IndexOrId, globalResolver: CoreTypesMap) throws(WatParserError) -> Int {
-                switch use {
-                case .id(let id, _):
-                    if let localDeclIndex = localTypeBindings[id.value] {
-                        return localDeclIndex
-                    }
-                    return try globalResolver.resolveIndex(use: use)
-                case .index:
-                    return try globalResolver.resolveIndex(use: use)
-                }
-            }
-        }
-
-        enum CoreModuleDecl {
-            case alias(CoreModuleAlias)
-            case type(TypeIndex)
-            case `import`(CoreModuleImport)
-            case export(CoreModuleExport)
-        }
-
-        struct CoreModuleAlias {
-            let sort: CoreDefSort
-            let target: CoreModuleAliasTarget
-            let bindingId: Name?
-        }
-
-        enum CoreModuleAliasTarget {
-            case outer(componentId: Parser.IndexOrId, index: Parser.IndexOrId, resolvedIndex: Int, outerCount: Int)
-        }
-
-        enum CoreAliasSort: String {
-            case `func`
-            case table
-            case memory
-            case global
-            case type
-        }
-
-        /// Component-level alias definition.
-        /// Syntax: (alias core export $instance "name" (core <sort> $bindingId))
-        ///         (alias export $instance "name" (<sort> $bindingId))
-        ///         (alias outer $component $idx (<sort> $bindingId))
-        ///
-        /// This is separate from `ComponentModel.ComponentAlias` because the parser works with
-        /// unresolved symbolic references (`Parser.IndexOrId`) while the binary representation
-        /// uses resolved numeric indices (`UInt32`). The encoder resolves these during binary encoding.
-        struct ComponentAlias {
-            enum Target {
-                case export(isCore: Bool, instanceIndex: Parser.IndexOrId, exportName: String)
-                case outer(outerCount: Parser.IndexOrId, typeIndex: Parser.IndexOrId)
-            }
-
-            let sort: ComponentDefSort
-            let target: Target
-            let bindingId: Name?
-        }
-
-        struct CoreModuleImport {
-            let moduleName: String
-            let name: String
-            let descriptor: CoreImportDesc
-        }
-
-        enum CoreImportDesc {
-            case `func`(typeIndex: Parser.IndexOrId)
-        }
-
-        struct CoreModuleExport {
-            let name: String
-            let descriptor: CoreImportDesc
-        }
-
-        struct FuncIndex {
-            var instance: Parser.IndexOrId
-            var exportName: String
-        }
-
-        /// Reference to a core memory via instance export.
-        /// Used in canon options: (memory $instance "export")
-        struct MemoryRef {
-            var instance: Parser.IndexOrId
-            var exportName: String
-        }
-
-        /// Reference to a component function via instance export.
-        /// Used in canon lower: (func $instance "export")
-        struct ComponentFuncRef {
-            var instance: Parser.IndexOrId
-            var exportName: String
-        }
-
-        struct CanonDef {
-            enum Option {
-                case stringEncoding(ComponentStringEncoding)
-                case memory(MemoryRef)
-                case realloc(FuncIndex)
-                case postReturn(FuncIndex)
-                case `async`
-                case callback(FuncIndex)
-            }
-
-            enum Kind {
-                case lower(ComponentFuncRef)
-                case lift(FuncIndex)
-            }
-            let kind: Kind
-            let functionIndex: FuncIndex
-            let options: [Option]
-        }
-
-        enum ExternDesc {
-            case module(Parser.IndexOrId)
-            case function(ComponentFuncIndex)
-            case functionFromInstance(Parser.IndexOrId, String)  // (instance, exportName)
-            case value(Parser.IndexOrId)
-            case type(Parser.IndexOrId)
-            case component(Parser.IndexOrId)
-            case instance(Parser.IndexOrId)
-        }
-
-        struct ExportDef {
-            let exportName: String
-            let descriptor: ExternDesc
-        }
-
-        struct ImportDef {
-            let importModuleName: String
-            let importName: String
-            let descriptor: ExternDesc
-        }
-
-        struct ComponentFuncDef: NamedFieldDecl {
-            var id: Name?
-            let paramNames: [String]
-            let type: ComponentTypeIndex
-        }
-
-        struct ComponentTypeDef: NamedFieldDecl {
-            enum Kind: Hashable {
-                case function(ComponentFuncType)
-                case value(ComponentValueType)
-                case instance(InstanceTypeDef)
-                case component(ComponentInnerTypeDef)
-            }
-            var id: Name?
-            let kind: Kind
-        }
-
-        struct InstanceTypeDef: Hashable {
-            struct TypeDecl: Hashable {
-                let id: Name?
-                let valueType: ComponentValueType
-            }
-            struct ExportDecl: Hashable {
-                let name: String
-                // Simplified - full implementation would handle type equality constraints
-            }
-            let typeDecls: [TypeDecl]
-            let exports: [ExportDecl]
-        }
-
-        struct ComponentInnerTypeDef: Hashable {
-            struct TypeDecl: Hashable {
-                let id: Name?
-                let valueType: ComponentValueType
-            }
-            struct ImportDecl: Hashable {
-                let name: String
-            }
-            struct ExportDecl: Hashable {
-                let name: String
-            }
-            let typeDecls: [TypeDecl]
-            let imports: [ImportDecl]
-            let exports: [ExportDecl]
         }
     }
 

--- a/Sources/WAT/Parser/NormalizedDefinition.swift
+++ b/Sources/WAT/Parser/NormalizedDefinition.swift
@@ -1,0 +1,78 @@
+#if ComponentModel
+
+    import ComponentModel
+    import WasmParser
+    import WasmTypes
+
+    extension ComponentWatParser {
+        /// A definition in normalized order, ready for binary encoding.
+        /// Each case maps to a component binary section.
+        enum NormalizedDefinition {
+            case coreModule(CoreModuleIndex)
+            case coreInstance(CoreInstanceIndex)
+            case coreType(TypeIndex)
+            case component(ComponentIndex)
+            case instance(ComponentInstanceIndex)
+            case componentType(ComponentTypeIndex)
+            case canon(CanonDef)
+            case componentExport(ExportDef)
+            case componentImport(ImportDef)
+            case alias(ComponentAlias)
+
+            /// The section ID this definition belongs to.
+            var sectionKind: ComponentSectionID {
+                switch self {
+                case .coreModule: return .coreModule
+                case .coreInstance: return .coreInstance
+                case .coreType: return .coreType
+                case .componentType: return .type
+                case .component: return .component
+                case .instance: return .instance
+                case .alias: return .alias
+                case .canon: return .canon
+                case .componentImport: return .import
+                case .componentExport: return .export
+                }
+            }
+        }
+    }
+
+    extension ComponentWatParser.NormalizedDefinition: CustomStringConvertible {
+        var description: String {
+            switch self {
+            case .coreModule(let idx): return "coreModule(\(idx))"
+            case .coreInstance(let idx): return "coreInstance(\(idx))"
+            case .coreType(let idx): return "coreType(\(idx))"
+            case .component(let idx): return "component(\(idx))"
+            case .instance(let idx): return "instance(\(idx))"
+            case .componentType(let idx): return "componentType(\(idx))"
+            case .canon(let def):
+                switch def.kind {
+                case .lift: return "canon lift"
+                case .lower: return "canon lower"
+                }
+            case .componentExport(let def): return "export \"\(def.exportName)\""
+            case .componentImport(let def): return "import \"\(def.importModuleName)\""
+            case .alias(let alias):
+                let sortStr: String
+                switch alias.sort {
+                case .core(let coreSort): sortStr = "core \(coreSort.rawValue)"
+                case .func: sortStr = "func"
+                case .value: sortStr = "value"
+                case .type: sortStr = "type"
+                case .component: sortStr = "component"
+                case .instance: sortStr = "instance"
+                }
+                let targetStr: String
+                switch alias.target {
+                case .export(let isCore, let instanceIndex, let exportName):
+                    targetStr = "\(isCore ? "core " : "")export \(instanceIndex) \"\(exportName)\""
+                case .outer(let outerCount, let typeIndex):
+                    targetStr = "outer \(outerCount) \(typeIndex)"
+                }
+                return "alias \(sortStr) \(targetStr)"
+            }
+        }
+    }
+
+#endif


### PR DESCRIPTION
`ComponentEncoder` should not have its own sophisticated batching logic. Ideally we shift definitions normalization to `ComponentWatParser`. This ensures that normalization logic as separated from the encoder and keeps it clean and lean. In the long term we should use `enum NormalizedDefinition` for accumulation in `ComponentWatParser`, cases of this enum store indices to a corresponding component definition in `ComponentDef` (now moved to a separate file).