### PR TITLE
Fix `lldb-dap` connection, add `decodingUnknownCommand` test

### DIFF
--- a/Sources/GDBRemoteProtocol/GDBHostCommand.swift
+++ b/Sources/GDBRemoteProtocol/GDBHostCommand.swift
@@ -52,6 +52,7 @@ package struct GDBHostCommand: Equatable {
         case detach
 
         case generalRegisters
+        case unsupported
 
         /// Decodes kind of a command from a raw string sent from a host.
         package init?(rawValue: String) {
@@ -169,7 +170,7 @@ package struct GDBHostCommand: Equatable {
     /// - Parameters:
     ///   - kindString: raw ``String`` that denotes kind of the command.
     ///   - arguments: raw arguments that immediately follow kind of the command.
-    package init(kindString: String, arguments: String) throws(GDBHostCommandDecoder.Error) {
+    package init(kindString: String, arguments: String) {
         for rule in Self.parsingRules {
             if kindString.starts(with: rule.prefix) {
                 self.kind = rule.kind
@@ -186,11 +187,11 @@ package struct GDBHostCommand: Equatable {
 
         if let kind = Kind(rawValue: kindString) {
             self.kind = kind
+            self.arguments = arguments
         } else {
-            throw GDBHostCommandDecoder.Error.unknownCommand(kind: kindString, arguments: arguments)
+            self.kind = .unsupported
+            self.arguments = arguments.isEmpty ? kindString : "\(kindString):\(arguments)"
         }
-
-        self.arguments = arguments
     }
 
     /// Member-wise initializer of `GDBHostCommand` type.

--- a/Sources/GDBRemoteProtocol/GDBHostCommandDecoder.swift
+++ b/Sources/GDBRemoteProtocol/GDBHostCommandDecoder.swift
@@ -51,9 +51,6 @@ package struct GDBHostCommandDecoder: ByteToMessageDecoder {
         /// Unexpected arguments value supplied for a given command.
         case unexpectedArgumentsValue
 
-        /// Host command kind could not be parsed. See `GDBHostCommand.Kind` for the
-        /// list of supported commands.
-        case unknownCommand(kind: String, arguments: String)
     }
 
     /// Type of the output value produced by this decoder.
@@ -180,7 +177,7 @@ package struct GDBHostCommandDecoder: ByteToMessageDecoder {
             )
         }
 
-        let payload = try GDBHostCommand(
+        let payload = GDBHostCommand(
             kindString: String(decoding: self.accummulatedKind, as: UTF8.self),
             arguments: String(decoding: self.accummulatedArguments, as: UTF8.self)
         )

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -44,7 +44,7 @@
             case stoppingAtEntrypointFailed
             case multipleThreadsNotSupported
             case unknownThreadAction(String)
-            case hostCommandNotImplemented(GDBHostCommand.Kind)
+
             case exitCodeUnknown([Value])
             case killRequestReceived
             case unknownHexEncodedArguments(String)
@@ -333,7 +333,14 @@
                 responseKind = .empty
 
             case .generalRegisters:
-                throw Error.hostCommandNotImplemented(command.kind)
+                responseKind = .empty
+
+            case .unsupported:
+                logger.debug(
+                    "unsupported GDB host command",
+                    metadata: ["rawCommand": .string(command.arguments)]
+                )
+                responseKind = .empty
             }
 
             logger.trace("handler produced a response", metadata: ["GDBTargetResponse": .string("\(responseKind)")])

--- a/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
+++ b/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
@@ -17,6 +17,22 @@ import Testing
 
 @Suite
 struct GDBRemoteProtocolTests {
+    var decoder: GDBHostCommandDecoder {
+        var logger = Logger(label: "com.swiftwasm.WasmKit.tests")
+        logger.logLevel = .critical
+        return GDBHostCommandDecoder(logger: logger)
+    }
+
+    @Test
+    func decodingUnknownCommand() throws {
+        var decoder = self.decoder
+        // "p0" is "read single register 0" — not supported by WasmKit
+        var buffer = ByteBuffer(string: "+$p0#a0")
+        let packet = try decoder.decode(buffer: &buffer)
+        #expect(packet?.payload.kind == .unsupported)
+        #expect(packet?.payload.arguments == "p0")
+    }
+
     @Test
     func decoding() throws {
         var logger = Logger(label: "com.swiftwasm.WasmKit.tests")


### PR DESCRIPTION
When `lldb-dap` connects to WasmKit via `process connect -p wasm`, it sends GDB Remote Protocol commands that WasmKit doesn't recognize (e.g., `p` for reading a single register, `H` for setting thread context, `qLaunchSuccess`). The `GDBHostCommandDecoder` throws `unknownCommand`, which propagates through the NIO pipeline and kills the connection. Per the GDB protocol spec, unrecognized commands should receive an empty response (`$#00`) and the connection should continue.