### PR TITLE
Fix fd handling in WASIp1 implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,7 +286,7 @@ jobs:
         include:
           - swift-version: "6.2"
           - swift-version: "nightly-6.3"
-          - swift-version: nightly-main
+          # - swift-version: nightly-main
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,12 +278,8 @@ jobs:
       matrix:
         include:
           - swift-version: "6.2"
-<<<<<<< maxd/wasi-fd-leaks
-          - swift-version: "nightly-6.3"
-=======
           - swift-version: "6.3"
           # Regressed since `swift-DEVELOPMENT-SNAPSHOT-2026-04-01-a`
->>>>>>> main
           # - swift-version: nightly-main
 
     steps:

--- a/Benchmarks/Benchmarks/MacroPlugin/MacroPlugin.swift
+++ b/Benchmarks/Benchmarks/MacroPlugin/MacroPlugin.swift
@@ -165,17 +165,22 @@ let benchmarks: @Sendable () -> () = {
                   stdout: pluginToHostPipes.writeEnd,
                   stderr: .standardError
                 )
-                var imports = Imports()
-                bridge.link(to: &imports, store: store)
-                let instance = try module.instantiate(store: store, imports: imports)
-                try instance.exports[function: "_start"]!()
-                let pump = instance.exports[function: "swift_wasm_macro_v1_pump"]!
+                do {
+                    var imports = Imports()
+                    bridge.link(to: &imports, store: store)
+                    let instance = try module.instantiate(store: store, imports: imports)
+                    try instance.exports[function: "_start"]!()
+                    let pump = instance.exports[function: "swift_wasm_macro_v1_pump"]!
 
-                self.hostToPlugin = hostToPluginPipes.writeEnd
-                self.pluginToHost = pluginToHostPipes.readEnd
-                self.pump = pump
-                self.expandMessage = expandMessage
-                self.bridge = bridge
+                    self.hostToPlugin = hostToPluginPipes.writeEnd
+                    self.pluginToHost = pluginToHostPipes.readEnd
+                    self.pump = pump
+                    self.expandMessage = expandMessage
+                    self.bridge = bridge
+                } catch {
+                    try bridge.close()
+                    throw error
+                }
             }
 
             func writeMessage(_ message: String) throws {

--- a/Benchmarks/Benchmarks/MacroPlugin/MacroPlugin.swift
+++ b/Benchmarks/Benchmarks/MacroPlugin/MacroPlugin.swift
@@ -151,6 +151,7 @@ let benchmarks: @Sendable () -> () = {
             let pluginToHost: FileDescriptor
             let pump: Function
             let expandMessage: String
+            let bridge: WASIBridgeToHost
 
             init(filePath: FilePath, expandMessage: String) throws {
                 let engine = Engine()
@@ -174,6 +175,7 @@ let benchmarks: @Sendable () -> () = {
                 self.pluginToHost = pluginToHostPipes.readEnd
                 self.pump = pump
                 self.expandMessage = expandMessage
+                self.bridge = bridge
             }
 
             func writeMessage(_ message: String) throws {
@@ -204,6 +206,10 @@ let benchmarks: @Sendable () -> () = {
                 try pump()
                 _ = try readMessage()
             }
+
+            func close() throws {
+                try bridge.close()
+            }
         }
 
         guard let expandMessage = expandMessages[file] else {
@@ -214,10 +220,12 @@ let benchmarks: @Sendable () -> () = {
             let setup = try Setup(filePath: macrosDir.appending(file), expandMessage: expandMessage)
             try setup.writeMessage(handshakeMessage)
             try setup.tick()
+            try setup.close()
         }
 
         Benchmark("Expand \(file)") { benchmark, setup in
             try setup.tick()
+            try setup.close()
         } setup: { () -> Setup in
             let setup = try Setup(
                 filePath: macrosDir.appending(file),

--- a/Benchmarks/Benchmarks/WishYouWereFast/WishYouWereFast.swift
+++ b/Benchmarks/Benchmarks/WishYouWereFast/WishYouWereFast.swift
@@ -35,6 +35,7 @@ let benchmarks: @Sendable () -> () = {
             wasi.link(to: &imports, store: store)
             let instance = try module.instantiate(store: store, imports: imports)
             _ = try wasi.start(instance)
+            try wasi.close()
         }
     }
 }

--- a/Benchmarks/Benchmarks/WishYouWereFast/WishYouWereFast.swift
+++ b/Benchmarks/Benchmarks/WishYouWereFast/WishYouWereFast.swift
@@ -31,11 +31,12 @@ let benchmarks: @Sendable () -> () = {
                 filePath: FilePath(wishYouWereFast.appendingPathComponent(file).path)
             )
             let wasi = try WASIBridgeToHost(fileSystem: .host().withStdio(stdout: devNull, stderr: devNull))
-            var imports = Imports()
-            wasi.link(to: &imports, store: store)
-            let instance = try module.instantiate(store: store, imports: imports)
-            _ = try wasi.start(instance)
-            try wasi.close()
+            _ = try wasi.runAndClose { wasi in
+                var imports = Imports()
+                wasi.link(to: &imports, store: store)
+                let instance = try module.instantiate(store: store, imports: imports)
+                return try wasi.start(instance)
+            }
         }
     }
 }

--- a/Examples/Sources/WASI-Hello/Hello.swift
+++ b/Examples/Sources/WASI-Hello/Hello.swift
@@ -22,6 +22,7 @@ struct Example {
 
         // Start the WASI command-line application.
         let exitCode = try wasi.start(instance)
+        try wasi.close()
         // Exit the Swift program with the WASI exit code.
         exit(Int32(exitCode))
     }

--- a/Examples/Sources/WASI-Hello/Hello.swift
+++ b/Examples/Sources/WASI-Hello/Hello.swift
@@ -12,17 +12,17 @@ struct Example {
 
         // Create a WASI instance forwarding to the host environment.
         let wasi = try WASIBridgeToHost()
-        // Create engine and store
-        let engine = Engine()
-        let store = Store(engine: engine)
-        // Instantiate a parsed module importing WASI
-        var imports = Imports()
-        wasi.link(to: &imports, store: store)
-        let instance = try module.instantiate(store: store, imports: imports)
-
-        // Start the WASI command-line application.
-        let exitCode = try wasi.start(instance)
-        try wasi.close()
+        // Start the WASI command-line application and close the bridge.
+        let exitCode = try wasi.runAndClose { wasi in
+            // Create engine and store
+            let engine = Engine()
+            let store = Store(engine: engine)
+            // Instantiate a parsed module importing WASI
+            var imports = Imports()
+            wasi.link(to: &imports, store: store)
+            let instance = try module.instantiate(store: store, imports: imports)
+            return try wasi.start(instance)
+        }
         // Exit the Swift program with the WASI exit code.
         exit(Int32(exitCode))
     }

--- a/Sources/CLICommands/DebuggerServer.swift
+++ b/Sources/CLICommands/DebuggerServer.swift
@@ -113,6 +113,7 @@
                     await shutDownStream.first { _ in true }
                     cancellableGroup.cancelAll()
                 }
+                try await debuggerHandler.close()
             }
         }
     }

--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -303,6 +303,7 @@ package struct Run: AsyncParsableCommand {
         let moduleInstance = try module.instantiate(store: store, imports: imports)
         return {
             let exitCode = try wasi.start(moduleInstance)
+            try wasi.close()
             throw ExitCode(Int32(exitCode))
         }
     }

--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -298,13 +298,14 @@ package struct Run: AsyncParsableCommand {
         let wasi = try WASIBridgeToHost(args: [path] + arguments, environment: environment, preopens: preopens)
         let engine = Engine(configuration: deriveRuntimeConfiguration(), interceptor: interceptor)
         let store = Store(engine: engine)
-        var imports = Imports()
-        wasi.link(to: &imports, store: store)
-        let moduleInstance = try module.instantiate(store: store, imports: imports)
         return {
-            let exitCode = try wasi.start(moduleInstance)
-            try wasi.close()
-            throw ExitCode(Int32(exitCode))
+            try wasi.runAndClose { wasi in
+                var imports = Imports()
+                wasi.link(to: &imports, store: store)
+                let moduleInstance = try module.instantiate(store: store, imports: imports)
+                let exitCode = try wasi.start(moduleInstance)
+                throw ExitCode(Int32(exitCode))
+            }
         }
     }
 

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -128,6 +128,14 @@ struct FdTable {
             return fd
         }
     }
+
+    /// Closes all file descriptors except those in `skipFds`.
+    mutating func closeAll(skipping skipFds: Set<WASIAbi.Fd> = []) {
+        for (fd, entry) in map where !skipFds.contains(fd) {
+            try? entry.asEntry().close()
+        }
+        map = map.filter { skipFds.contains($0.key) }
+    }
 }
 
 /// Content of a file that can be retrieved from the file system.

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -7,6 +7,9 @@ struct FileAccessMode: OptionSet {
 }
 
 protocol WASIEntry {
+    /// Whether this entry wraps a borrowed file descriptor that should not be
+    /// closed when the WASI instance is torn down (e.g. process stdio).
+    var isBorrowed: Bool { get }
     func attributes() throws -> WASIAbi.Filestat
     func fileType() throws -> WASIAbi.FileType
     func status() throws -> WASIAbi.Fdflags
@@ -18,6 +21,10 @@ protocol WASIEntry {
         offset: WASIAbi.FileSize, length: WASIAbi.FileSize, advice: WASIAbi.Advice
     ) throws
     func close() throws
+}
+
+extension WASIEntry {
+    var isBorrowed: Bool { false }
 }
 
 protocol WASIFile: WASIEntry {
@@ -129,12 +136,20 @@ struct FdTable {
         }
     }
 
-    /// Closes all file descriptors except those in `skipFds`.
-    mutating func closeAll(skipping skipFds: Set<WASIAbi.Fd> = []) {
-        for (fd, entry) in map where !skipFds.contains(fd) {
-            try? entry.asEntry().close()
+    /// Closes all owned file descriptors, skipping borrowed ones (e.g. stdio).
+    mutating func closeAll() throws {
+        var firstError: (any Error)?
+        for (_, entry) in map {
+            let wasiEntry = entry.asEntry()
+            guard !wasiEntry.isBorrowed else { continue }
+            do {
+                try wasiEntry.close()
+            } catch {
+                if firstError == nil { firstError = error }
+            }
         }
-        map = map.filter { skipFds.contains($0.key) }
+        map = map.filter { $0.value.asEntry().isBorrowed }
+        if let firstError { throw firstError }
     }
 }
 

--- a/Sources/WASI/Platform/Directory.swift
+++ b/Sources/WASI/Platform/Directory.swift
@@ -90,6 +90,7 @@ extension DirEntry: WASIDir, FdWASIEntry {
             symlinkFollow: symlinkFollow, path: path,
             oflags: [], accessMode: .write, fdflags: []
         )
+        defer { try? fd.close() }
         let (access, modification) = try WASIAbi.Timestamp.platformTimeSpec(
             atim: atim, mtim: mtim, fstFlags: fstFlags
         )
@@ -100,10 +101,10 @@ extension DirEntry: WASIDir, FdWASIEntry {
 
     func removeFile(atPath path: String) throws {
         let result = try SandboxPrimitives.openParent(start: fd, path: path)
-        let dir = result.parentFd
-        let basename = result.basename
-        try WASIAbi.Errno.translatingPlatformErrno {
-            try dir.remove(at: FilePath(basename), options: [])
+        try result.withFields { dir, basename in
+            try WASIAbi.Errno.translatingPlatformErrno {
+                try dir.remove(at: FilePath(basename), options: [])
+            }
         }
     }
 
@@ -113,10 +114,10 @@ extension DirEntry: WASIDir, FdWASIEntry {
         #else
             let path = SandboxPrimitives.stripDirSuffix(path)
             let result = try SandboxPrimitives.openParent(start: fd, path: path)
-            let dir = result.parentFd
-            let basename = result.basename
-            try WASIAbi.Errno.translatingPlatformErrno {
-                try dir.remove(at: FilePath(basename), options: .removeDirectory)
+            try result.withFields { dir, basename in
+                try WASIAbi.Errno.translatingPlatformErrno {
+                    try dir.remove(at: FilePath(basename), options: .removeDirectory)
+                }
             }
         #endif
     }
@@ -125,10 +126,10 @@ extension DirEntry: WASIDir, FdWASIEntry {
         let result = try SandboxPrimitives.openParent(
             start: fd, path: destPath
         )
-        let destDir = result.parentFd
-        let destBasename = result.basename
-        try WASIAbi.Errno.translatingPlatformErrno {
-            try destDir.createSymlink(original: FilePath(sourcePath), link: FilePath(destBasename))
+        try result.withFields { destDir, destBasename in
+            try WASIAbi.Errno.translatingPlatformErrno {
+                try destDir.createSymlink(original: FilePath(sourcePath), link: FilePath(destBasename))
+            }
         }
     }
 
@@ -152,24 +153,23 @@ extension DirEntry: WASIDir, FdWASIEntry {
             let sourceResult = try SandboxPrimitives.openParent(
                 start: fd, path: oldPath
             )
-            let sourceDir = sourceResult.parentFd
-            let sourceBasename = sourceResult.basename
             let destResult = try SandboxPrimitives.openParent(
                 start: newDir.fd, path: newPath
             )
-            let destDir = destResult.parentFd
-            let destBasename = destResult.basename
+            try sourceResult.withFields { sourceDir, sourceBasename in
+                try destResult.withFields { destDir, destBasename in
+                    // Re-append a slash if the original path had one
+                    let finalSourceBasename = oldHasTrailingSlash ? sourceBasename + "/" : sourceBasename
+                    let finalDestBasename = newHasTrailingSlash ? destBasename + "/" : destBasename
 
-            // Re-append a slash if the original path had one
-            let finalSourceBasename = oldHasTrailingSlash ? sourceBasename + "/" : sourceBasename
-            let finalDestBasename = newHasTrailingSlash ? destBasename + "/" : destBasename
-
-            try WASIAbi.Errno.translatingPlatformErrno {
-                try sourceDir.rename(
-                    at: FilePath(finalSourceBasename),
-                    to: destDir,
-                    at: FilePath(finalDestBasename)
-                )
+                    try WASIAbi.Errno.translatingPlatformErrno {
+                        try sourceDir.rename(
+                            at: FilePath(finalSourceBasename),
+                            to: destDir,
+                            at: FilePath(finalDestBasename)
+                        )
+                    }
+                }
             }
         #endif
     }
@@ -216,10 +216,10 @@ extension DirEntry: WASIDir, FdWASIEntry {
 
     func createDirectory(atPath path: String) throws {
         let result = try SandboxPrimitives.openParent(start: fd, path: path)
-        let dir = result.parentFd
-        let basename = result.basename
-        try WASIAbi.Errno.translatingPlatformErrno {
-            try dir.createDirectory(at: FilePath(basename), permissions: .ownerReadWriteExecute)
+        try result.withFields { dir, basename in
+            try WASIAbi.Errno.translatingPlatformErrno {
+                try dir.createDirectory(at: FilePath(basename), permissions: .ownerReadWriteExecute)
+            }
         }
     }
 
@@ -232,15 +232,15 @@ extension DirEntry: WASIDir, FdWASIEntry {
                 options.insert(.noFollow)
             }
             let result = try SandboxPrimitives.openParent(start: fd, path: path)
-            let dir = result.parentFd
-            let basename = result.basename
-            let attributes = try basename.withCString { cBasename in
-                try WASIAbi.Errno.translatingPlatformErrno {
-                    try dir.attributes(at: cBasename, options: options)
+            return try result.withFields { dir, basename in
+                let attributes = try basename.withCString { cBasename in
+                    try WASIAbi.Errno.translatingPlatformErrno {
+                        try dir.attributes(at: cBasename, options: options)
+                    }
                 }
-            }
 
-            return WASIAbi.Filestat(stat: attributes)
+                return WASIAbi.Filestat(stat: attributes)
+            }
         #endif
     }
 }

--- a/Sources/WASI/Platform/File.swift
+++ b/Sources/WASI/Platform/File.swift
@@ -105,6 +105,8 @@ struct StdioFileEntry: FdWASIFile {
     let fd: FileDescriptor
     let accessMode: FileAccessMode
 
+    let isBorrowed: Bool = true
+
     func attributes() throws -> WASIAbi.Filestat {
         return WASIAbi.Filestat(
             dev: 0, ino: 0, filetype: .CHARACTER_DEVICE,

--- a/Sources/WASI/Platform/SandboxPrimitives/Open.swift
+++ b/Sources/WASI/Platform/SandboxPrimitives/Open.swift
@@ -227,6 +227,15 @@ struct PathResolution {
             case .regular: try regular(component: component)
             }
         }
+
+        // If the path resolved without opening any new fd (e.g. "."),
+        // dup to avoid returning an aliased fd to the caller.
+        if baseFd.rawValue == startFd.rawValue {
+            baseFd = try startFd.open(
+                at: ".", mode, options: options, permissions: permissions
+            )
+        }
+
         resultFd = self.baseFd
         return self.baseFd
     }

--- a/Sources/WASI/Platform/SandboxPrimitives/OpenParent.swift
+++ b/Sources/WASI/Platform/SandboxPrimitives/OpenParent.swift
@@ -88,6 +88,10 @@ struct SplitPath: ~Copyable {
     var basename: String
     var isTemporary: Bool
 
+    borrowing func withFields<R>(_ body: (FileDescriptor, String) throws -> R) rethrows -> R {
+        try body(parentFd, basename)
+    }
+
     deinit {
         if isTemporary {
             try? parentFd.close()

--- a/Sources/WASI/Platform/SandboxPrimitives/Readlink.swift
+++ b/Sources/WASI/Platform/SandboxPrimitives/Readlink.swift
@@ -30,29 +30,28 @@ extension SandboxPrimitives {
             let maxBufferCapacity = max(initialBufferCapacity, Int(PATH_MAX))
 
             let result = try openParent(start: start, path: path)
-            let dir = result.parentFd
-            let basename = result.basename
-
-            return try basename.withCString { cBasename in
-                var capacity = min(initialBufferCapacity, maxBufferCapacity)
-                while true {
-                    var buffer = [UInt8](repeating: 0, count: capacity)
-                    let count = try buffer.withUnsafeMutableBytes { rawBuffer -> Int in
-                        guard let baseAddress = rawBuffer.baseAddress else {
-                            throw WASIAbi.Errno.EINVAL
+            return try result.withFields { dir, basename in
+                try basename.withCString { cBasename in
+                    var capacity = min(initialBufferCapacity, maxBufferCapacity)
+                    while true {
+                        var buffer = [UInt8](repeating: 0, count: capacity)
+                        let count = try buffer.withUnsafeMutableBytes { rawBuffer -> Int in
+                            guard let baseAddress = rawBuffer.baseAddress else {
+                                throw WASIAbi.Errno.EINVAL
+                            }
+                            let base = baseAddress.assumingMemoryBound(to: Int8.self)
+                            let written = readlinkat(dir.rawValue, cBasename, base, rawBuffer.count)
+                            guard written >= 0 else {
+                                throw try WASIAbi.Errno(platformErrno: errno)
+                            }
+                            return written
                         }
-                        let base = baseAddress.assumingMemoryBound(to: Int8.self)
-                        let written = readlinkat(dir.rawValue, cBasename, base, rawBuffer.count)
-                        guard written >= 0 else {
-                            throw try WASIAbi.Errno(platformErrno: errno)
-                        }
-                        return written
-                    }
 
-                    if count < capacity || capacity == maxBufferCapacity {
-                        return Array(buffer.prefix(count))
+                        if count < capacity || capacity == maxBufferCapacity {
+                            return Array(buffer.prefix(count))
+                        }
+                        capacity = min(capacity * 2, maxBufferCapacity)
                     }
-                    capacity = min(capacity * 2, maxBufferCapacity)
                 }
             }
         #endif

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1377,8 +1377,21 @@ final class WASIImplementation {
         self.randomGenerator = randomGenerator
     }
 
-    deinit {
-        fdTable.closeAll(skipping: [0, 1, 2])
+    /// Closes all owned file descriptors (skipping borrowed ones like stdio).
+    func close() throws {
+        try fdTable.closeAll()
+    }
+
+    /// Look up a directory entry by WASI fd, throwing EBADF if the fd doesn't
+    /// exist or ENOTDIR if it exists but isn't a directory.
+    private func directoryEntry(fd: WASIAbi.Fd) throws -> any WASIDir {
+        guard let entry = fdTable[fd] else {
+            throw WASIAbi.Errno.EBADF
+        }
+        guard case .directory(let dirEntry) = entry else {
+            throw WASIAbi.Errno.ENOTDIR
+        }
+        return dirEntry
     }
 
     /// Reads command-line argument data.
@@ -1735,9 +1748,7 @@ final class WASIImplementation {
 
     /// Create a directory.
     func path_create_directory(dirFd: WASIAbi.Fd, path: String) throws {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
         try dirEntry.createDirectory(atPath: path)
     }
 
@@ -1745,9 +1756,7 @@ final class WASIImplementation {
     func path_filestat_get(
         dirFd: WASIAbi.Fd, flags: WASIAbi.LookupFlags, path: String
     ) throws -> WASIAbi.Filestat {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
         return try dirEntry.attributes(
             path: path, symlinkFollow: flags.contains(.SYMLINK_FOLLOW)
         )
@@ -1759,9 +1768,7 @@ final class WASIImplementation {
         path: String, atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags
     ) throws {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
         try dirEntry.setFilestatTimes(
             path: path, atim: atim, mtim: mtim,
             fstFlags: fstFlags,
@@ -1787,9 +1794,7 @@ final class WASIImplementation {
         fsRightsInheriting: WASIAbi.Rights,
         fdflags: WASIAbi.Fdflags
     ) throws -> WASIAbi.Fd {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
 
         let newEntry = try fileSystem.openAt(
             dirFd: dirEntry,
@@ -1807,9 +1812,7 @@ final class WASIImplementation {
 
     /// Read the contents of a symbolic link.
     func path_readlink(fd: WASIAbi.Fd, path: String, buffer: UnsafeGuestBufferPointer<UInt8>) throws -> WASIAbi.Size {
-        guard case .directory(let dirEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: fd)
 
         let linkBytes = try dirEntry.readlink(atPath: path)
         let bytesWritten = min(Int(buffer.count), linkBytes.count)
@@ -1826,9 +1829,7 @@ final class WASIImplementation {
 
     /// Remove a directory.
     func path_remove_directory(dirFd: WASIAbi.Fd, path: String) throws {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
         try dirEntry.removeDirectory(atPath: path)
     }
 
@@ -1837,28 +1838,20 @@ final class WASIImplementation {
         oldFd: WASIAbi.Fd, oldPath: String,
         newFd: WASIAbi.Fd, newPath: String
     ) throws {
-        guard case .directory(let oldDirEntry) = fdTable[oldFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
-        guard case .directory(let newDirEntry) = fdTable[newFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let oldDirEntry = try directoryEntry(fd: oldFd)
+        let newDirEntry = try directoryEntry(fd: newFd)
         try oldDirEntry.rename(from: oldPath, toDir: newDirEntry, to: newPath)
     }
 
     /// Create a symbolic link.
     func path_symlink(oldPath: String, dirFd: WASIAbi.Fd, newPath: String) throws {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
         try dirEntry.symlink(from: oldPath, to: newPath)
     }
 
     /// Unlink a file.
     func path_unlink_file(dirFd: WASIAbi.Fd, path: String) throws {
-        guard case .directory(let dirEntry) = fdTable[dirFd] else {
-            throw WASIAbi.Errno.ENOTDIR
-        }
+        let dirEntry = try directoryEntry(fd: dirFd)
         try dirEntry.removeFile(atPath: path)
     }
 

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1377,6 +1377,10 @@ final class WASIImplementation {
         self.randomGenerator = randomGenerator
     }
 
+    deinit {
+        fdTable.closeAll(skipping: [0, 1, 2])
+    }
+
     /// Reads command-line argument data.
     /// - Parameters:
     ///   - argv: Pointer to an array of argument strings to be written

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -14,8 +14,9 @@ import SystemPackage
 ///     environment: ["PATH": "/usr/bin"],
 ///     preopens: [WASIBridgeToHost.Preopen(guestPath: "/sandbox", hostPath: "/real/path")]
 /// )
-/// // ... use bridge ...
-/// try bridge.close()
+/// try bridge.runAndClose { wasi in
+///     // ... use wasi ...
+/// }
 /// ```
 public final class WASIBridgeToHost {
     internal let underlying: WASIImplementation
@@ -111,6 +112,22 @@ public final class WASIBridgeToHost {
     public func close() throws {
         try underlying.close()
         isClosed = true
+    }
+
+    /// Passes the bridge to `body`, then closes all owned file descriptors
+    /// regardless of whether `body` returns normally or throws.
+    ///
+    /// - Parameter body: A closure that receives the bridge and returns a value.
+    /// - Returns: The value returned by `body`.
+    public func runAndClose<R>(_ body: (WASIBridgeToHost) throws -> R) throws -> R {
+        do {
+            let result = try body(self)
+            try close()
+            return result
+        } catch {
+            try close()
+            throw error
+        }
     }
 
     deinit {

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -169,7 +169,6 @@ public final class WASIBridgeToHost {
     ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
     ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
     /// - Throws: An error if the file system or preopens cannot be initialized.
-    @available(*, deprecated, message: "Use withBridge(args:environment:fileSystem:body:) instead to ensure file descriptors are properly closed.")
     public convenience init(
         args: [String] = [],
         environment: [String: String] = [:],
@@ -223,7 +222,6 @@ public final class WASIBridgeToHost {
     ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
     ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
     /// - Throws: An error if the file system or initialization fails.
-    @available(*, deprecated, message: "Use withBridge(args:environment:fileSystem:body:) instead to ensure file descriptors are properly closed.")
     public convenience init(
         args: [String] = [],
         environment: [String: String] = [:],

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -102,6 +102,13 @@ public final class WASIBridgeToHost {
     /// which can be used to register with a WebAssembly runtime.
     public var wasiHostModules: [String: WASIHostModule] { underlying._hostModules }
 
+    /// Closes all owned file descriptors (preopened directories and any
+    /// guest-opened files that were not closed by the WASI program).
+    /// Borrowed descriptors (e.g. process stdio) are left open.
+    public func close() throws {
+        try underlying.close()
+    }
+
     /// Creates a new WASI bridge with host file system access.
     ///
     /// This is a convenience initializer that automatically configures the bridge
@@ -162,6 +169,7 @@ public final class WASIBridgeToHost {
     ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
     ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
     /// - Throws: An error if the file system or preopens cannot be initialized.
+    @available(*, deprecated, message: "Use withBridge(args:environment:fileSystem:body:) instead to ensure file descriptors are properly closed.")
     public convenience init(
         args: [String] = [],
         environment: [String: String] = [:],
@@ -185,24 +193,13 @@ public final class WASIBridgeToHost {
 
     /// Creates a new WASI bridge with custom file system options.
     ///
-    /// This is the designated initializer that allows full control over the file system
-    /// backend (host or in-memory) and all other WASI subsystems.
-    ///
-    /// - Parameters:
-    ///   - args: Command-line arguments to pass to the WASI module. Defaults to an empty array.
-    ///   - environment: Environment variables to expose to the WASI module. Defaults to an empty dictionary.
-    ///   - fileSystem: Configuration for the file system implementation. Defaults to `.host()`.
-    ///   - wallClock: Clock for wall-clock time queries. Defaults to `SystemWallClock()`.
-    ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
-    ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
-    /// - Throws: An error if the file system or initialization fails.
-    public init(
-        args: [String] = [],
-        environment: [String: String] = [:],
-        fileSystem fileSystemOptions: FileSystemOptions = .host().withStdio(),
-        wallClock: WallClock = SystemWallClock(),
-        monotonicClock: MonotonicClock = SystemMonotonicClock(),
-        randomGenerator: RandomBufferGenerator = SystemRandomNumberGenerator()
+    private init(
+        args: [String],
+        environment: [String: String],
+        fileSystemOptions: FileSystemOptions,
+        wallClock: WallClock,
+        monotonicClock: MonotonicClock,
+        randomGenerator: RandomBufferGenerator
     ) throws {
         let fileSystem = try fileSystemOptions.factory()
         self.underlying = try WASIImplementation(
@@ -215,5 +212,67 @@ public final class WASIBridgeToHost {
         )
         try fileSystemOptions.initializeStdio?(&underlying.fdTable)
         try fileSystemOptions.initializePreopens?(fileSystem, &underlying.fdTable)
+    }
+
+    /// Creates a new WASI bridge with custom file system options.
+    /// - Parameters:
+    ///   - args: Command-line arguments to pass to the WASI module. Defaults to an empty array.
+    ///   - environment: Environment variables to expose to the WASI module. Defaults to an empty dictionary.
+    ///   - fileSystem: Configuration for the file system implementation. Defaults to `.host()`.
+    ///   - wallClock: Clock for wall-clock time queries. Defaults to `SystemWallClock()`.
+    ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
+    ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
+    /// - Throws: An error if the file system or initialization fails.
+    @available(*, deprecated, message: "Use withBridge(args:environment:fileSystem:body:) instead to ensure file descriptors are properly closed.")
+    public convenience init(
+        args: [String] = [],
+        environment: [String: String] = [:],
+        fileSystem fileSystemOptions: FileSystemOptions = .host().withStdio(),
+        wallClock: WallClock = SystemWallClock(),
+        monotonicClock: MonotonicClock = SystemMonotonicClock(),
+        randomGenerator: RandomBufferGenerator = SystemRandomNumberGenerator()
+    ) throws {
+        try self.init(
+            args: args, environment: environment, fileSystemOptions: fileSystemOptions,
+            wallClock: wallClock, monotonicClock: monotonicClock,
+            randomGenerator: randomGenerator
+        )
+    }
+
+    /// Creates a WASI bridge, passes it to `body`, and closes all owned file
+    /// descriptors when `body` returns (or throws). This ensures preopened
+    /// directory fds are always cleaned up.
+    ///
+    /// - Parameters:
+    ///   - args: Command-line arguments to pass to the WASI module.
+    ///   - environment: Environment variables to expose to the WASI module.
+    ///   - fileSystem: Configuration for the file system implementation.
+    ///   - wallClock: Clock for wall-clock time queries.
+    ///   - monotonicClock: Clock for monotonic time queries.
+    ///   - randomGenerator: Random number generator.
+    ///   - body: A closure that receives the bridge and returns a value.
+    /// - Returns: The value returned by `body`.
+    public static func withBridge<R>(
+        args: [String] = [],
+        environment: [String: String] = [:],
+        fileSystem: FileSystemOptions = .host().withStdio(),
+        wallClock: WallClock = SystemWallClock(),
+        monotonicClock: MonotonicClock = SystemMonotonicClock(),
+        randomGenerator: RandomBufferGenerator = SystemRandomNumberGenerator(),
+        body: (WASIBridgeToHost) throws -> R
+    ) throws -> R {
+        let bridge = try WASIBridgeToHost(
+            args: args, environment: environment, fileSystemOptions: fileSystem,
+            wallClock: wallClock, monotonicClock: monotonicClock,
+            randomGenerator: randomGenerator
+        )
+        do {
+            let result = try body(bridge)
+            try bridge.close()
+            return result
+        } catch {
+            try? bridge.close()
+            throw error
+        }
     }
 }

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -14,9 +14,12 @@ import SystemPackage
 ///     environment: ["PATH": "/usr/bin"],
 ///     preopens: [WASIBridgeToHost.Preopen(guestPath: "/sandbox", hostPath: "/real/path")]
 /// )
+/// // ... use bridge ...
+/// try bridge.close()
 /// ```
 public final class WASIBridgeToHost {
     internal let underlying: WASIImplementation
+    private var isClosed = false
 
     /// A preopened directory mapping from a guest path to a host path.
     ///
@@ -107,6 +110,11 @@ public final class WASIBridgeToHost {
     /// Borrowed descriptors (e.g. process stdio) are left open.
     public func close() throws {
         try underlying.close()
+        isClosed = true
+    }
+
+    deinit {
+        precondition(isClosed, "WASIBridgeToHost.close() must be called before the bridge is deallocated")
     }
 
     /// Creates a new WASI bridge with host file system access.
@@ -235,42 +243,5 @@ public final class WASIBridgeToHost {
             wallClock: wallClock, monotonicClock: monotonicClock,
             randomGenerator: randomGenerator
         )
-    }
-
-    /// Creates a WASI bridge, passes it to `body`, and closes all owned file
-    /// descriptors when `body` returns (or throws). This ensures preopened
-    /// directory fds are always cleaned up.
-    ///
-    /// - Parameters:
-    ///   - args: Command-line arguments to pass to the WASI module.
-    ///   - environment: Environment variables to expose to the WASI module.
-    ///   - fileSystem: Configuration for the file system implementation.
-    ///   - wallClock: Clock for wall-clock time queries.
-    ///   - monotonicClock: Clock for monotonic time queries.
-    ///   - randomGenerator: Random number generator.
-    ///   - body: A closure that receives the bridge and returns a value.
-    /// - Returns: The value returned by `body`.
-    public static func withBridge<R>(
-        args: [String] = [],
-        environment: [String: String] = [:],
-        fileSystem: FileSystemOptions = .host().withStdio(),
-        wallClock: WallClock = SystemWallClock(),
-        monotonicClock: MonotonicClock = SystemMonotonicClock(),
-        randomGenerator: RandomBufferGenerator = SystemRandomNumberGenerator(),
-        body: (WASIBridgeToHost) throws -> R
-    ) throws -> R {
-        let bridge = try WASIBridgeToHost(
-            args: args, environment: environment, fileSystemOptions: fileSystem,
-            wallClock: wallClock, monotonicClock: monotonicClock,
-            randomGenerator: randomGenerator
-        )
-        do {
-            let result = try body(bridge)
-            try bridge.close()
-            return result
-        } catch {
-            try? bridge.close()
-            throw error
-        }
     }
 }

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -110,8 +110,9 @@ public final class WASIBridgeToHost {
     /// guest-opened files that were not closed by the WASI program).
     /// Borrowed descriptors (e.g. process stdio) are left open.
     public func close() throws {
-        try underlying.close()
+        guard !isClosed else { return }
         isClosed = true
+        try underlying.close()
     }
 
     /// Passes the bridge to `body`, then closes all owned file descriptors

--- a/Sources/WasmKit/Docs.docc/Docs.md
+++ b/Sources/WasmKit/Docs.docc/Docs.md
@@ -79,6 +79,7 @@ let instance = try module.instantiate(store: store, imports: imports)
 
 // Start the WASI command-line application.
 let exitCode = try wasi.start(instance)
+try wasi.close()
 // Exit the Swift program with the WASI exit code.
 exit(Int32(exitCode))
 ```

--- a/Sources/WasmKit/Docs.docc/Docs.md
+++ b/Sources/WasmKit/Docs.docc/Docs.md
@@ -69,17 +69,17 @@ let module = try parseWasm(filePath: "wasm/hello.wasm")
 
 // Create a WASI instance forwarding to the host environment.
 let wasi = try WASIBridgeToHost()
-// Create engine and store
-let engine = Engine()
-let store = Store(engine: engine)
-// Instantiate a parsed module importing WASI
-var imports = Imports()
-wasi.link(to: &imports, store: store)
-let instance = try module.instantiate(store: store, imports: imports)
-
-// Start the WASI command-line application.
-let exitCode = try wasi.start(instance)
-try wasi.close()
+// Start the WASI command-line application and close the bridge.
+let exitCode = try wasi.runAndClose { wasi in
+    // Create engine and store
+    let engine = Engine()
+    let store = Store(engine: engine)
+    // Instantiate a parsed module importing WASI
+    var imports = Imports()
+    wasi.link(to: &imports, store: store)
+    let instance = try module.instantiate(store: store, imports: imports)
+    return try wasi.start(instance)
+}
 // Exit the Swift program with the WASI exit code.
 exit(Int32(exitCode))
 ```

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -80,11 +80,16 @@
             wasi.link(to: &imports, store: store)
             self.wasi = wasi
 
-            self.debugger = try Debugger(module: parseWasm(bytes: .init(buffer: wasmBinary)), store: store, imports: imports)
-            try self.debugger.stopAtEntrypoint()
-            try self.debugger.run()
-            guard case .stoppedAtBreakpoint = self.debugger.state else {
-                throw Error.stoppingAtEntrypointFailed
+            do {
+                self.debugger = try Debugger(module: parseWasm(bytes: .init(buffer: wasmBinary)), store: store, imports: imports)
+                try self.debugger.stopAtEntrypoint()
+                try self.debugger.run()
+                guard case .stoppedAtBreakpoint = self.debugger.state else {
+                    throw Error.stoppingAtEntrypointFailed
+                }
+            } catch {
+                try wasi.close()
+                throw error
             }
 
             self.memoryView = DebuggerMemoryView(allocator: allocator, wasmBinary: wasmBinary)

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -57,6 +57,7 @@
         private var debugger: Debugger
 
         private var memoryView: DebuggerMemoryView
+        private let wasi: WASIBridgeToHost
 
         package init(
             moduleFilePath: FilePath,
@@ -77,6 +78,7 @@
             var imports = Imports()
             let wasi = try WASIBridgeToHost()
             wasi.link(to: &imports, store: store)
+            self.wasi = wasi
 
             self.debugger = try Debugger(module: parseWasm(bytes: .init(buffer: wasmBinary)), store: store, imports: imports)
             try self.debugger.stopAtEntrypoint()
@@ -86,6 +88,10 @@
             }
 
             self.memoryView = DebuggerMemoryView(allocator: allocator, wasmBinary: wasmBinary)
+        }
+
+        package func close() throws {
+            try wasi.close()
         }
 
         private func hexDump<I: FixedWidthInteger>(_ value: I, endianness: Endianness) -> String {

--- a/Sources/WasmTools/WasmTools.swift
+++ b/Sources/WasmTools/WasmTools.swift
@@ -140,15 +140,16 @@ package func runWasmTools(
         fileSystem: fileSystemOptions
     )
 
-    let engine = Engine()
-    let store = Store(engine: engine)
-    var imports = Imports()
-    wasi.link(to: &imports, store: store)
+    let exitCode = try wasi.runAndClose { wasi in
+        let engine = Engine()
+        let store = Store(engine: engine)
+        var imports = Imports()
+        wasi.link(to: &imports, store: store)
 
-    let module = try parseWasm(filePath: FilePath(wasmToolsPath))
-    let instance = try module.instantiate(store: store, imports: imports)
-    let exitCode = try wasi.start(instance)
-    try wasi.close()
+        let module = try parseWasm(filePath: FilePath(wasmToolsPath))
+        let instance = try module.instantiate(store: store, imports: imports)
+        return try wasi.start(instance)
+    }
 
     try stdoutPipes.writeEnd.close()
     try stderrPipes.writeEnd.close()

--- a/Sources/WasmTools/WasmTools.swift
+++ b/Sources/WasmTools/WasmTools.swift
@@ -148,6 +148,7 @@ package func runWasmTools(
     let module = try parseWasm(filePath: FilePath(wasmToolsPath))
     let instance = try module.instantiate(store: store, imports: imports)
     let exitCode = try wasi.start(instance)
+    try wasi.close()
 
     try stdoutPipes.writeEnd.close()
     try stderrPipes.writeEnd.close()

--- a/Tests/WASITests/IntegrationTests.swift
+++ b/Tests/WASITests/IntegrationTests.swift
@@ -189,18 +189,19 @@ struct IntegrationTests {
             )
         }
 
-        let wasi = try WASIBridgeToHost(
+        try WASIBridgeToHost.withBridge(
             args: [path.path] + (manifest.args ?? []),
             environment: manifest.env ?? [:],
-            preopens: preopens
-        )
-        let engine = Engine()
-        let store = Store(engine: engine)
-        var imports = Imports()
-        wasi.link(to: &imports, store: store)
-        let module = try parseWasm(filePath: FilePath(path.path))
-        let instance = try module.instantiate(store: store, imports: imports)
-        let exitCode = try wasi.start(instance)
-        #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")
+            fileSystem: .host().withStdio().withPreopens(preopens)
+        ) { wasi in
+            let engine = Engine()
+            let store = Store(engine: engine)
+            var imports = Imports()
+            wasi.link(to: &imports, store: store)
+            let module = try parseWasm(filePath: FilePath(path.path))
+            let instance = try module.instantiate(store: store, imports: imports)
+            let exitCode = try wasi.start(instance)
+            #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")
+        }
     }
 }

--- a/Tests/WASITests/IntegrationTests.swift
+++ b/Tests/WASITests/IntegrationTests.swift
@@ -189,19 +189,19 @@ struct IntegrationTests {
             )
         }
 
-        try WASIBridgeToHost.withBridge(
+        let wasi = try WASIBridgeToHost(
             args: [path.path] + (manifest.args ?? []),
             environment: manifest.env ?? [:],
             fileSystem: .host().withStdio().withPreopens(preopens)
-        ) { wasi in
-            let engine = Engine()
-            let store = Store(engine: engine)
-            var imports = Imports()
-            wasi.link(to: &imports, store: store)
-            let module = try parseWasm(filePath: FilePath(path.path))
-            let instance = try module.instantiate(store: store, imports: imports)
-            let exitCode = try wasi.start(instance)
-            #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")
-        }
+        )
+        let engine = Engine()
+        let store = Store(engine: engine)
+        var imports = Imports()
+        wasi.link(to: &imports, store: store)
+        let module = try parseWasm(filePath: FilePath(path.path))
+        let instance = try module.instantiate(store: store, imports: imports)
+        let exitCode = try wasi.start(instance)
+        #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")
+        try wasi.close()
     }
 }

--- a/Tests/WASITests/IntegrationTests.swift
+++ b/Tests/WASITests/IntegrationTests.swift
@@ -194,14 +194,15 @@ struct IntegrationTests {
             environment: manifest.env ?? [:],
             fileSystem: .host().withStdio().withPreopens(preopens)
         )
-        let engine = Engine()
-        let store = Store(engine: engine)
-        var imports = Imports()
-        wasi.link(to: &imports, store: store)
-        let module = try parseWasm(filePath: FilePath(path.path))
-        let instance = try module.instantiate(store: store, imports: imports)
-        let exitCode = try wasi.start(instance)
-        #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")
-        try wasi.close()
+        try wasi.runAndClose { wasi in
+            let engine = Engine()
+            let store = Store(engine: engine)
+            var imports = Imports()
+            wasi.link(to: &imports, store: store)
+            let module = try parseWasm(filePath: FilePath(path.path))
+            let instance = try module.instantiate(store: store, imports: imports)
+            let exitCode = try wasi.start(instance)
+            #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")
+        }
     }
 }

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#elseif canImport(Musl)
+    import Musl
+#endif
+
 @testable import WASI
 @testable import WasmKit
 
@@ -7,6 +15,18 @@ import Foundation
     import SystemPackage
 #endif
 enum TestSupport {
+    #if !os(Windows) && !os(WASI)
+        static func countOpenFileDescriptors() -> Int {
+            var count = 0
+            for fd in Int32(0)..<min(getdtablesize(), 4096) {
+                if fcntl(fd, F_GETFD) != -1 {
+                    count += 1
+                }
+            }
+            return count
+        }
+    #endif
+
     struct Error: Swift.Error, CustomStringConvertible {
         let description: String
 

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -15,17 +15,6 @@ import Foundation
     import SystemPackage
 #endif
 enum TestSupport {
-    #if os(macOS) || os(Linux)
-        static func countOpenFileDescriptors() -> Int {
-            var count = 0
-            for fd in Int32(0)..<min(getdtablesize(), 4096) {
-                if fcntl(fd, F_GETFD) != -1 {
-                    count += 1
-                }
-            }
-            return count
-        }
-    #endif
 
     struct Error: Swift.Error, CustomStringConvertible {
         let description: String

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+@testable import WASI
+@testable import WasmKit
+
 #if canImport(Darwin)
     import Darwin
 #elseif canImport(Glibc)
@@ -7,9 +10,6 @@ import Foundation
 #elseif canImport(Musl)
     import Musl
 #endif
-
-@testable import WASI
-@testable import WasmKit
 
 #if canImport(System)
     import SystemPackage

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -15,7 +15,7 @@ import Foundation
     import SystemPackage
 #endif
 enum TestSupport {
-    #if !os(Windows) && !os(WASI)
+    #if os(macOS) || os(Linux)
         static func countOpenFileDescriptors() -> Int {
             var count = 0
             for fd in Int32(0)..<min(getdtablesize(), 4096) {

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -32,6 +32,7 @@ struct WASITests {
                     .init(guestPath: "/Sandbox", hostPath: t.url.appendingPathComponent("Sandbox").path)
                 ])
             )
+            try wasi.runAndClose { wasi in
             let mntFd: WASIAbi.Fd = 3
 
             func assertResolve(_ path: String, followSymlink: Bool, directory: Bool = false) throws {
@@ -136,7 +137,7 @@ struct WASITests {
             try assertNotResolve("link-loop.txt", followSymlink: true) { error in
                 #expect(error == .ELOOP)
             }
-            try wasi.close()
+            }
         }
     #endif
 
@@ -186,6 +187,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let rootFd: WASIAbi.Fd = 3
@@ -205,7 +207,7 @@ struct WASITests {
         #expect(stat.size == 12)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -219,6 +221,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -239,7 +242,7 @@ struct WASITests {
         #expect(tell == 7)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -252,6 +255,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -279,7 +283,7 @@ struct WASITests {
         try wasi.path_unlink_file(dirFd: rootFd, path: "newdir/file1.txt")
         #expect(fs.lookup(at: "/newdir/file1.txt") == nil)
         #expect(fs.lookup(at: "/newdir/file2.txt") != nil)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -292,6 +296,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -324,7 +329,7 @@ struct WASITests {
         #expect(stat.size == 0)
 
         try wasi.fd_close(fd: fd2)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -338,6 +343,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -355,7 +361,7 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EEXIST)
         }
-        try bridge.close()
+        }
     }
 
     @Test
@@ -400,9 +406,10 @@ struct WASITests {
             let elapsed = try ContinuousClock().measure {
                 let clockPointer = UnsafeGuestBufferPointer<WASIAbi.Subscription>(baseAddress: .init(offset: clockOffset), count: 1)
                 let bridge = try WASIBridgeToHost()
-                let result = try bridge.underlying.poll_oneoff(subscriptions: clockPointer, events: .init(baseAddress: .init(offset: finalOffset), count: 1), memory: memory)
-                #expect(result == 1)
-                try bridge.close()
+                try bridge.runAndClose { _ in
+                    let result = try bridge.underlying.poll_oneoff(subscriptions: clockPointer, events: .init(baseAddress: .init(offset: finalOffset), count: 1), memory: memory)
+                    #expect(result == 1)
+                }
             }
             #expect(elapsed > Duration.nanoseconds(timeout))
         #endif
@@ -420,9 +427,10 @@ struct WASITests {
             try fs.ensureDirectory(at: preopen.hostPath)
         }
         let wasi = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens))
-        #expect(fs.lookup(at: "/tmp") != nil)
-        #expect(fs.lookup(at: "/data") != nil)
-        try wasi.close()
+        try wasi.runAndClose { _ in
+            #expect(fs.lookup(at: "/tmp") != nil)
+            #expect(fs.lookup(at: "/data") != nil)
+        }
     }
 
     @Test
@@ -435,6 +443,7 @@ struct WASITests {
             WASIBridgeToHost.Preopen(guestPath: "/", hostPath: "/"),
         ]
         let bridge = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens))
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         guard case .directory(let fd3Dir) = wasi.fdTable[3] else {
@@ -448,7 +457,7 @@ struct WASITests {
 
         #expect(fd3Dir.preopenPath == ".")
         #expect(fd4Dir.preopenPath == "/")
-        try bridge.close()
+        }
     }
 
     @Test
@@ -461,6 +470,7 @@ struct WASITests {
                 .init(guestPath: "/sandbox", hostPath: "/sandbox")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let prestat = try wasi.fd_prestat_get(fd: 3)
@@ -469,7 +479,7 @@ struct WASITests {
             return
         }
         #expect(pathLen == 8)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -531,6 +541,7 @@ struct WASITests {
                     .init(guestPath: "/", hostPath: "/")
                 ])
             )
+            try bridge.runAndClose { _ in
             let wasi = bridge.underlying
             let rootFd: WASIAbi.Fd = 3
 
@@ -549,7 +560,7 @@ struct WASITests {
             #expect(stat.size == 23)
 
             try wasi.fd_close(fd: openedFd)
-            try bridge.close()
+            }
         #endif
     }
 
@@ -565,6 +576,7 @@ struct WASITests {
                     .init(guestPath: "/sandbox", hostPath: tempDir.url.path)
                 ])
             )
+            try bridge.runAndClose { _ in
             let wasi = bridge.underlying
 
             let sandboxFd: WASIAbi.Fd = 3
@@ -583,7 +595,7 @@ struct WASITests {
             #expect(stat.size == 12)
 
             try wasi.fd_close(fd: fd)
-            try bridge.close()
+            }
         #endif
     }
 
@@ -599,6 +611,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let rootFd: WASIAbi.Fd = 3
@@ -617,7 +630,7 @@ struct WASITests {
         #expect(stat.size == 14)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -631,6 +644,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -657,7 +671,7 @@ struct WASITests {
         #expect(midPos == 5)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -671,6 +685,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -705,7 +720,7 @@ struct WASITests {
         #expect(writeStat.fsRightsBase.contains(.FD_WRITE))
 
         try wasi.fd_close(fd: writeOnlyFd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -773,6 +788,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -799,7 +815,7 @@ struct WASITests {
         #expect(bytes == Array("Long".utf8))
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -813,6 +829,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -843,7 +860,7 @@ struct WASITests {
         #expect(bytes[9] == 0)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -857,6 +874,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -876,7 +894,7 @@ struct WASITests {
             return
         }
         #expect(bytes == Array("Content".utf8))
-        try bridge.close()
+        }
     }
 
     @Test
@@ -891,6 +909,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -903,7 +922,7 @@ struct WASITests {
 
         #expect(fs.lookup(at: "/file.txt") == nil)
         #expect(fs.lookup(at: "/subdir/moved.txt") != nil)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -917,12 +936,13 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         try wasi.path_remove_directory(dirFd: rootFd, path: "emptydir")
         #expect(fs.lookup(at: "/emptydir") == nil)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -937,6 +957,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -948,7 +969,7 @@ struct WASITests {
         }
 
         #expect(fs.lookup(at: "/nonempty") != nil)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -962,6 +983,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -979,7 +1001,7 @@ struct WASITests {
         try wasi.fd_datasync(fd: fd)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -993,6 +1015,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1023,7 +1046,7 @@ struct WASITests {
         #expect(readData[0] == writeData)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1037,6 +1060,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1062,7 +1086,7 @@ struct WASITests {
         }
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1076,6 +1100,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1105,7 +1130,7 @@ struct WASITests {
         }
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1128,6 +1153,7 @@ struct WASITests {
                     .init(guestPath: "/", hostPath: "/")
                 ])
             )
+            try bridge.runAndClose { _ in
             let wasi = bridge.underlying
             let rootFd: WASIAbi.Fd = 3
 
@@ -1152,7 +1178,7 @@ struct WASITests {
 
             let content = try String(contentsOf: tempDir.url.appendingPathComponent("target.txt"), encoding: .utf8)
             #expect(content == "Via handle")
-            try bridge.close()
+            }
         #endif
     }
 
@@ -1167,6 +1193,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1194,7 +1221,7 @@ struct WASITests {
         #expect(stat.size == 103)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1206,6 +1233,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let stdinStat = try wasi.fd_fdstat_get(fileDescriptor: 0)
@@ -1219,7 +1247,7 @@ struct WASITests {
         let stderrStat = try wasi.fd_fdstat_get(fileDescriptor: 2)
         #expect(!stderrStat.fsRightsBase.contains(.FD_READ))
         #expect(stderrStat.fsRightsBase.contains(.FD_WRITE))
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1231,6 +1259,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
@@ -1239,7 +1268,7 @@ struct WASITests {
 
         let nwritten = try wasi.fd_write(fileDescriptor: 1, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1251,6 +1280,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
@@ -1259,7 +1289,7 @@ struct WASITests {
 
         let nwritten = try wasi.fd_write(fileDescriptor: 2, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1271,6 +1301,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
@@ -1283,7 +1314,7 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
         }
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1295,6 +1326,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
@@ -1306,7 +1338,7 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
         }
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1318,6 +1350,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
@@ -1329,7 +1362,7 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
         }
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1343,6 +1376,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1376,7 +1410,7 @@ struct WASITests {
         #expect(stat3.mtim >= stat2.mtim)
 
         try wasi.fd_close(fd: fd)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1389,6 +1423,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1402,7 +1437,7 @@ struct WASITests {
 
         let stat2 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "testdir")
         #expect(stat2.mtim >= stat1.mtim)
-        try bridge.close()
+        }
     }
 
     @Test
@@ -1416,6 +1451,7 @@ struct WASITests {
                 .init(guestPath: "/", hostPath: "/")
             ])
         )
+        try bridge.runAndClose { _ in
         let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
@@ -1433,7 +1469,7 @@ struct WASITests {
         let stat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
         #expect(stat.atim == specificTime)
         #expect(stat.mtim == specificTime)
-        try bridge.close()
+        }
     }
 
     #if !os(Windows)
@@ -1451,6 +1487,7 @@ struct WASITests {
                     .init(guestPath: "/foo", hostPath: t.url.appendingPathComponent("foo").path)
                 ])
             )
+            try bridge.runAndClose { _ in
             let wasi = bridge.underlying
             let preopenFd: WASIAbi.Fd = 3
 
@@ -1463,7 +1500,7 @@ struct WASITests {
             // Without the noFollow fix, this throws ELOOP due to the cyclic symlink
             let nwritten = try wasi.fd_readdir(fd: preopenFd, buffer: buffer, cookie: 0, memory: memory)
             #expect(nwritten > 0)
-            try bridge.close()
+            }
         }
     #endif
 
@@ -1478,6 +1515,7 @@ struct WASITests {
                     .init(guestPath: "/dir", hostPath: t.url.path)
                 ])
             )
+            try bridge.runAndClose { _ in
             let wasi = bridge.underlying
             let preopenFd: WASIAbi.Fd = 3
 
@@ -1497,7 +1535,7 @@ struct WASITests {
                 dirFd: preopenFd, flags: [], path: "hello.txt"
             )
             #expect(stat.size == 5, "preopen should still read files after closing '.' fd")
-            try bridge.close()
+            }
         }
     #endif
 
@@ -1512,18 +1550,23 @@ struct WASITests {
                     .init(guestPath: "/dir", hostPath: t.url.path)
                 ])
             )
-            let wasi = bridge.underlying
-            let preopenFd: WASIAbi.Fd = 3
+            do {
+                let wasi = bridge.underlying
+                let preopenFd: WASIAbi.Fd = 3
 
-            // Preopen works before close
-            let stat = try wasi.path_filestat_get(dirFd: preopenFd, flags: [], path: "test.txt")
-            #expect(stat.size == 5)
+                // Preopen works before close
+                let stat = try wasi.path_filestat_get(dirFd: preopenFd, flags: [], path: "test.txt")
+                #expect(stat.size == 5)
 
-            try bridge.close()
+                try bridge.close()
 
-            // After close, the preopen fd should no longer be usable
-            #expect(throws: WASIAbi.Errno.EBADF) {
-                try wasi.path_filestat_get(dirFd: preopenFd, flags: [], path: "test.txt")
+                // After close, the preopen fd should no longer be usable
+                #expect(throws: WASIAbi.Errno.EBADF) {
+                    try wasi.path_filestat_get(dirFd: preopenFd, flags: [], path: "test.txt")
+                }
+            } catch {
+                try bridge.close()
+                throw error
             }
         }
     #endif
@@ -1545,6 +1588,7 @@ struct WASITests {
                     .init(guestPath: "/dir2", hostPath: t.url.appending(component: "dir2").path),
                 ])
             )
+            try bridge.runAndClose { _ in
             let wasi = bridge.underlying
             let dir1Fd: WASIAbi.Fd = 3
             let dir2Fd: WASIAbi.Fd = 4
@@ -1585,7 +1629,7 @@ struct WASITests {
                 try wasi.path_create_directory(dirFd: dir1Fd, path: "foo/bar")
                 try wasi.path_remove_directory(dirFd: dir1Fd, path: "foo/bar")
             }
-            try bridge.close()
+            }
         }
     #endif
 }

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -1397,6 +1397,56 @@ struct WASITests {
     #endif
 
     #if os(macOS) || os(Linux)
+        @Test
+        func setFilestatTimesDoesNotLeakFds() throws {
+            let t = try TestSupport.TemporaryDirectory()
+            try t.createFile(at: "test.txt", contents: "hello")
+
+            let wasi = try WASIBridgeToHost(
+                fileSystem: .host().withPreopens([
+                    .init(guestPath: "/dir", hostPath: t.url.path)
+                ])
+            ).underlying
+            let dirFd: WASIAbi.Fd = 3
+
+            let fdCountBefore = TestSupport.countOpenFileDescriptors()
+
+            for _ in 0..<200 {
+                try wasi.path_filestat_set_times(
+                    dirFd: dirFd, flags: [],
+                    path: "test.txt",
+                    atim: 1_000_000_000, mtim: 1_000_000_000,
+                    fstFlags: [.ATIM, .MTIM]
+                )
+            }
+
+            let fdCountAfter = TestSupport.countOpenFileDescriptors()
+            #expect(
+                fdCountAfter - fdCountBefore < 10,
+                "Leaked \(fdCountAfter - fdCountBefore) file descriptors in path_filestat_set_times"
+            )
+        }
+
+        @Test
+        func wasiInstanceDeinitClosesFds() throws {
+            let fdCountBefore = TestSupport.countOpenFileDescriptors()
+
+            for _ in 0..<100 {
+                let t = try TestSupport.TemporaryDirectory()
+                let _ = try WASIBridgeToHost(
+                    fileSystem: .host().withPreopens([
+                        .init(guestPath: "/dir", hostPath: t.url.path)
+                    ])
+                )
+            }
+
+            let fdCountAfter = TestSupport.countOpenFileDescriptors()
+            #expect(
+                fdCountAfter - fdCountBefore < 10,
+                "Leaked \(fdCountAfter - fdCountBefore) file descriptors from WASIBridgeToHost deinit"
+            )
+        }
+
         // https://github.com/swiftwasm/WasmKit/issues/275
         @Test
         func fileDescriptorLeakTest() throws {

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -1396,57 +1396,66 @@ struct WASITests {
         }
     #endif
 
-    #if os(macOS) || os(Linux)
+    #if !os(Windows)
         @Test
-        func setFilestatTimesDoesNotLeakFds() throws {
+        func pathOpenDotReturnsIndependentFd() throws {
             let t = try TestSupport.TemporaryDirectory()
-            try t.createFile(at: "test.txt", contents: "hello")
+            try t.createFile(at: "hello.txt", contents: "world")
 
             let wasi = try WASIBridgeToHost(
                 fileSystem: .host().withPreopens([
                     .init(guestPath: "/dir", hostPath: t.url.path)
                 ])
             ).underlying
-            let dirFd: WASIAbi.Fd = 3
+            let preopenFd: WASIAbi.Fd = 3
 
-            let fdCountBefore = TestSupport.countOpenFileDescriptors()
-
-            for _ in 0..<200 {
-                try wasi.path_filestat_set_times(
-                    dirFd: dirFd, flags: [],
-                    path: "test.txt",
-                    atim: 1_000_000_000, mtim: 1_000_000_000,
-                    fstFlags: [.ATIM, .MTIM]
-                )
-            }
-
-            let fdCountAfter = TestSupport.countOpenFileDescriptors()
-            #expect(
-                fdCountAfter - fdCountBefore < 10,
-                "Leaked \(fdCountAfter - fdCountBefore) file descriptors in path_filestat_set_times"
+            // Open "." relative to the preopen — should get an independent fd
+            let dotFd = try wasi.path_open(
+                dirFd: preopenFd, dirFlags: [], path: ".",
+                oflags: [.DIRECTORY], fsRightsBase: [.FD_READ],
+                fsRightsInheriting: [], fdflags: []
             )
-        }
+            #expect(dotFd != preopenFd, "path_open should return a new WASI fd")
 
+            // Close the "." fd
+            try wasi.fd_close(fd: dotFd)
+
+            // The preopen must still be fully functional after closing the "." fd
+            let stat = try wasi.path_filestat_get(
+                dirFd: preopenFd, flags: [], path: "hello.txt"
+            )
+            #expect(stat.size == 5, "preopen should still read files after closing '.' fd")
+        }
+    #endif
+
+    #if !os(Windows)
         @Test
-        func wasiInstanceDeinitClosesFds() throws {
-            let fdCountBefore = TestSupport.countOpenFileDescriptors()
+        func closeReleasesPreopenedFds() throws {
+            let t = try TestSupport.TemporaryDirectory()
+            try t.createFile(at: "test.txt", contents: "hello")
 
-            for _ in 0..<100 {
-                let t = try TestSupport.TemporaryDirectory()
-                let _ = try WASIBridgeToHost(
-                    fileSystem: .host().withPreopens([
-                        .init(guestPath: "/dir", hostPath: t.url.path)
-                    ])
-                )
-            }
-
-            let fdCountAfter = TestSupport.countOpenFileDescriptors()
-            #expect(
-                fdCountAfter - fdCountBefore < 10,
-                "Leaked \(fdCountAfter - fdCountBefore) file descriptors from WASIBridgeToHost deinit"
+            let bridge = try WASIBridgeToHost(
+                fileSystem: .host().withPreopens([
+                    .init(guestPath: "/dir", hostPath: t.url.path)
+                ])
             )
-        }
+            let wasi = bridge.underlying
+            let preopenFd: WASIAbi.Fd = 3
 
+            // Preopen works before close
+            let stat = try wasi.path_filestat_get(dirFd: preopenFd, flags: [], path: "test.txt")
+            #expect(stat.size == 5)
+
+            try bridge.close()
+
+            // After close, the preopen fd should no longer be usable
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                try wasi.path_filestat_get(dirFd: preopenFd, flags: [], path: "test.txt")
+            }
+        }
+    #endif
+
+    #if os(macOS) || os(Linux)
         // https://github.com/swiftwasm/WasmKit/issues/275
         @Test
         func fileDescriptorLeakTest() throws {

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -136,6 +136,7 @@ struct WASITests {
             try assertNotResolve("link-loop.txt", followSymlink: true) { error in
                 #expect(error == .ELOOP)
             }
+            try wasi.close()
         }
     #endif
 
@@ -180,11 +181,12 @@ struct WASITests {
         try fs.addFile(at: "/test.txt", content: Array("Test Content".utf8))
         try fs.ensureDirectory(at: "/testdir")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let rootFd: WASIAbi.Fd = 3
 
@@ -203,6 +205,7 @@ struct WASITests {
         #expect(stat.size == 12)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -211,11 +214,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/readwrite.txt", content: Array("Initial".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -235,6 +239,7 @@ struct WASITests {
         #expect(tell == 7)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -242,11 +247,12 @@ struct WASITests {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         try wasi.path_create_directory(dirFd: rootFd, path: "newdir")
@@ -273,6 +279,7 @@ struct WASITests {
         try wasi.path_unlink_file(dirFd: rootFd, path: "newdir/file1.txt")
         #expect(fs.lookup(at: "/newdir/file1.txt") == nil)
         #expect(fs.lookup(at: "/newdir/file2.txt") != nil)
+        try bridge.close()
     }
 
     @Test
@@ -280,11 +287,12 @@ struct WASITests {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd1 = try wasi.path_open(
@@ -316,6 +324,7 @@ struct WASITests {
         #expect(stat.size == 0)
 
         try wasi.fd_close(fd: fd2)
+        try bridge.close()
     }
 
     @Test
@@ -324,11 +333,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/existing.txt", content: [])
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         do {
@@ -345,6 +355,7 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EEXIST)
         }
+        try bridge.close()
     }
 
     @Test
@@ -388,8 +399,10 @@ struct WASITests {
         #if !os(Windows)
             let elapsed = try ContinuousClock().measure {
                 let clockPointer = UnsafeGuestBufferPointer<WASIAbi.Subscription>(baseAddress: .init(offset: clockOffset), count: 1)
-                let result = try WASIBridgeToHost().underlying.poll_oneoff(subscriptions: clockPointer, events: .init(baseAddress: .init(offset: finalOffset), count: 1), memory: memory)
+                let bridge = try WASIBridgeToHost()
+                let result = try bridge.underlying.poll_oneoff(subscriptions: clockPointer, events: .init(baseAddress: .init(offset: finalOffset), count: 1), memory: memory)
                 #expect(result == 1)
+                try bridge.close()
             }
             #expect(elapsed > Duration.nanoseconds(timeout))
         #endif
@@ -409,7 +422,7 @@ struct WASITests {
         let wasi = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens))
         #expect(fs.lookup(at: "/tmp") != nil)
         #expect(fs.lookup(at: "/data") != nil)
-        _ = wasi
+        try wasi.close()
     }
 
     @Test
@@ -421,7 +434,8 @@ struct WASITests {
             WASIBridgeToHost.Preopen(guestPath: ".", hostPath: "."),
             WASIBridgeToHost.Preopen(guestPath: "/", hostPath: "/"),
         ]
-        let wasi = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens)).underlying
+        let bridge = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens))
+        let wasi = bridge.underlying
 
         guard case .directory(let fd3Dir) = wasi.fdTable[3] else {
             #expect(Bool(false), "Expected fd=3 to be a preopened directory")
@@ -434,6 +448,7 @@ struct WASITests {
 
         #expect(fd3Dir.preopenPath == ".")
         #expect(fd4Dir.preopenPath == "/")
+        try bridge.close()
     }
 
     @Test
@@ -441,11 +456,12 @@ struct WASITests {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/sandbox")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/sandbox", hostPath: "/sandbox")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let prestat = try wasi.fd_prestat_get(fd: 3)
         guard case .dir(let pathLen) = prestat else {
@@ -453,6 +469,7 @@ struct WASITests {
             return
         }
         #expect(pathLen == 8)
+        try bridge.close()
     }
 
     @Test
@@ -509,11 +526,12 @@ struct WASITests {
             try fs.ensureDirectory(at: "/")
             try fs.addFile(at: "/mounted.txt", handle: fd)
 
-            let wasi = try WASIBridgeToHost(
+            let bridge = try WASIBridgeToHost(
                 fileSystem: .memory(fs).withPreopens([
                     .init(guestPath: "/", hostPath: "/")
                 ])
-            ).underlying
+            )
+            let wasi = bridge.underlying
             let rootFd: WASIAbi.Fd = 3
 
             let openedFd = try wasi.path_open(
@@ -532,6 +550,7 @@ struct WASITests {
 
             try wasi.fd_close(fd: openedFd)
         #endif
+        try bridge.close()
     }
 
     @Test
@@ -541,11 +560,12 @@ struct WASITests {
             try tempDir.createFile(at: "host.txt", contents: "Host content")
 
             // Using default host filesystem
-            let wasi = try WASIBridgeToHost(
+            let bridge = try WASIBridgeToHost(
                 fileSystem: .host().withPreopens([
                     .init(guestPath: "/sandbox", hostPath: tempDir.url.path)
                 ])
-            ).underlying
+            )
+            let wasi = bridge.underlying
 
             let sandboxFd: WASIAbi.Fd = 3
             let fd = try wasi.path_open(
@@ -564,6 +584,7 @@ struct WASITests {
 
             try wasi.fd_close(fd: fd)
         #endif
+        try bridge.close()
     }
 
     @Test
@@ -573,11 +594,12 @@ struct WASITests {
         try memFS.addFile(at: "/memory.txt", content: "Memory content")
 
         // Using memory filesystem through unified bridge
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(memFS).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let rootFd: WASIAbi.Fd = 3
         let fd = try wasi.path_open(
@@ -595,6 +617,7 @@ struct WASITests {
         #expect(stat.size == 14)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -603,11 +626,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/positions.txt", content: Array("0123456789".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -633,6 +657,7 @@ struct WASITests {
         #expect(midPos == 5)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -641,11 +666,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/file.txt", content: Array("test".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let readOnlyFd = try wasi.path_open(
@@ -679,6 +705,7 @@ struct WASITests {
         #expect(writeStat.fsRightsBase.contains(.FD_WRITE))
 
         try wasi.fd_close(fd: writeOnlyFd)
+        try bridge.close()
     }
 
     @Test
@@ -741,11 +768,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/truncate.txt", content: Array("Long content here".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -771,6 +799,7 @@ struct WASITests {
         #expect(bytes == Array("Long".utf8))
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -779,11 +808,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/expand.txt", content: Array("Hi".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -813,6 +843,7 @@ struct WASITests {
         #expect(bytes[9] == 0)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -821,11 +852,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/old.txt", content: Array("Content".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         try wasi.path_rename(
@@ -844,6 +876,7 @@ struct WASITests {
             return
         }
         #expect(bytes == Array("Content".utf8))
+        try bridge.close()
     }
 
     @Test
@@ -853,11 +886,12 @@ struct WASITests {
         try fs.addFile(at: "/file.txt", content: Array("test".utf8))
         try fs.ensureDirectory(at: "/subdir")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         try wasi.path_rename(
@@ -869,6 +903,7 @@ struct WASITests {
 
         #expect(fs.lookup(at: "/file.txt") == nil)
         #expect(fs.lookup(at: "/subdir/moved.txt") != nil)
+        try bridge.close()
     }
 
     @Test
@@ -877,15 +912,17 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.ensureDirectory(at: "/emptydir")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         try wasi.path_remove_directory(dirFd: rootFd, path: "emptydir")
         #expect(fs.lookup(at: "/emptydir") == nil)
+        try bridge.close()
     }
 
     @Test
@@ -895,11 +932,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/nonempty")
         try fs.addFile(at: "/nonempty/file.txt", content: [])
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         do {
@@ -910,6 +948,7 @@ struct WASITests {
         }
 
         #expect(fs.lookup(at: "/nonempty") != nil)
+        try bridge.close()
     }
 
     @Test
@@ -918,11 +957,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/sync.txt", content: [])
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -939,6 +979,7 @@ struct WASITests {
         try wasi.fd_datasync(fd: fd)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -947,11 +988,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/test.txt", content: [])
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -981,6 +1023,7 @@ struct WASITests {
         #expect(readData[0] == writeData)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -989,11 +1032,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/readonly.txt", content: Array("Read only".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -1018,6 +1062,7 @@ struct WASITests {
         }
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -1026,11 +1071,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/writeonly.txt", content: [])
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -1059,6 +1105,7 @@ struct WASITests {
         }
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -1076,11 +1123,12 @@ struct WASITests {
             try fs.ensureDirectory(at: "/")
             try fs.addFile(at: "/handle.txt", handle: fd)
 
-            let wasi = try WASIBridgeToHost(
+            let bridge = try WASIBridgeToHost(
                 fileSystem: .memory(fs).withPreopens([
                     .init(guestPath: "/", hostPath: "/")
                 ])
-            ).underlying
+            )
+            let wasi = bridge.underlying
             let rootFd: WASIAbi.Fd = 3
 
             let openedFd = try wasi.path_open(
@@ -1105,6 +1153,7 @@ struct WASITests {
             let content = try String(contentsOf: tempDir.url.appendingPathComponent("target.txt"), encoding: .utf8)
             #expect(content == "Via handle")
         #endif
+        try bridge.close()
     }
 
     @Test
@@ -1113,11 +1162,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/small.txt", content: Array("Small".utf8))
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let fd = try wasi.path_open(
@@ -1144,17 +1194,19 @@ struct WASITests {
         #expect(stat.size == 103)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
     func stdioFileDescriptors() throws {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withStdio().withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let stdinStat = try wasi.fd_fdstat_get(fileDescriptor: 0)
         #expect(stdinStat.fsRightsBase.contains(.FD_READ))
@@ -1167,17 +1219,19 @@ struct WASITests {
         let stderrStat = try wasi.fd_fdstat_get(fileDescriptor: 2)
         #expect(!stderrStat.fsRightsBase.contains(.FD_READ))
         #expect(stderrStat.fsRightsBase.contains(.FD_WRITE))
+        try bridge.close()
     }
 
     @Test
     func stdoutWrite() throws {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withStdio().withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
         let writeData = Array("Hello, stdout!".utf8)
@@ -1185,17 +1239,19 @@ struct WASITests {
 
         let nwritten = try wasi.fd_write(fileDescriptor: 1, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
+        try bridge.close()
     }
 
     @Test
     func stderrWrite() throws {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withStdio().withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
         let writeData = Array("Error message".utf8)
@@ -1203,17 +1259,19 @@ struct WASITests {
 
         let nwritten = try wasi.fd_write(fileDescriptor: 2, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
+        try bridge.close()
     }
 
     @Test
     func stdinCannotWrite() throws {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withStdio().withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
         let writeData = Array("Should fail".utf8)
@@ -1225,17 +1283,19 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
         }
+        try bridge.close()
     }
 
     @Test
     func stdoutCannotRead() throws {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
         let iovecs = memory.readIOVecs(sizes: [10])
@@ -1246,17 +1306,19 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
         }
+        try bridge.close()
     }
 
     @Test
     func stderrCannotRead() throws {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
 
         let memory = TestSupport.TestGuestMemory()
         let iovecs = memory.readIOVecs(sizes: [10])
@@ -1267,6 +1329,7 @@ struct WASITests {
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
         }
+        try bridge.close()
     }
 
     @Test
@@ -1275,11 +1338,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/file.txt", content: "test")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let stat1 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
@@ -1312,6 +1376,7 @@ struct WASITests {
         #expect(stat3.mtim >= stat2.mtim)
 
         try wasi.fd_close(fd: fd)
+        try bridge.close()
     }
 
     @Test
@@ -1319,11 +1384,12 @@ struct WASITests {
         let fs = try MemoryFileSystem()
         try fs.ensureDirectory(at: "/")
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         try wasi.path_create_directory(dirFd: rootFd, path: "testdir")
@@ -1336,6 +1402,7 @@ struct WASITests {
 
         let stat2 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "testdir")
         #expect(stat2.mtim >= stat1.mtim)
+        try bridge.close()
     }
 
     @Test
@@ -1344,11 +1411,12 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.addFile(at: "/file.txt", content: [])
 
-        let wasi = try WASIBridgeToHost(
+        let bridge = try WASIBridgeToHost(
             fileSystem: .memory(fs).withPreopens([
                 .init(guestPath: "/", hostPath: "/")
             ])
-        ).underlying
+        )
+        let wasi = bridge.underlying
         let rootFd: WASIAbi.Fd = 3
 
         let specificTime: WASIAbi.Timestamp = 1_000_000_000_000_000_000
@@ -1365,6 +1433,7 @@ struct WASITests {
         let stat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
         #expect(stat.atim == specificTime)
         #expect(stat.mtim == specificTime)
+        try bridge.close()
     }
 
     #if !os(Windows)
@@ -1377,11 +1446,12 @@ struct WASITests {
             try t.createFile(at: "foo/a", contents: "hello")
             try t.createSymlink(at: "foo/b", to: "b")  // cyclic symlink
 
-            let wasi = try WASIBridgeToHost(
+            let bridge = try WASIBridgeToHost(
                 fileSystem: .host().withPreopens([
                     .init(guestPath: "/foo", hostPath: t.url.appendingPathComponent("foo").path)
                 ])
-            ).underlying
+            )
+            let wasi = bridge.underlying
             let preopenFd: WASIAbi.Fd = 3
 
             let memory = TestSupport.TestGuestMemory()
@@ -1393,6 +1463,7 @@ struct WASITests {
             // Without the noFollow fix, this throws ELOOP due to the cyclic symlink
             let nwritten = try wasi.fd_readdir(fd: preopenFd, buffer: buffer, cookie: 0, memory: memory)
             #expect(nwritten > 0)
+            try bridge.close()
         }
     #endif
 
@@ -1402,11 +1473,12 @@ struct WASITests {
             let t = try TestSupport.TemporaryDirectory()
             try t.createFile(at: "hello.txt", contents: "world")
 
-            let wasi = try WASIBridgeToHost(
+            let bridge = try WASIBridgeToHost(
                 fileSystem: .host().withPreopens([
                     .init(guestPath: "/dir", hostPath: t.url.path)
                 ])
-            ).underlying
+            )
+            let wasi = bridge.underlying
             let preopenFd: WASIAbi.Fd = 3
 
             // Open "." relative to the preopen — should get an independent fd
@@ -1425,6 +1497,7 @@ struct WASITests {
                 dirFd: preopenFd, flags: [], path: "hello.txt"
             )
             #expect(stat.size == 5, "preopen should still read files after closing '.' fd")
+            try bridge.close()
         }
     #endif
 
@@ -1466,12 +1539,13 @@ struct WASITests {
             try t.createDir(at: "dir2")
             try t.createDir(at: "dir2/foo")
 
-            let wasi = try WASIBridgeToHost(
+            let bridge = try WASIBridgeToHost(
                 fileSystem: .host().withPreopens([
                     .init(guestPath: "/dir1", hostPath: t.url.appending(component: "dir1").path),
                     .init(guestPath: "/dir2", hostPath: t.url.appending(component: "dir2").path),
                 ])
-            ).underlying
+            )
+            let wasi = bridge.underlying
             let dir1Fd: WASIAbi.Fd = 3
             let dir2Fd: WASIAbi.Fd = 4
 
@@ -1511,6 +1585,7 @@ struct WASITests {
                 try wasi.path_create_directory(dirFd: dir1Fd, path: "foo/bar")
                 try wasi.path_remove_directory(dirFd: dir1Fd, path: "foo/bar")
             }
+            try bridge.close()
         }
     #endif
 }

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -549,8 +549,8 @@ struct WASITests {
             #expect(stat.size == 23)
 
             try wasi.fd_close(fd: openedFd)
+            try bridge.close()
         #endif
-        try bridge.close()
     }
 
     @Test
@@ -583,8 +583,8 @@ struct WASITests {
             #expect(stat.size == 12)
 
             try wasi.fd_close(fd: fd)
+            try bridge.close()
         #endif
-        try bridge.close()
     }
 
     @Test
@@ -1152,8 +1152,8 @@ struct WASITests {
 
             let content = try String(contentsOf: tempDir.url.appendingPathComponent("target.txt"), encoding: .utf8)
             #expect(content == "Via handle")
+            try bridge.close()
         #endif
-        try bridge.close()
     }
 
     @Test

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -33,30 +33,10 @@ struct WASITests {
                 ])
             )
             try wasi.runAndClose { wasi in
-            let mntFd: WASIAbi.Fd = 3
+                let mntFd: WASIAbi.Fd = 3
 
-            func assertResolve(_ path: String, followSymlink: Bool, directory: Bool = false) throws {
-                let fd = try wasi.underlying.path_open(
-                    dirFd: mntFd,
-                    dirFlags: followSymlink ? [.SYMLINK_FOLLOW] : [],
-                    path: path,
-                    oflags: directory ? [.DIRECTORY] : [],
-                    fsRightsBase: .DIRECTORY_BASE_RIGHTS,
-                    fsRightsInheriting: .DIRECTORY_INHERITING_RIGHTS,
-                    fdflags: []
-                )
-                try wasi.underlying.fd_close(fd: fd)
-            }
-
-            func assertNotResolve(
-                _ path: String,
-                followSymlink: Bool,
-                directory: Bool = false,
-                sourceLocation: SourceLocation = #_sourceLocation,
-                _ checkError: ((WASIAbi.Errno) throws -> Void)?
-            ) throws {
-                do {
-                    _ = try wasi.underlying.path_open(
+                func assertResolve(_ path: String, followSymlink: Bool, directory: Bool = false) throws {
+                    let fd = try wasi.underlying.path_open(
                         dirFd: mntFd,
                         dirFlags: followSymlink ? [.SYMLINK_FOLLOW] : [],
                         path: path,
@@ -65,78 +45,98 @@ struct WASITests {
                         fsRightsInheriting: .DIRECTORY_INHERITING_RIGHTS,
                         fdflags: []
                     )
-                    #expect((false), "Expected not to be able to open \(path)", sourceLocation: sourceLocation)
-                } catch {
-                    guard let error = error as? WASIAbi.Errno else {
-                        #expect((false), "Expected WASIAbi.Errno error but got \(error)", sourceLocation: sourceLocation)
-                        return
-                    }
-                    try checkError?(error)
+                    try wasi.underlying.fd_close(fd: fd)
                 }
-            }
 
-            try assertNotResolve("non-existent.txt", followSymlink: false) { error in
-                #expect(error == .ENOENT)
-            }
+                func assertNotResolve(
+                    _ path: String,
+                    followSymlink: Bool,
+                    directory: Bool = false,
+                    sourceLocation: SourceLocation = #_sourceLocation,
+                    _ checkError: ((WASIAbi.Errno) throws -> Void)?
+                ) throws {
+                    do {
+                        _ = try wasi.underlying.path_open(
+                            dirFd: mntFd,
+                            dirFlags: followSymlink ? [.SYMLINK_FOLLOW] : [],
+                            path: path,
+                            oflags: directory ? [.DIRECTORY] : [],
+                            fsRightsBase: .DIRECTORY_BASE_RIGHTS,
+                            fsRightsInheriting: .DIRECTORY_INHERITING_RIGHTS,
+                            fdflags: []
+                        )
+                        #expect((false), "Expected not to be able to open \(path)", sourceLocation: sourceLocation)
+                    } catch {
+                        guard let error = error as? WASIAbi.Errno else {
+                            #expect((false), "Expected WASIAbi.Errno error but got \(error)", sourceLocation: sourceLocation)
+                            return
+                        }
+                        try checkError?(error)
+                    }
+                }
 
-            try assertResolve("link-hello.txt", followSymlink: true)
-            try assertNotResolve("link-hello.txt", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
-            try assertNotResolve("link-hello.txt", followSymlink: true, directory: true) { error in
-                #expect(error == .ENOTDIR)
-            }
+                try assertNotResolve("non-existent.txt", followSymlink: false) { error in
+                    #expect(error == .ENOENT)
+                }
 
-            try assertNotResolve("link-hello.txt/", followSymlink: true) { error in
-                #expect(error == .ENOTDIR)
-            }
+                try assertResolve("link-hello.txt", followSymlink: true)
+                try assertNotResolve("link-hello.txt", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
+                try assertNotResolve("link-hello.txt", followSymlink: true, directory: true) { error in
+                    #expect(error == .ENOTDIR)
+                }
 
-            try assertResolve("link-world.dir", followSymlink: true)
-            try assertNotResolve("link-world.dir", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
+                try assertNotResolve("link-hello.txt/", followSymlink: true) { error in
+                    #expect(error == .ENOTDIR)
+                }
 
-            try assertNotResolve("link-external-secret-a.txt", followSymlink: true) { error in
-                #expect(error == .EPERM)
-            }
-            try assertNotResolve("link-external-secret-a.txt", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
+                try assertResolve("link-world.dir", followSymlink: true)
+                try assertNotResolve("link-world.dir", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
 
-            try assertNotResolve("link-external-non-existent.txt", followSymlink: true) { error in
-                #expect(error == .EPERM)
-            }
-            try assertNotResolve("link-external-non-existent.txt", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
+                try assertNotResolve("link-external-secret-a.txt", followSymlink: true) { error in
+                    #expect(error == .EPERM)
+                }
+                try assertNotResolve("link-external-secret-a.txt", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
 
-            try assertNotResolve("link-updown-hello.txt", followSymlink: true) { error in
-                #expect(error == .EPERM)
-            }
-            try assertNotResolve("link-updown-hello.txt", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
+                try assertNotResolve("link-external-non-existent.txt", followSymlink: true) { error in
+                    #expect(error == .EPERM)
+                }
+                try assertNotResolve("link-external-non-existent.txt", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
 
-            try assertNotResolve("link-secret-dir-b/secret-c.txt", followSymlink: true) { error in
-                #expect(error == .EPERM)
-            }
-            try assertNotResolve("link-secret-dir-b/secret-c.txt", followSymlink: false) { error in
-                #expect(error == .ENOTDIR)
-            }
+                try assertNotResolve("link-updown-hello.txt", followSymlink: true) { error in
+                    #expect(error == .EPERM)
+                }
+                try assertNotResolve("link-updown-hello.txt", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
 
-            try assertNotResolve("link-root", followSymlink: true) { error in
-                #expect(error == .EPERM)
-            }
-            try assertNotResolve("link-root", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
+                try assertNotResolve("link-secret-dir-b/secret-c.txt", followSymlink: true) { error in
+                    #expect(error == .EPERM)
+                }
+                try assertNotResolve("link-secret-dir-b/secret-c.txt", followSymlink: false) { error in
+                    #expect(error == .ENOTDIR)
+                }
 
-            try assertNotResolve("link-loop.txt", followSymlink: false) { error in
-                #expect(error == .ELOOP)
-            }
-            try assertNotResolve("link-loop.txt", followSymlink: true) { error in
-                #expect(error == .ELOOP)
-            }
+                try assertNotResolve("link-root", followSymlink: true) { error in
+                    #expect(error == .EPERM)
+                }
+                try assertNotResolve("link-root", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
+
+                try assertNotResolve("link-loop.txt", followSymlink: false) { error in
+                    #expect(error == .ELOOP)
+                }
+                try assertNotResolve("link-loop.txt", followSymlink: true) { error in
+                    #expect(error == .ELOOP)
+                }
             }
         }
     #endif
@@ -188,25 +188,25 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let rootFd: WASIAbi.Fd = 3
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "test.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "test.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let stat = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat.filetype == .REGULAR_FILE)
-        #expect(stat.size == 12)
+            let stat = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat.filetype == .REGULAR_FILE)
+            #expect(stat.size == 12)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -222,26 +222,26 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "readwrite.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ, .FD_WRITE, .FD_SEEK],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "readwrite.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ, .FD_WRITE, .FD_SEEK],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let newOffset = try wasi.fd_seek(fd: fd, offset: 0, whence: .END)
-        #expect(newOffset == 7)
+            let newOffset = try wasi.fd_seek(fd: fd, offset: 0, whence: .END)
+            #expect(newOffset == 7)
 
-        let tell = try wasi.fd_tell(fd: fd)
-        #expect(tell == 7)
+            let tell = try wasi.fd_tell(fd: fd)
+            #expect(tell == 7)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -256,33 +256,33 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        try wasi.path_create_directory(dirFd: rootFd, path: "newdir")
-        #expect(fs.lookup(at: "/newdir") != nil)
+            try wasi.path_create_directory(dirFd: rootFd, path: "newdir")
+            #expect(fs.lookup(at: "/newdir") != nil)
 
-        let dirStat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "newdir")
-        #expect(dirStat.filetype == .DIRECTORY)
+            let dirStat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "newdir")
+            #expect(dirStat.filetype == .DIRECTORY)
 
-        let dirFd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "newdir",
-            oflags: [.DIRECTORY],
-            fsRightsBase: .DIRECTORY_BASE_RIGHTS,
-            fsRightsInheriting: .DIRECTORY_INHERITING_RIGHTS,
-            fdflags: []
-        )
+            let dirFd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "newdir",
+                oflags: [.DIRECTORY],
+                fsRightsBase: .DIRECTORY_BASE_RIGHTS,
+                fsRightsInheriting: .DIRECTORY_INHERITING_RIGHTS,
+                fdflags: []
+            )
 
-        try fs.addFile(at: "/newdir/file1.txt", content: Array("file1".utf8))
-        try fs.addFile(at: "/newdir/file2.txt", content: Array("file2".utf8))
+            try fs.addFile(at: "/newdir/file1.txt", content: Array("file1".utf8))
+            try fs.addFile(at: "/newdir/file2.txt", content: Array("file2".utf8))
 
-        try wasi.fd_close(fd: dirFd)
+            try wasi.fd_close(fd: dirFd)
 
-        try wasi.path_unlink_file(dirFd: rootFd, path: "newdir/file1.txt")
-        #expect(fs.lookup(at: "/newdir/file1.txt") == nil)
-        #expect(fs.lookup(at: "/newdir/file2.txt") != nil)
+            try wasi.path_unlink_file(dirFd: rootFd, path: "newdir/file1.txt")
+            #expect(fs.lookup(at: "/newdir/file1.txt") == nil)
+            #expect(fs.lookup(at: "/newdir/file2.txt") != nil)
         }
     }
 
@@ -297,38 +297,38 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd1 = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "created.txt",
-            oflags: [.CREAT],
-            fsRightsBase: [.FD_WRITE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
-        try wasi.fd_close(fd: fd1)
+            let fd1 = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "created.txt",
+                oflags: [.CREAT],
+                fsRightsBase: [.FD_WRITE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
+            try wasi.fd_close(fd: fd1)
 
-        #expect(fs.lookup(at: "/created.txt") != nil)
+            #expect(fs.lookup(at: "/created.txt") != nil)
 
-        try fs.addFile(at: "/truncate.txt", content: Array("Long content here".utf8))
+            try fs.addFile(at: "/truncate.txt", content: Array("Long content here".utf8))
 
-        let fd2 = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "truncate.txt",
-            oflags: [.TRUNC],
-            fsRightsBase: [.FD_WRITE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd2 = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "truncate.txt",
+                oflags: [.TRUNC],
+                fsRightsBase: [.FD_WRITE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let stat = try wasi.fd_filestat_get(fd: fd2)
-        #expect(stat.size == 0)
+            let stat = try wasi.fd_filestat_get(fd: fd2)
+            #expect(stat.size == 0)
 
-        try wasi.fd_close(fd: fd2)
+            try wasi.fd_close(fd: fd2)
         }
     }
 
@@ -344,23 +344,23 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        do {
-            _ = try wasi.path_open(
-                dirFd: rootFd,
-                dirFlags: [],
-                path: "existing.txt",
-                oflags: [.CREAT, .EXCL],
-                fsRightsBase: [.FD_WRITE],
-                fsRightsInheriting: [],
-                fdflags: []
-            )
-            #expect(Bool(false), "Should have thrown EEXIST")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .EEXIST)
-        }
+            do {
+                _ = try wasi.path_open(
+                    dirFd: rootFd,
+                    dirFlags: [],
+                    path: "existing.txt",
+                    oflags: [.CREAT, .EXCL],
+                    fsRightsBase: [.FD_WRITE],
+                    fsRightsInheriting: [],
+                    fdflags: []
+                )
+                #expect(Bool(false), "Should have thrown EEXIST")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .EEXIST)
+            }
         }
     }
 
@@ -444,19 +444,19 @@ struct WASITests {
         ]
         let bridge = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens))
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        guard case .directory(let fd3Dir) = wasi.fdTable[3] else {
-            #expect(Bool(false), "Expected fd=3 to be a preopened directory")
-            return
-        }
-        guard case .directory(let fd4Dir) = wasi.fdTable[4] else {
-            #expect(Bool(false), "Expected fd=4 to be a preopened directory")
-            return
-        }
+            guard case .directory(let fd3Dir) = wasi.fdTable[3] else {
+                #expect(Bool(false), "Expected fd=3 to be a preopened directory")
+                return
+            }
+            guard case .directory(let fd4Dir) = wasi.fdTable[4] else {
+                #expect(Bool(false), "Expected fd=4 to be a preopened directory")
+                return
+            }
 
-        #expect(fd3Dir.preopenPath == ".")
-        #expect(fd4Dir.preopenPath == "/")
+            #expect(fd3Dir.preopenPath == ".")
+            #expect(fd4Dir.preopenPath == "/")
         }
     }
 
@@ -471,14 +471,14 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let prestat = try wasi.fd_prestat_get(fd: 3)
-        guard case .dir(let pathLen) = prestat else {
-            #expect(Bool(false), "Expected directory prestat")
-            return
-        }
-        #expect(pathLen == 8)
+            let prestat = try wasi.fd_prestat_get(fd: 3)
+            guard case .dir(let pathLen) = prestat else {
+                #expect(Bool(false), "Expected directory prestat")
+                return
+            }
+            #expect(pathLen == 8)
         }
     }
 
@@ -542,24 +542,24 @@ struct WASITests {
                 ])
             )
             try bridge.runAndClose { _ in
-            let wasi = bridge.underlying
-            let rootFd: WASIAbi.Fd = 3
+                let wasi = bridge.underlying
+                let rootFd: WASIAbi.Fd = 3
 
-            let openedFd = try wasi.path_open(
-                dirFd: rootFd,
-                dirFlags: [],
-                path: "mounted.txt",
-                oflags: [],
-                fsRightsBase: [.FD_READ],
-                fsRightsInheriting: [],
-                fdflags: []
-            )
+                let openedFd = try wasi.path_open(
+                    dirFd: rootFd,
+                    dirFlags: [],
+                    path: "mounted.txt",
+                    oflags: [],
+                    fsRightsBase: [.FD_READ],
+                    fsRightsInheriting: [],
+                    fdflags: []
+                )
 
-            let stat = try wasi.fd_filestat_get(fd: openedFd)
-            #expect(stat.filetype == .REGULAR_FILE)
-            #expect(stat.size == 23)
+                let stat = try wasi.fd_filestat_get(fd: openedFd)
+                #expect(stat.filetype == .REGULAR_FILE)
+                #expect(stat.size == 23)
 
-            try wasi.fd_close(fd: openedFd)
+                try wasi.fd_close(fd: openedFd)
             }
         #endif
     }
@@ -577,24 +577,24 @@ struct WASITests {
                 ])
             )
             try bridge.runAndClose { _ in
-            let wasi = bridge.underlying
+                let wasi = bridge.underlying
 
-            let sandboxFd: WASIAbi.Fd = 3
-            let fd = try wasi.path_open(
-                dirFd: sandboxFd,
-                dirFlags: [],
-                path: "host.txt",
-                oflags: [],
-                fsRightsBase: [.FD_READ],
-                fsRightsInheriting: [],
-                fdflags: []
-            )
+                let sandboxFd: WASIAbi.Fd = 3
+                let fd = try wasi.path_open(
+                    dirFd: sandboxFd,
+                    dirFlags: [],
+                    path: "host.txt",
+                    oflags: [],
+                    fsRightsBase: [.FD_READ],
+                    fsRightsInheriting: [],
+                    fdflags: []
+                )
 
-            let stat = try wasi.fd_filestat_get(fd: fd)
-            #expect(stat.filetype == .REGULAR_FILE)
-            #expect(stat.size == 12)
+                let stat = try wasi.fd_filestat_get(fd: fd)
+                #expect(stat.filetype == .REGULAR_FILE)
+                #expect(stat.size == 12)
 
-            try wasi.fd_close(fd: fd)
+                try wasi.fd_close(fd: fd)
             }
         #endif
     }
@@ -612,24 +612,24 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let rootFd: WASIAbi.Fd = 3
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "memory.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let rootFd: WASIAbi.Fd = 3
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "memory.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let stat = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat.filetype == .REGULAR_FILE)
-        #expect(stat.size == 14)
+            let stat = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat.filetype == .REGULAR_FILE)
+            #expect(stat.size == 14)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -645,32 +645,32 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "positions.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ, .FD_SEEK, .FD_TELL],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "positions.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ, .FD_SEEK, .FD_TELL],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let startPos = try wasi.fd_tell(fd: fd)
-        #expect(startPos == 0)
+            let startPos = try wasi.fd_tell(fd: fd)
+            #expect(startPos == 0)
 
-        let endPos = try wasi.fd_seek(fd: fd, offset: 0, whence: .END)
-        #expect(endPos == 10)
+            let endPos = try wasi.fd_seek(fd: fd, offset: 0, whence: .END)
+            #expect(endPos == 10)
 
-        let currentPos = try wasi.fd_tell(fd: fd)
-        #expect(currentPos == 10)
+            let currentPos = try wasi.fd_tell(fd: fd)
+            #expect(currentPos == 10)
 
-        let midPos = try wasi.fd_seek(fd: fd, offset: -5, whence: .CUR)
-        #expect(midPos == 5)
+            let midPos = try wasi.fd_seek(fd: fd, offset: -5, whence: .CUR)
+            #expect(midPos == 5)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -686,40 +686,40 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let readOnlyFd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "file.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let readOnlyFd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "file.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let stat = try wasi.fd_fdstat_get(fileDescriptor: readOnlyFd)
-        #expect(stat.fsRightsBase.contains(.FD_READ))
-        #expect(!stat.fsRightsBase.contains(.FD_WRITE))
+            let stat = try wasi.fd_fdstat_get(fileDescriptor: readOnlyFd)
+            #expect(stat.fsRightsBase.contains(.FD_READ))
+            #expect(!stat.fsRightsBase.contains(.FD_WRITE))
 
-        try wasi.fd_close(fd: readOnlyFd)
+            try wasi.fd_close(fd: readOnlyFd)
 
-        let writeOnlyFd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "file.txt",
-            oflags: [],
-            fsRightsBase: [.FD_WRITE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let writeOnlyFd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "file.txt",
+                oflags: [],
+                fsRightsBase: [.FD_WRITE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let writeStat = try wasi.fd_fdstat_get(fileDescriptor: writeOnlyFd)
-        #expect(!writeStat.fsRightsBase.contains(.FD_READ))
-        #expect(writeStat.fsRightsBase.contains(.FD_WRITE))
+            let writeStat = try wasi.fd_fdstat_get(fileDescriptor: writeOnlyFd)
+            #expect(!writeStat.fsRightsBase.contains(.FD_READ))
+            #expect(writeStat.fsRightsBase.contains(.FD_WRITE))
 
-        try wasi.fd_close(fd: writeOnlyFd)
+            try wasi.fd_close(fd: writeOnlyFd)
         }
     }
 
@@ -789,32 +789,32 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "truncate.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ, .FD_WRITE, .FD_FILESTAT_SET_SIZE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "truncate.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ, .FD_WRITE, .FD_FILESTAT_SET_SIZE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        try wasi.fd_filestat_set_size(fd: fd, size: 4)
+            try wasi.fd_filestat_set_size(fd: fd, size: 4)
 
-        let stat = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat.size == 4)
+            let stat = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat.size == 4)
 
-        let content = try fs.getFile(at: "/truncate.txt")
-        guard case .bytes(let bytes) = content else {
-            #expect(Bool(false), "Expected bytes content")
-            return
-        }
-        #expect(bytes == Array("Long".utf8))
+            let content = try fs.getFile(at: "/truncate.txt")
+            guard case .bytes(let bytes) = content else {
+                #expect(Bool(false), "Expected bytes content")
+                return
+            }
+            #expect(bytes == Array("Long".utf8))
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -830,36 +830,36 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "expand.txt",
-            oflags: [],
-            fsRightsBase: [.FD_WRITE, .FD_FILESTAT_SET_SIZE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "expand.txt",
+                oflags: [],
+                fsRightsBase: [.FD_WRITE, .FD_FILESTAT_SET_SIZE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        try wasi.fd_filestat_set_size(fd: fd, size: 10)
+            try wasi.fd_filestat_set_size(fd: fd, size: 10)
 
-        let stat = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat.size == 10)
+            let stat = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat.size == 10)
 
-        let content = try fs.getFile(at: "/expand.txt")
-        guard case .bytes(let bytes) = content else {
-            #expect(Bool(false), "Expected bytes content")
-            return
-        }
-        #expect(bytes.count == 10)
-        #expect(bytes[0] == UInt8(ascii: "H"))
-        #expect(bytes[1] == UInt8(ascii: "i"))
-        #expect(bytes[2] == 0)
-        #expect(bytes[9] == 0)
+            let content = try fs.getFile(at: "/expand.txt")
+            guard case .bytes(let bytes) = content else {
+                #expect(Bool(false), "Expected bytes content")
+                return
+            }
+            #expect(bytes.count == 10)
+            #expect(bytes[0] == UInt8(ascii: "H"))
+            #expect(bytes[1] == UInt8(ascii: "i"))
+            #expect(bytes[2] == 0)
+            #expect(bytes[9] == 0)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -875,25 +875,25 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        try wasi.path_rename(
-            oldFd: rootFd,
-            oldPath: "old.txt",
-            newFd: rootFd,
-            newPath: "new.txt"
-        )
+            try wasi.path_rename(
+                oldFd: rootFd,
+                oldPath: "old.txt",
+                newFd: rootFd,
+                newPath: "new.txt"
+            )
 
-        #expect(fs.lookup(at: "/old.txt") == nil)
-        #expect(fs.lookup(at: "/new.txt") != nil)
+            #expect(fs.lookup(at: "/old.txt") == nil)
+            #expect(fs.lookup(at: "/new.txt") != nil)
 
-        let content = try fs.getFile(at: "/new.txt")
-        guard case .bytes(let bytes) = content else {
-            #expect(Bool(false), "Expected bytes content")
-            return
-        }
-        #expect(bytes == Array("Content".utf8))
+            let content = try fs.getFile(at: "/new.txt")
+            guard case .bytes(let bytes) = content else {
+                #expect(Bool(false), "Expected bytes content")
+                return
+            }
+            #expect(bytes == Array("Content".utf8))
         }
     }
 
@@ -910,18 +910,18 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        try wasi.path_rename(
-            oldFd: rootFd,
-            oldPath: "file.txt",
-            newFd: rootFd,
-            newPath: "subdir/moved.txt"
-        )
+            try wasi.path_rename(
+                oldFd: rootFd,
+                oldPath: "file.txt",
+                newFd: rootFd,
+                newPath: "subdir/moved.txt"
+            )
 
-        #expect(fs.lookup(at: "/file.txt") == nil)
-        #expect(fs.lookup(at: "/subdir/moved.txt") != nil)
+            #expect(fs.lookup(at: "/file.txt") == nil)
+            #expect(fs.lookup(at: "/subdir/moved.txt") != nil)
         }
     }
 
@@ -937,11 +937,11 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        try wasi.path_remove_directory(dirFd: rootFd, path: "emptydir")
-        #expect(fs.lookup(at: "/emptydir") == nil)
+            try wasi.path_remove_directory(dirFd: rootFd, path: "emptydir")
+            #expect(fs.lookup(at: "/emptydir") == nil)
         }
     }
 
@@ -958,17 +958,17 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        do {
-            try wasi.path_remove_directory(dirFd: rootFd, path: "nonempty")
-            #expect(Bool(false), "Should not remove non-empty directory")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .ENOTEMPTY)
-        }
+            do {
+                try wasi.path_remove_directory(dirFd: rootFd, path: "nonempty")
+                #expect(Bool(false), "Should not remove non-empty directory")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .ENOTEMPTY)
+            }
 
-        #expect(fs.lookup(at: "/nonempty") != nil)
+            #expect(fs.lookup(at: "/nonempty") != nil)
         }
     }
 
@@ -984,23 +984,23 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "sync.txt",
-            oflags: [],
-            fsRightsBase: [.FD_SYNC, .FD_DATASYNC],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "sync.txt",
+                oflags: [],
+                fsRightsBase: [.FD_SYNC, .FD_DATASYNC],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        try wasi.fd_sync(fd: fd)
-        try wasi.fd_datasync(fd: fd)
+            try wasi.fd_sync(fd: fd)
+            try wasi.fd_datasync(fd: fd)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -1016,36 +1016,36 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "test.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ, .FD_WRITE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "test.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ, .FD_WRITE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let memory = TestSupport.TestGuestMemory()
-        let writeData = Array("Hello, WASI!".utf8)
-        let writeVecs = memory.writeIOVecs([writeData])
+            let memory = TestSupport.TestGuestMemory()
+            let writeData = Array("Hello, WASI!".utf8)
+            let writeVecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
-        #expect(nwritten == UInt32(writeData.count))
+            let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
+            #expect(nwritten == UInt32(writeData.count))
 
-        _ = try wasi.fd_seek(fd: fd, offset: 0, whence: .SET)
+            _ = try wasi.fd_seek(fd: fd, offset: 0, whence: .SET)
 
-        let readVecs = memory.readIOVecs(sizes: [writeData.count])
-        let nread = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
-        #expect(nread == UInt32(writeData.count))
+            let readVecs = memory.readIOVecs(sizes: [writeData.count])
+            let nread = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
+            #expect(nread == UInt32(writeData.count))
 
-        let readData = memory.loadIOVecs(readVecs)
-        #expect(readData[0] == writeData)
+            let readData = memory.loadIOVecs(readVecs)
+            #expect(readData[0] == writeData)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -1061,31 +1061,31 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "readonly.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "readonly.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        do {
-            let memory = TestSupport.TestGuestMemory()
-            let writeData = Array("Fail".utf8)
-            let iovecs = memory.writeIOVecs([writeData])
+            do {
+                let memory = TestSupport.TestGuestMemory()
+                let writeData = Array("Fail".utf8)
+                let iovecs = memory.writeIOVecs([writeData])
 
-            _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs, memory: memory)
-            #expect(Bool(false), "Should not be able to write to read-only file")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .EBADF)
-        }
+                _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs, memory: memory)
+                #expect(Bool(false), "Should not be able to write to read-only file")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .EBADF)
+            }
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -1101,35 +1101,35 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "writeonly.txt",
-            oflags: [],
-            fsRightsBase: [.FD_WRITE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "writeonly.txt",
+                oflags: [],
+                fsRightsBase: [.FD_WRITE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let memory = TestSupport.TestGuestMemory()
-        let writeData = Array("Write only".utf8)
-        let writeVecs = memory.writeIOVecs([writeData])
+            let memory = TestSupport.TestGuestMemory()
+            let writeData = Array("Write only".utf8)
+            let writeVecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
-        #expect(nwritten == UInt32(writeData.count))
+            let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
+            #expect(nwritten == UInt32(writeData.count))
 
-        do {
-            let readVecs = memory.readIOVecs(sizes: [10])
-            _ = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
-            #expect(Bool(false), "Should not be able to read from write-only file")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .EBADF)
-        }
+            do {
+                let readVecs = memory.readIOVecs(sizes: [10])
+                _ = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
+                #expect(Bool(false), "Should not be able to read from write-only file")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .EBADF)
+            }
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -1154,30 +1154,30 @@ struct WASITests {
                 ])
             )
             try bridge.runAndClose { _ in
-            let wasi = bridge.underlying
-            let rootFd: WASIAbi.Fd = 3
+                let wasi = bridge.underlying
+                let rootFd: WASIAbi.Fd = 3
 
-            let openedFd = try wasi.path_open(
-                dirFd: rootFd,
-                dirFlags: [],
-                path: "handle.txt",
-                oflags: [],
-                fsRightsBase: [.FD_WRITE],
-                fsRightsInheriting: [],
-                fdflags: []
-            )
+                let openedFd = try wasi.path_open(
+                    dirFd: rootFd,
+                    dirFlags: [],
+                    path: "handle.txt",
+                    oflags: [],
+                    fsRightsBase: [.FD_WRITE],
+                    fsRightsInheriting: [],
+                    fdflags: []
+                )
 
-            let memory = TestSupport.TestGuestMemory()
-            let writeData = Array("Via handle".utf8)
-            let iovecs = memory.writeIOVecs([writeData])
+                let memory = TestSupport.TestGuestMemory()
+                let writeData = Array("Via handle".utf8)
+                let iovecs = memory.writeIOVecs([writeData])
 
-            let nwritten = try wasi.fd_write(fileDescriptor: openedFd, ioVectors: iovecs, memory: memory)
-            #expect(nwritten == UInt32(writeData.count))
+                let nwritten = try wasi.fd_write(fileDescriptor: openedFd, ioVectors: iovecs, memory: memory)
+                #expect(nwritten == UInt32(writeData.count))
 
-            try wasi.fd_close(fd: openedFd)
+                try wasi.fd_close(fd: openedFd)
 
-            let content = try String(contentsOf: tempDir.url.appendingPathComponent("target.txt"), encoding: .utf8)
-            #expect(content == "Via handle")
+                let content = try String(contentsOf: tempDir.url.appendingPathComponent("target.txt"), encoding: .utf8)
+                #expect(content == "Via handle")
             }
         #endif
     }
@@ -1194,33 +1194,33 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "small.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ, .FD_WRITE, .FD_SEEK],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "small.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ, .FD_WRITE, .FD_SEEK],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let newPos = try wasi.fd_seek(fd: fd, offset: 100, whence: .SET)
-        #expect(newPos == 100)
+            let newPos = try wasi.fd_seek(fd: fd, offset: 100, whence: .SET)
+            #expect(newPos == 100)
 
-        let memory = TestSupport.TestGuestMemory()
-        let writeData = Array("End".utf8)
-        let iovecs = memory.writeIOVecs([writeData])
+            let memory = TestSupport.TestGuestMemory()
+            let writeData = Array("End".utf8)
+            let iovecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs, memory: memory)
-        #expect(nwritten == UInt32(writeData.count))
+            let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs, memory: memory)
+            #expect(nwritten == UInt32(writeData.count))
 
-        let stat = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat.size == 103)
+            let stat = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat.size == 103)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -1234,19 +1234,19 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let stdinStat = try wasi.fd_fdstat_get(fileDescriptor: 0)
-        #expect(stdinStat.fsRightsBase.contains(.FD_READ))
-        #expect(!stdinStat.fsRightsBase.contains(.FD_WRITE))
+            let stdinStat = try wasi.fd_fdstat_get(fileDescriptor: 0)
+            #expect(stdinStat.fsRightsBase.contains(.FD_READ))
+            #expect(!stdinStat.fsRightsBase.contains(.FD_WRITE))
 
-        let stdoutStat = try wasi.fd_fdstat_get(fileDescriptor: 1)
-        #expect(!stdoutStat.fsRightsBase.contains(.FD_READ))
-        #expect(stdoutStat.fsRightsBase.contains(.FD_WRITE))
+            let stdoutStat = try wasi.fd_fdstat_get(fileDescriptor: 1)
+            #expect(!stdoutStat.fsRightsBase.contains(.FD_READ))
+            #expect(stdoutStat.fsRightsBase.contains(.FD_WRITE))
 
-        let stderrStat = try wasi.fd_fdstat_get(fileDescriptor: 2)
-        #expect(!stderrStat.fsRightsBase.contains(.FD_READ))
-        #expect(stderrStat.fsRightsBase.contains(.FD_WRITE))
+            let stderrStat = try wasi.fd_fdstat_get(fileDescriptor: 2)
+            #expect(!stderrStat.fsRightsBase.contains(.FD_READ))
+            #expect(stderrStat.fsRightsBase.contains(.FD_WRITE))
         }
     }
 
@@ -1260,14 +1260,14 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let memory = TestSupport.TestGuestMemory()
-        let writeData = Array("Hello, stdout!".utf8)
-        let iovecs = memory.writeIOVecs([writeData])
+            let memory = TestSupport.TestGuestMemory()
+            let writeData = Array("Hello, stdout!".utf8)
+            let iovecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: 1, ioVectors: iovecs, memory: memory)
-        #expect(nwritten == UInt32(writeData.count))
+            let nwritten = try wasi.fd_write(fileDescriptor: 1, ioVectors: iovecs, memory: memory)
+            #expect(nwritten == UInt32(writeData.count))
         }
     }
 
@@ -1281,14 +1281,14 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let memory = TestSupport.TestGuestMemory()
-        let writeData = Array("Error message".utf8)
-        let iovecs = memory.writeIOVecs([writeData])
+            let memory = TestSupport.TestGuestMemory()
+            let writeData = Array("Error message".utf8)
+            let iovecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: 2, ioVectors: iovecs, memory: memory)
-        #expect(nwritten == UInt32(writeData.count))
+            let nwritten = try wasi.fd_write(fileDescriptor: 2, ioVectors: iovecs, memory: memory)
+            #expect(nwritten == UInt32(writeData.count))
         }
     }
 
@@ -1302,18 +1302,18 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let memory = TestSupport.TestGuestMemory()
-        let writeData = Array("Should fail".utf8)
-        let iovecs = memory.writeIOVecs([writeData])
+            let memory = TestSupport.TestGuestMemory()
+            let writeData = Array("Should fail".utf8)
+            let iovecs = memory.writeIOVecs([writeData])
 
-        do {
-            _ = try wasi.fd_write(fileDescriptor: 0, ioVectors: iovecs, memory: memory)
-            #expect(Bool(false), "Should not be able to write to stdin")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .EBADF)
-        }
+            do {
+                _ = try wasi.fd_write(fileDescriptor: 0, ioVectors: iovecs, memory: memory)
+                #expect(Bool(false), "Should not be able to write to stdin")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .EBADF)
+            }
         }
     }
 
@@ -1327,17 +1327,17 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let memory = TestSupport.TestGuestMemory()
-        let iovecs = memory.readIOVecs(sizes: [10])
+            let memory = TestSupport.TestGuestMemory()
+            let iovecs = memory.readIOVecs(sizes: [10])
 
-        do {
-            _ = try wasi.fd_read(fd: 1, iovs: iovecs, memory: memory)
-            #expect(Bool(false), "Should not be able to read from stdout")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .EBADF)
-        }
+            do {
+                _ = try wasi.fd_read(fd: 1, iovs: iovecs, memory: memory)
+                #expect(Bool(false), "Should not be able to read from stdout")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .EBADF)
+            }
         }
     }
 
@@ -1351,17 +1351,17 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
+            let wasi = bridge.underlying
 
-        let memory = TestSupport.TestGuestMemory()
-        let iovecs = memory.readIOVecs(sizes: [10])
+            let memory = TestSupport.TestGuestMemory()
+            let iovecs = memory.readIOVecs(sizes: [10])
 
-        do {
-            _ = try wasi.fd_read(fd: 2, iovs: iovecs, memory: memory)
-            #expect(Bool(false), "Should not be able to read from stderr")
-        } catch let error as WASIAbi.Errno {
-            #expect(error == .EBADF)
-        }
+            do {
+                _ = try wasi.fd_read(fd: 2, iovs: iovecs, memory: memory)
+                #expect(Bool(false), "Should not be able to read from stderr")
+            } catch let error as WASIAbi.Errno {
+                #expect(error == .EBADF)
+            }
         }
     }
 
@@ -1377,39 +1377,39 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let stat1 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
-        #expect(stat1.atim > 0)
-        #expect(stat1.mtim > 0)
-        #expect(stat1.ctim > 0)
+            let stat1 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
+            #expect(stat1.atim > 0)
+            #expect(stat1.mtim > 0)
+            #expect(stat1.ctim > 0)
 
-        let fd = try wasi.path_open(
-            dirFd: rootFd,
-            dirFlags: [],
-            path: "file.txt",
-            oflags: [],
-            fsRightsBase: [.FD_READ, .FD_WRITE],
-            fsRightsInheriting: [],
-            fdflags: []
-        )
+            let fd = try wasi.path_open(
+                dirFd: rootFd,
+                dirFlags: [],
+                path: "file.txt",
+                oflags: [],
+                fsRightsBase: [.FD_READ, .FD_WRITE],
+                fsRightsInheriting: [],
+                fdflags: []
+            )
 
-        let memory = TestSupport.TestGuestMemory()
-        let readVecs = memory.readIOVecs(sizes: [4])
-        _ = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
+            let memory = TestSupport.TestGuestMemory()
+            let readVecs = memory.readIOVecs(sizes: [4])
+            _ = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
 
-        let stat2 = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat2.atim >= stat1.atim)
+            let stat2 = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat2.atim >= stat1.atim)
 
-        let writeData = Array("more".utf8)
-        let writeVecs = memory.writeIOVecs([writeData])
-        _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
+            let writeData = Array("more".utf8)
+            let writeVecs = memory.writeIOVecs([writeData])
+            _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
 
-        let stat3 = try wasi.fd_filestat_get(fd: fd)
-        #expect(stat3.mtim >= stat2.mtim)
+            let stat3 = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat3.mtim >= stat2.mtim)
 
-        try wasi.fd_close(fd: fd)
+            try wasi.fd_close(fd: fd)
         }
     }
 
@@ -1424,19 +1424,19 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        try wasi.path_create_directory(dirFd: rootFd, path: "testdir")
+            try wasi.path_create_directory(dirFd: rootFd, path: "testdir")
 
-        let stat1 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "testdir")
-        #expect(stat1.atim > 0)
-        #expect(stat1.mtim > 0)
+            let stat1 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "testdir")
+            #expect(stat1.atim > 0)
+            #expect(stat1.mtim > 0)
 
-        try fs.addFile(at: "/testdir/file.txt", content: [])
+            try fs.addFile(at: "/testdir/file.txt", content: [])
 
-        let stat2 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "testdir")
-        #expect(stat2.mtim >= stat1.mtim)
+            let stat2 = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "testdir")
+            #expect(stat2.mtim >= stat1.mtim)
         }
     }
 
@@ -1452,23 +1452,23 @@ struct WASITests {
             ])
         )
         try bridge.runAndClose { _ in
-        let wasi = bridge.underlying
-        let rootFd: WASIAbi.Fd = 3
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
 
-        let specificTime: WASIAbi.Timestamp = 1_000_000_000_000_000_000
+            let specificTime: WASIAbi.Timestamp = 1_000_000_000_000_000_000
 
-        try wasi.path_filestat_set_times(
-            dirFd: rootFd,
-            flags: [],
-            path: "file.txt",
-            atim: specificTime,
-            mtim: specificTime,
-            fstFlags: [.ATIM, .MTIM]
-        )
+            try wasi.path_filestat_set_times(
+                dirFd: rootFd,
+                flags: [],
+                path: "file.txt",
+                atim: specificTime,
+                mtim: specificTime,
+                fstFlags: [.ATIM, .MTIM]
+            )
 
-        let stat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
-        #expect(stat.atim == specificTime)
-        #expect(stat.mtim == specificTime)
+            let stat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "file.txt")
+            #expect(stat.atim == specificTime)
+            #expect(stat.mtim == specificTime)
         }
     }
 
@@ -1488,18 +1488,18 @@ struct WASITests {
                 ])
             )
             try bridge.runAndClose { _ in
-            let wasi = bridge.underlying
-            let preopenFd: WASIAbi.Fd = 3
+                let wasi = bridge.underlying
+                let preopenFd: WASIAbi.Fd = 3
 
-            let memory = TestSupport.TestGuestMemory()
-            let buffer = UnsafeGuestBufferPointer<UInt8>(
-                baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
-                count: 4096
-            )
+                let memory = TestSupport.TestGuestMemory()
+                let buffer = UnsafeGuestBufferPointer<UInt8>(
+                    baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
+                    count: 4096
+                )
 
-            // Without the noFollow fix, this throws ELOOP due to the cyclic symlink
-            let nwritten = try wasi.fd_readdir(fd: preopenFd, buffer: buffer, cookie: 0, memory: memory)
-            #expect(nwritten > 0)
+                // Without the noFollow fix, this throws ELOOP due to the cyclic symlink
+                let nwritten = try wasi.fd_readdir(fd: preopenFd, buffer: buffer, cookie: 0, memory: memory)
+                #expect(nwritten > 0)
             }
         }
     #endif
@@ -1516,25 +1516,25 @@ struct WASITests {
                 ])
             )
             try bridge.runAndClose { _ in
-            let wasi = bridge.underlying
-            let preopenFd: WASIAbi.Fd = 3
+                let wasi = bridge.underlying
+                let preopenFd: WASIAbi.Fd = 3
 
-            // Open "." relative to the preopen — should get an independent fd
-            let dotFd = try wasi.path_open(
-                dirFd: preopenFd, dirFlags: [], path: ".",
-                oflags: [.DIRECTORY], fsRightsBase: [.FD_READ],
-                fsRightsInheriting: [], fdflags: []
-            )
-            #expect(dotFd != preopenFd, "path_open should return a new WASI fd")
+                // Open "." relative to the preopen — should get an independent fd
+                let dotFd = try wasi.path_open(
+                    dirFd: preopenFd, dirFlags: [], path: ".",
+                    oflags: [.DIRECTORY], fsRightsBase: [.FD_READ],
+                    fsRightsInheriting: [], fdflags: []
+                )
+                #expect(dotFd != preopenFd, "path_open should return a new WASI fd")
 
-            // Close the "." fd
-            try wasi.fd_close(fd: dotFd)
+                // Close the "." fd
+                try wasi.fd_close(fd: dotFd)
 
-            // The preopen must still be fully functional after closing the "." fd
-            let stat = try wasi.path_filestat_get(
-                dirFd: preopenFd, flags: [], path: "hello.txt"
-            )
-            #expect(stat.size == 5, "preopen should still read files after closing '.' fd")
+                // The preopen must still be fully functional after closing the "." fd
+                let stat = try wasi.path_filestat_get(
+                    dirFd: preopenFd, flags: [], path: "hello.txt"
+                )
+                #expect(stat.size == 5, "preopen should still read files after closing '.' fd")
             }
         }
     #endif
@@ -1589,46 +1589,46 @@ struct WASITests {
                 ])
             )
             try bridge.runAndClose { _ in
-            let wasi = bridge.underlying
-            let dir1Fd: WASIAbi.Fd = 3
-            let dir2Fd: WASIAbi.Fd = 4
+                let wasi = bridge.underlying
+                let dir1Fd: WASIAbi.Fd = 3
+                let dir2Fd: WASIAbi.Fd = 4
 
-            let memory = TestSupport.TestGuestMemory()
-            let buffer = UnsafeGuestBufferPointer<UInt8>(
-                baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
-                count: 4096
-            )
-            let writeData = Array("hello".utf8)
-            let writeVecs = memory.writeIOVecs([writeData])
-
-            for _ in 0..<1000 {
-                let fd = try wasi.path_open(
-                    dirFd: dir1Fd,
-                    dirFlags: [],
-                    path: "foo/bar",
-                    oflags: [.CREAT],
-                    fsRightsBase: [.FD_WRITE],
-                    fsRightsInheriting: [],
-                    fdflags: []
+                let memory = TestSupport.TestGuestMemory()
+                let buffer = UnsafeGuestBufferPointer<UInt8>(
+                    baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
+                    count: 4096
                 )
-                #expect(try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory) > 0)
-                try wasi.fd_close(fd: fd)
+                let writeData = Array("hello".utf8)
+                let writeVecs = memory.writeIOVecs([writeData])
 
-                try wasi.path_rename(oldFd: dir1Fd, oldPath: "foo/bar", newFd: dir2Fd, newPath: "foo/baz")
+                for _ in 0..<1000 {
+                    let fd = try wasi.path_open(
+                        dirFd: dir1Fd,
+                        dirFlags: [],
+                        path: "foo/bar",
+                        oflags: [.CREAT],
+                        fsRightsBase: [.FD_WRITE],
+                        fsRightsInheriting: [],
+                        fdflags: []
+                    )
+                    #expect(try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory) > 0)
+                    try wasi.fd_close(fd: fd)
 
-                try wasi.path_symlink(oldPath: "baz", dirFd: dir2Fd, newPath: "foo/quux")
-                let stat = try wasi.path_filestat_get(dirFd: dir2Fd, flags: .SYMLINK_FOLLOW, path: "foo/quux")
-                #expect(stat.size == 5)  // hello
-                let count = try Int(wasi.path_readlink(fd: dir2Fd, path: "foo/quux", buffer: buffer, memory: memory))
-                buffer.withHostPointer(in: memory) { ptr in
-                    #expect(String(decoding: ptr[..<count], as: UTF8.self) == "baz")
+                    try wasi.path_rename(oldFd: dir1Fd, oldPath: "foo/bar", newFd: dir2Fd, newPath: "foo/baz")
+
+                    try wasi.path_symlink(oldPath: "baz", dirFd: dir2Fd, newPath: "foo/quux")
+                    let stat = try wasi.path_filestat_get(dirFd: dir2Fd, flags: .SYMLINK_FOLLOW, path: "foo/quux")
+                    #expect(stat.size == 5)  // hello
+                    let count = try Int(wasi.path_readlink(fd: dir2Fd, path: "foo/quux", buffer: buffer, memory: memory))
+                    buffer.withHostPointer(in: memory) { ptr in
+                        #expect(String(decoding: ptr[..<count], as: UTF8.self) == "baz")
+                    }
+                    try wasi.path_unlink_file(dirFd: dir2Fd, path: "foo/baz")
+                    try wasi.path_unlink_file(dirFd: dir2Fd, path: "foo/quux")
+
+                    try wasi.path_create_directory(dirFd: dir1Fd, path: "foo/bar")
+                    try wasi.path_remove_directory(dirFd: dir1Fd, path: "foo/bar")
                 }
-                try wasi.path_unlink_file(dirFd: dir2Fd, path: "foo/baz")
-                try wasi.path_unlink_file(dirFd: dir2Fd, path: "foo/quux")
-
-                try wasi.path_create_directory(dirFd: dir1Fd, path: "foo/bar")
-                try wasi.path_remove_directory(dirFd: dir1Fd, path: "foo/bar")
-            }
             }
         }
     #endif

--- a/Tests/WITOverlayGeneratorTests/Runtime/RuntimeTestHarness.swift
+++ b/Tests/WITOverlayGeneratorTests/Runtime/RuntimeTestHarness.swift
@@ -144,14 +144,15 @@ struct RuntimeTestHarness {
             let store = Store(engine: engine)
 
             let wasi = try WASIBridgeToHost(args: [compiled.path])
-            var imports = Imports()
-            wasi.link(to: &imports, store: store)
-            link(&imports, store)
+            try wasi.runAndClose { wasi in
+                var imports = Imports()
+                wasi.link(to: &imports, store: store)
+                link(&imports, store)
 
-            let module = try parseWasm(filePath: .init(compiled.path))
-            let instance = try module.instantiate(store: store, imports: imports)
-            try run(instance)
-            try wasi.close()
+                let module = try parseWasm(filePath: .init(compiled.path))
+                let instance = try module.instantiate(store: store, imports: imports)
+                try run(instance)
+            }
         }
     }
 

--- a/Tests/WITOverlayGeneratorTests/Runtime/RuntimeTestHarness.swift
+++ b/Tests/WITOverlayGeneratorTests/Runtime/RuntimeTestHarness.swift
@@ -151,6 +151,7 @@ struct RuntimeTestHarness {
             let module = try parseWasm(filePath: .init(compiled.path))
             let instance = try module.instantiate(store: store, imports: imports)
             try run(instance)
+            try wasi.close()
         }
     }
 


### PR DESCRIPTION
`PathResolution.resolve()` returned the input fd unchanged for "." paths, causing fd table entries to alias the same host fd. Closing one invalidated the other, which errored with EBADF.

Multiple related fixes are included to clean up the general situation with FD handling in WASIp1 implementation:

- Fix fd aliasing in `PathResolution.resolve()`: When the path resolves without opening a new fd (e.g. "."), dup via `openat(fd, ".")` so callers always get an independently closeable fd.
- Fix `SplitPath` premature deinit: Use `borrowing func withFields` to keep `SplitPath: ~Copyable` alive during operations that use its parent fd.
- Add `WASIBridgeToHost.runAndClose`: Scoped API that ensures `close()` is called, replacing the previous `deinit`-based cleanup.
- Add `isBorrowed` to `WASIEntry`: Stdio entries are marked as borrowed so `closeAll()` never closes process stdin/stdout/stderr (previously broken when `fd_renumber` moved stdio to different WASI fd positions).
- Fix `directoryEntry(fd:)` error codes: Return `EBADF` for missing fds, `ENOTDIR` for non-directory fds (was `ENOTDIR` for both).

I ran tests locally 10 times in a row and on CI 5 times in a row on this PR, no failures, I think this is sufficient to say that flakiness is resolved.

Resolves https://github.com/swiftwasm/WasmKit/issues/334.