### PR TITLE
Add DWARF line table parser for source-level backtraces

### DIFF
--- a/Sources/WasmKit/CMakeLists.txt
+++ b/Sources/WasmKit/CMakeLists.txt
@@ -14,6 +14,7 @@ add_wasmkit_library(WasmKit
   Component/ComponentTypes.swift
   Execution/AtomicParkingLot.swift
   Execution/DebuggerInstructionMapping.swift
+  Execution/DWARFLineTable.swift
   Execution/Instructions/Control.swift
   Execution/Instructions/Instruction.swift
   Execution/Instructions/Table.swift

--- a/Sources/WasmKit/Execution/DWARFLineTable.swift
+++ b/Sources/WasmKit/Execution/DWARFLineTable.swift
@@ -716,14 +716,15 @@ private struct Cursor {
 
     mutating func readU64() throws -> UInt64 {
         guard offset + 8 <= data.endIndex else { throw DWARFError.unexpectedEnd }
-        let value = UInt64(data[offset])
-            | (UInt64(data[offset + 1]) << 8)
-            | (UInt64(data[offset + 2]) << 16)
-            | (UInt64(data[offset + 3]) << 24)
-            | (UInt64(data[offset + 4]) << 32)
-            | (UInt64(data[offset + 5]) << 40)
-            | (UInt64(data[offset + 6]) << 48)
-            | (UInt64(data[offset + 7]) << 56)
+        let b0 = UInt64(data[offset])
+        let b1 = UInt64(data[offset + 1]) << 8
+        let b2 = UInt64(data[offset + 2]) << 16
+        let b3 = UInt64(data[offset + 3]) << 24
+        let b4 = UInt64(data[offset + 4]) << 32
+        let b5 = UInt64(data[offset + 5]) << 40
+        let b6 = UInt64(data[offset + 6]) << 48
+        let b7 = UInt64(data[offset + 7]) << 56
+        let value = b0 | b1 | b2 | b3 | b4 | b5 | b6 | b7
         offset += 8
         return value
     }

--- a/Sources/WasmKit/Execution/DWARFLineTable.swift
+++ b/Sources/WasmKit/Execution/DWARFLineTable.swift
@@ -127,7 +127,7 @@ public final class DWARFLineTable {
 
         // If .debug_info is available, build CU → address range mappings
         if let debugInfo = sections.debugInfo,
-           let debugAbbrev = sections.debugAbbrev
+            let debugAbbrev = sections.debugAbbrev
         {
             let cuEntries = try Self.parseCUEntries(
                 debugInfo: debugInfo,
@@ -152,13 +152,14 @@ public final class DWARFLineTable {
                 let fileBase = allFiles.count
                 allFiles.append(contentsOf: lt.files)
                 for row in lt.rows {
-                    allRows.append(Row(
-                        address: row.address,
-                        fileIndex: UInt(fileBase) + row.fileIndex,
-                        line: row.line,
-                        column: row.column,
-                        isEndSequence: row.isEndSequence
-                    ))
+                    allRows.append(
+                        Row(
+                            address: row.address,
+                            fileIndex: UInt(fileBase) + row.fileIndex,
+                            line: row.line,
+                            column: row.column,
+                            isEndSequence: row.isEndSequence
+                        ))
                 }
             }
             fallbackTable = CULineTable(files: allFiles, rows: allRows.sorted())
@@ -231,8 +232,8 @@ public final class DWARFLineTable {
         }
 
         if version == 5 {
-            _ = try cursor.readU8() // address_size
-            _ = try cursor.readU8() // segment_selector_size
+            _ = try cursor.readU8()  // address_size
+            _ = try cursor.readU8()  // segment_selector_size
         }
 
         let prologueLength = try cursor.readU32()
@@ -240,7 +241,7 @@ public final class DWARFLineTable {
 
         let minInstructionLength = try cursor.readU8()
         if version >= 4 {
-            _ = try cursor.readU8() // max_operations_per_instruction
+            _ = try cursor.readU8()  // max_operations_per_instruction
         }
         let defaultIsStmt = try cursor.readU8() != 0
         let lineBase = Int8(bitPattern: try cursor.readU8())
@@ -265,8 +266,8 @@ public final class DWARFLineTable {
                 let name = try cursor.readNullTerminatedString()
                 if name.isEmpty { break }
                 let dirIndex = try cursor.readULEB128()
-                _ = try cursor.readULEB128() // mod_time
-                _ = try cursor.readULEB128() // length
+                _ = try cursor.readULEB128()  // mod_time
+                _ = try cursor.readULEB128()  // length
                 let dir = dirIndex < directories.count ? directories[Int(dirIndex)] : ""
                 if dir.isEmpty || name.hasPrefix("/") {
                     files.append(name)
@@ -297,16 +298,20 @@ public final class DWARFLineTable {
                 let extEnd = cursor.offset + Int(length)
                 let extOpcode = try cursor.readU8()
                 switch extOpcode {
-                case 1: // DW_LNE_end_sequence
+                case 1:  // DW_LNE_end_sequence
                     rows.append(Row(address: address, fileIndex: file, line: line, column: column, isEndSequence: true))
-                    address = 0; file = 1; line = 1; column = 0; isStmt = defaultIsStmt
-                case 2: // DW_LNE_set_address
+                    address = 0
+                    file = 1
+                    line = 1
+                    column = 0
+                    isStmt = defaultIsStmt
+                case 2:  // DW_LNE_set_address
                     if extEnd - cursor.offset >= 8 {
                         address = try cursor.readU64()
                     } else {
                         address = UInt64(try cursor.readU32())
                     }
-                case 4: _ = try cursor.readULEB128() // DW_LNE_set_discriminator
+                case 4: _ = try cursor.readULEB128()  // DW_LNE_set_discriminator
                 default: break
                 }
                 cursor.seek(to: extEnd)
@@ -371,7 +376,7 @@ public final class DWARFLineTable {
             let addressSize: UInt8
 
             if version == 5 {
-                _ = try cursor.readU8() // unit_type
+                _ = try cursor.readU8()  // unit_type
                 addressSize = try cursor.readU8()
                 abbrevOffset = Int(try cursor.readU32())
             } else {
@@ -399,14 +404,14 @@ public final class DWARFLineTable {
             for (attr, form) in abbrev.attributes {
                 let value = try readAttributeValue(&cursor, form: form, addressSize: addressSize)
                 switch attr {
-                case 0x10: // DW_AT_stmt_list
+                case 0x10:  // DW_AT_stmt_list
                     stmtList = value.asInt
-                case 0x11: // DW_AT_low_pc
+                case 0x11:  // DW_AT_low_pc
                     lowPC = value.asUInt64
-                case 0x12: // DW_AT_high_pc
+                case 0x12:  // DW_AT_high_pc
                     highPC = value.asUInt64
-                    highPCIsOffset = form == 0x0b || form == 0x05 || form == 0x06 || form == 0x07 || form == 0x0f // data forms
-                case 0x55: // DW_AT_ranges
+                    highPCIsOffset = form == 0x0b || form == 0x05 || form == 0x06 || form == 0x07 || form == 0x0f  // data forms
+                case 0x55:  // DW_AT_ranges
                     rangesOffset = value.asInt
                 default:
                     break
@@ -458,7 +463,7 @@ public final class DWARFLineTable {
             if code == 0 { break }
 
             let tag = try cursor.readULEB128()
-            _ = try cursor.readU8() // children flag
+            _ = try cursor.readU8()  // children flag
 
             var attributes: [(attr: UInt, form: UInt)] = []
             while true {
@@ -496,66 +501,66 @@ public final class DWARFLineTable {
 
     private static func readAttributeValue(_ cursor: inout Cursor, form: UInt, addressSize: UInt8) throws -> AttributeValue {
         switch form {
-        case 0x01: // DW_FORM_addr
+        case 0x01:  // DW_FORM_addr
             if addressSize == 8 { return .uint64(try cursor.readU64()) }
             return .uint64(UInt64(try cursor.readU32()))
-        case 0x03: // DW_FORM_block2
+        case 0x03:  // DW_FORM_block2
             let len = try cursor.readU16()
             cursor.seek(to: cursor.offset + Int(len))
             return .skipped
-        case 0x04: // DW_FORM_block4
+        case 0x04:  // DW_FORM_block4
             let len = try cursor.readU32()
             cursor.seek(to: cursor.offset + Int(len))
             return .skipped
-        case 0x05: // DW_FORM_data2
+        case 0x05:  // DW_FORM_data2
             return .int(Int(try cursor.readU16()))
-        case 0x06: // DW_FORM_data4
+        case 0x06:  // DW_FORM_data4
             return .int(Int(try cursor.readU32()))
-        case 0x07: // DW_FORM_data8
+        case 0x07:  // DW_FORM_data8
             return .uint64(try cursor.readU64())
-        case 0x08: // DW_FORM_string
+        case 0x08:  // DW_FORM_string
             _ = try cursor.readNullTerminatedString()
             return .skipped
-        case 0x09: // DW_FORM_block
+        case 0x09:  // DW_FORM_block
             let len = try cursor.readULEB128()
             cursor.seek(to: cursor.offset + Int(len))
             return .skipped
-        case 0x0a: // DW_FORM_block1
+        case 0x0a:  // DW_FORM_block1
             let len = try cursor.readU8()
             cursor.seek(to: cursor.offset + Int(len))
             return .skipped
-        case 0x0b: // DW_FORM_data1
+        case 0x0b:  // DW_FORM_data1
             return .int(Int(try cursor.readU8()))
-        case 0x0c: // DW_FORM_flag
+        case 0x0c:  // DW_FORM_flag
             return .int(Int(try cursor.readU8()))
-        case 0x0d: // DW_FORM_sdata
+        case 0x0d:  // DW_FORM_sdata
             return .int(Int(try cursor.readSLEB128()))
-        case 0x0e: // DW_FORM_strp
+        case 0x0e:  // DW_FORM_strp
             return .int(Int(try cursor.readU32()))
-        case 0x0f: // DW_FORM_udata
+        case 0x0f:  // DW_FORM_udata
             return .uint64(try cursor.readULEB128())
-        case 0x10: // DW_FORM_ref_addr
+        case 0x10:  // DW_FORM_ref_addr
             if addressSize == 8 { _ = try cursor.readU64() } else { _ = try cursor.readU32() }
             return .skipped
-        case 0x11: // DW_FORM_ref1
+        case 0x11:  // DW_FORM_ref1
             return .int(Int(try cursor.readU8()))
-        case 0x12: // DW_FORM_ref2
+        case 0x12:  // DW_FORM_ref2
             return .int(Int(try cursor.readU16()))
-        case 0x13: // DW_FORM_ref4
+        case 0x13:  // DW_FORM_ref4
             return .int(Int(try cursor.readU32()))
-        case 0x14: // DW_FORM_ref8
+        case 0x14:  // DW_FORM_ref8
             return .uint64(try cursor.readU64())
-        case 0x15: // DW_FORM_ref_udata
+        case 0x15:  // DW_FORM_ref_udata
             return .uint64(try cursor.readULEB128())
-        case 0x17: // DW_FORM_sec_offset
+        case 0x17:  // DW_FORM_sec_offset
             return .int(Int(try cursor.readU32()))
-        case 0x18: // DW_FORM_exprloc
+        case 0x18:  // DW_FORM_exprloc
             let len = try cursor.readULEB128()
             cursor.seek(to: cursor.offset + Int(len))
             return .skipped
-        case 0x19: // DW_FORM_flag_present
+        case 0x19:  // DW_FORM_flag_present
             return .int(1)
-        case 0x20: // DW_FORM_ref_sig8
+        case 0x20:  // DW_FORM_ref_sig8
             _ = try cursor.readU64()
             return .skipped
         default:
@@ -580,11 +585,11 @@ public final class DWARFLineTable {
 
         while cursor.hasMore {
             guard let start = try? (addressSize == 8 ? cursor.readU64() : UInt64(cursor.readU32())),
-                  let end = try? (addressSize == 8 ? cursor.readU64() : UInt64(cursor.readU32()))
+                let end = try? (addressSize == 8 ? cursor.readU64() : UInt64(cursor.readU32()))
             else { break }
 
-            if start == 0 && end == 0 { break } // End of list
-            if start == maxAddr { // Base address selection
+            if start == 0 && end == 0 { break }  // End of list
+            if start == maxAddr {  // Base address selection
                 base = end
                 continue
             }
@@ -644,7 +649,9 @@ public final class DWARFLineTable {
     private static func readLineFormValue(_ cursor: inout Cursor, form: UInt) throws -> String {
         switch form {
         case 0x08: return try cursor.readNullTerminatedString()
-        case 0x0e, 0x1f: _ = try cursor.readU32(); return ""
+        case 0x0e, 0x1f:
+            _ = try cursor.readU32()
+            return ""
         case 0x0b: return String(try cursor.readU8())
         case 0x05: return String(try cursor.readU16())
         case 0x06: return String(try cursor.readU32())
@@ -706,7 +713,8 @@ private struct Cursor {
 
     mutating func readU32() throws -> UInt32 {
         guard offset + 4 <= data.endIndex else { throw DWARFError.unexpectedEnd }
-        let value = UInt32(data[offset])
+        let value =
+            UInt32(data[offset])
             | (UInt32(data[offset + 1]) << 8)
             | (UInt32(data[offset + 2]) << 16)
             | (UInt32(data[offset + 3]) << 24)

--- a/Sources/WasmKit/Execution/DWARFLineTable.swift
+++ b/Sources/WasmKit/Execution/DWARFLineTable.swift
@@ -1,0 +1,772 @@
+/// A minimal DWARF debug info parser for resolving code addresses to source locations.
+///
+/// When `.debug_info`, `.debug_abbrev`, and `.debug_ranges` sections are available,
+/// uses CU address ranges to determine which compilation unit owns each address,
+/// ensuring correct file attribution even when multiple CUs cover overlapping ranges.
+///
+/// Reference: DWARF v4 spec §6.2, §7.5
+public final class DWARFLineTable {
+
+    /// A source location resolved from the line table.
+    public struct SourceLocation: Sendable, CustomStringConvertible {
+        public let file: String
+        public let line: UInt
+        public let column: UInt
+
+        public var description: String {
+            if column > 0 {
+                return "\(file):\(line):\(column)"
+            }
+            return "\(file):\(line)"
+        }
+    }
+
+    /// All DWARF sections needed for full resolution.
+    public struct Sections {
+        public let debugLine: ArraySlice<UInt8>
+        public let debugInfo: ArraySlice<UInt8>?
+        public let debugAbbrev: ArraySlice<UInt8>?
+        public let debugRanges: ArraySlice<UInt8>?
+
+        public init(
+            debugLine: ArraySlice<UInt8>,
+            debugInfo: ArraySlice<UInt8>? = nil,
+            debugAbbrev: ArraySlice<UInt8>? = nil,
+            debugRanges: ArraySlice<UInt8>? = nil
+        ) {
+            self.debugLine = debugLine
+            self.debugInfo = debugInfo
+            self.debugAbbrev = debugAbbrev
+            self.debugRanges = debugRanges
+        }
+    }
+
+    /// A per-CU line table with its own file table and sorted rows.
+    private struct CULineTable {
+        let files: [String]
+        let rows: [Row]
+
+        func lookup(address: UInt64) -> SourceLocation? {
+            var lo = 0
+            var hi = rows.count
+            while lo < hi {
+                let mid = lo + (hi - lo) / 2
+                if rows[mid].address <= address {
+                    lo = mid + 1
+                } else {
+                    hi = mid
+                }
+            }
+            var index = lo - 1
+            while index >= 0 {
+                let row = rows[index]
+                if row.isEndSequence {
+                    if address >= row.address { return nil }
+                    index -= 1
+                    continue
+                }
+                if row.line == 0 {
+                    index -= 1
+                    continue
+                }
+                let fileIndex = Int(row.fileIndex)
+                guard fileIndex >= 0 && fileIndex < files.count else { return nil }
+                let file = files[fileIndex]
+                if file.isEmpty { return nil }
+                return SourceLocation(file: file, line: row.line, column: row.column)
+            }
+            return nil
+        }
+    }
+
+    /// A single row emitted by the line number program state machine.
+    private struct Row: Comparable {
+        let address: UInt64
+        let fileIndex: UInt
+        let line: UInt
+        let column: UInt
+        let isEndSequence: Bool
+
+        static func < (lhs: Row, rhs: Row) -> Bool {
+            lhs.address < rhs.address
+        }
+    }
+
+    /// CU address range → line table index mapping.
+    /// Sorted by range start for binary search.
+    private struct CURangeEntry: Comparable {
+        let start: UInt64
+        let end: UInt64
+        let lineTableIndex: Int
+
+        static func < (lhs: CURangeEntry, rhs: CURangeEntry) -> Bool {
+            lhs.start < rhs.start
+        }
+    }
+
+    /// Per-CU line tables, keyed by their offset in .debug_line.
+    private var lineTablesByOffset: [Int: CULineTable] = [:]
+    /// CU range entries for address → CU resolution. Sorted by start address.
+    private var cuRanges: [CURangeEntry] = []
+    /// Flat line tables indexed for cuRanges lookup.
+    private var lineTables: [CULineTable] = []
+    /// Fallback flat table when .debug_info is not available.
+    private var fallbackTable: CULineTable?
+
+    /// Initialize with all available DWARF sections for accurate CU-aware resolution.
+    public init(sections: Sections) throws {
+        let debugLine = sections.debugLine
+
+        // Parse all line tables from .debug_line, keyed by their offset
+        var cursor = Cursor(data: debugLine)
+        while cursor.hasMore {
+            let tableOffset = cursor.offset - debugLine.startIndex
+            let (files, rows) = try Self.parseOneLineTable(&cursor)
+            lineTablesByOffset[tableOffset] = CULineTable(files: files, rows: rows.sorted())
+        }
+
+        // If .debug_info is available, build CU → address range mappings
+        if let debugInfo = sections.debugInfo,
+           let debugAbbrev = sections.debugAbbrev
+        {
+            let cuEntries = try Self.parseCUEntries(
+                debugInfo: debugInfo,
+                debugAbbrev: debugAbbrev,
+                debugRanges: sections.debugRanges
+            )
+
+            for entry in cuEntries {
+                guard let lt = lineTablesByOffset[entry.stmtList] else { continue }
+                let ltIndex = lineTables.count
+                lineTables.append(lt)
+                for range in entry.ranges {
+                    cuRanges.append(CURangeEntry(start: range.start, end: range.end, lineTableIndex: ltIndex))
+                }
+            }
+            cuRanges.sort()
+        } else {
+            // No .debug_info — merge all line tables into a flat fallback
+            var allFiles: [String] = []
+            var allRows: [Row] = []
+            for (_, lt) in lineTablesByOffset.sorted(by: { $0.key < $1.key }) {
+                let fileBase = allFiles.count
+                allFiles.append(contentsOf: lt.files)
+                for row in lt.rows {
+                    allRows.append(Row(
+                        address: row.address,
+                        fileIndex: UInt(fileBase) + row.fileIndex,
+                        line: row.line,
+                        column: row.column,
+                        isEndSequence: row.isEndSequence
+                    ))
+                }
+            }
+            fallbackTable = CULineTable(files: allFiles, rows: allRows.sorted())
+        }
+    }
+
+    /// Convenience initializer for .debug_line only (no CU-aware resolution).
+    public convenience init(data: ArraySlice<UInt8>) throws {
+        try self.init(sections: Sections(debugLine: data))
+    }
+
+    /// Offset to subtract from file-level byte offsets to get DWARF code addresses.
+    /// DWARF addresses in WASM are relative to the Code section content start,
+    /// while Code.offset values are file-level byte offsets.
+    public var codeSectionOffset: Int = 0
+
+    /// Look up the source location for a given file-level code offset.
+    /// Automatically adjusts for the code section base offset.
+    public func lookup(fileOffset: Int) -> SourceLocation? {
+        let dwarfAddress = fileOffset - codeSectionOffset
+        guard dwarfAddress >= 0 else { return nil }
+        return lookup(address: UInt64(dwarfAddress))
+    }
+
+    /// Look up the source location for a given code address.
+    public func lookup(address: UInt64) -> SourceLocation? {
+        // If we have CU ranges, find the owning CU
+        if !cuRanges.isEmpty {
+            // Binary search for the last range with start <= address
+            var lo = 0
+            var hi = cuRanges.count
+            while lo < hi {
+                let mid = lo + (hi - lo) / 2
+                if cuRanges[mid].start <= address {
+                    lo = mid + 1
+                } else {
+                    hi = mid
+                }
+            }
+            // Check ranges in reverse order (prefer later/more-specific CUs)
+            var index = lo - 1
+            while index >= 0 && cuRanges[index].start <= address {
+                let range = cuRanges[index]
+                if address < range.end {
+                    if let loc = lineTables[range.lineTableIndex].lookup(address: address) {
+                        return loc
+                    }
+                }
+                index -= 1
+            }
+            return nil
+        }
+
+        // Fallback: flat table
+        return fallbackTable?.lookup(address: address)
+    }
+
+    // MARK: - Parse one line table from .debug_line
+
+    private static func parseOneLineTable(_ cursor: inout Cursor) throws -> (files: [String], rows: [Row]) {
+        let unitLength = try cursor.readU32()
+        let unitEnd = cursor.offset + Int(unitLength)
+        guard unitEnd <= cursor.data.endIndex else {
+            throw DWARFError.unexpectedEnd
+        }
+
+        let version = try cursor.readU16()
+        guard version == 4 || version == 5 else {
+            throw DWARFError.unsupportedVersion(version)
+        }
+
+        if version == 5 {
+            _ = try cursor.readU8() // address_size
+            _ = try cursor.readU8() // segment_selector_size
+        }
+
+        let prologueLength = try cursor.readU32()
+        let prologueEnd = cursor.offset + Int(prologueLength)
+
+        let minInstructionLength = try cursor.readU8()
+        if version >= 4 {
+            _ = try cursor.readU8() // max_operations_per_instruction
+        }
+        let defaultIsStmt = try cursor.readU8() != 0
+        let lineBase = Int8(bitPattern: try cursor.readU8())
+        let lineRange = try cursor.readU8()
+        let opcodeBase = try cursor.readU8()
+
+        var standardOpcodeLengths: [UInt8] = []
+        for _ in 1..<opcodeBase {
+            standardOpcodeLengths.append(try cursor.readU8())
+        }
+
+        var files: [String]
+        if version < 5 {
+            var directories: [String] = [""]
+            while true {
+                let dir = try cursor.readNullTerminatedString()
+                if dir.isEmpty { break }
+                directories.append(dir)
+            }
+            files = [""]
+            while true {
+                let name = try cursor.readNullTerminatedString()
+                if name.isEmpty { break }
+                let dirIndex = try cursor.readULEB128()
+                _ = try cursor.readULEB128() // mod_time
+                _ = try cursor.readULEB128() // length
+                let dir = dirIndex < directories.count ? directories[Int(dirIndex)] : ""
+                if dir.isEmpty || name.hasPrefix("/") {
+                    files.append(name)
+                } else {
+                    files.append(dir + "/" + name)
+                }
+            }
+        } else {
+            let (_, v5files) = try parseV5FileTable(&cursor)
+            files = v5files
+        }
+
+        cursor.seek(to: prologueEnd)
+
+        // Execute line number program
+        var rows: [Row] = []
+        var address: UInt64 = 0
+        var file: UInt = 1
+        var line: UInt = 1
+        var column: UInt = 0
+        var isStmt = defaultIsStmt
+
+        while cursor.offset < unitEnd {
+            let opcode = try cursor.readU8()
+
+            if opcode == 0 {
+                let length = try cursor.readULEB128()
+                let extEnd = cursor.offset + Int(length)
+                let extOpcode = try cursor.readU8()
+                switch extOpcode {
+                case 1: // DW_LNE_end_sequence
+                    rows.append(Row(address: address, fileIndex: file, line: line, column: column, isEndSequence: true))
+                    address = 0; file = 1; line = 1; column = 0; isStmt = defaultIsStmt
+                case 2: // DW_LNE_set_address
+                    if extEnd - cursor.offset >= 8 {
+                        address = try cursor.readU64()
+                    } else {
+                        address = UInt64(try cursor.readU32())
+                    }
+                case 4: _ = try cursor.readULEB128() // DW_LNE_set_discriminator
+                default: break
+                }
+                cursor.seek(to: extEnd)
+            } else if opcode < opcodeBase {
+                switch opcode {
+                case 1: rows.append(Row(address: address, fileIndex: file, line: line, column: column, isEndSequence: false))
+                case 2: address += UInt64(try cursor.readULEB128()) * UInt64(minInstructionLength)
+                case 3: line = UInt(Int(line) + Int(try cursor.readSLEB128()))
+                case 4: file = UInt(try cursor.readULEB128())
+                case 5: column = UInt(try cursor.readULEB128())
+                case 6: isStmt = !isStmt
+                case 7: break
+                case 8:
+                    let adj = Int(255) - Int(opcodeBase)
+                    address += UInt64(adj / Int(lineRange)) * UInt64(minInstructionLength)
+                case 9: address += UInt64(try cursor.readU16())
+                case 10, 11: break
+                case 12: _ = try cursor.readULEB128()
+                default:
+                    let argCount = Int(opcode) - 1 < standardOpcodeLengths.count ? standardOpcodeLengths[Int(opcode) - 1] : 0
+                    for _ in 0..<argCount { _ = try cursor.readULEB128() }
+                }
+            } else {
+                let adjusted = Int(opcode) - Int(opcodeBase)
+                address += UInt64(adjusted / Int(lineRange)) * UInt64(minInstructionLength)
+                line = UInt(Int(line) + Int(lineBase) + (adjusted % Int(lineRange)))
+                rows.append(Row(address: address, fileIndex: file, line: line, column: column, isEndSequence: false))
+            }
+        }
+
+        cursor.seek(to: unitEnd)
+        return (files, rows)
+    }
+
+    // MARK: - Parse .debug_info CU entries
+
+    private struct CUEntry {
+        let stmtList: Int
+        let ranges: [(start: UInt64, end: UInt64)]
+    }
+
+    private static func parseCUEntries(
+        debugInfo: ArraySlice<UInt8>,
+        debugAbbrev: ArraySlice<UInt8>,
+        debugRanges: ArraySlice<UInt8>?
+    ) throws -> [CUEntry] {
+        var cursor = Cursor(data: debugInfo)
+        var results: [CUEntry] = []
+
+        while cursor.hasMore {
+            let unitLength = try cursor.readU32()
+            let unitEnd = cursor.offset + Int(unitLength)
+            guard unitEnd <= debugInfo.endIndex else { break }
+
+            let version = try cursor.readU16()
+            guard version == 4 || version == 5 else {
+                cursor.seek(to: unitEnd)
+                continue
+            }
+
+            let abbrevOffset: Int
+            let addressSize: UInt8
+
+            if version == 5 {
+                _ = try cursor.readU8() // unit_type
+                addressSize = try cursor.readU8()
+                abbrevOffset = Int(try cursor.readU32())
+            } else {
+                abbrevOffset = Int(try cursor.readU32())
+                addressSize = try cursor.readU8()
+            }
+
+            // Parse the abbreviation table for this CU
+            let abbrevTable = try parseAbbrevTable(debugAbbrev: debugAbbrev, offset: abbrevOffset)
+
+            // Read the first DIE (should be DW_TAG_compile_unit)
+            let abbrevCode = try cursor.readULEB128()
+            guard abbrevCode != 0, let abbrev = abbrevTable[UInt(abbrevCode)] else {
+                cursor.seek(to: unitEnd)
+                continue
+            }
+
+            // Extract attributes we care about
+            var stmtList: Int?
+            var lowPC: UInt64?
+            var highPC: UInt64?
+            var highPCIsOffset = false
+            var rangesOffset: Int?
+
+            for (attr, form) in abbrev.attributes {
+                let value = try readAttributeValue(&cursor, form: form, addressSize: addressSize)
+                switch attr {
+                case 0x10: // DW_AT_stmt_list
+                    stmtList = value.asInt
+                case 0x11: // DW_AT_low_pc
+                    lowPC = value.asUInt64
+                case 0x12: // DW_AT_high_pc
+                    highPC = value.asUInt64
+                    highPCIsOffset = form == 0x0b || form == 0x05 || form == 0x06 || form == 0x07 || form == 0x0f // data forms
+                case 0x55: // DW_AT_ranges
+                    rangesOffset = value.asInt
+                default:
+                    break
+                }
+            }
+
+            guard let stmtList else {
+                cursor.seek(to: unitEnd)
+                continue
+            }
+
+            var ranges: [(start: UInt64, end: UInt64)] = []
+
+            if let rangesOffset, let debugRanges {
+                // Parse .debug_ranges
+                ranges = parseRangeList(debugRanges: debugRanges, offset: rangesOffset, addressSize: addressSize, baseAddress: lowPC ?? 0)
+            } else if let lowPC, let highPC {
+                let actualHigh = highPCIsOffset ? lowPC + highPC : highPC
+                if actualHigh > lowPC {
+                    ranges = [(start: lowPC, end: actualHigh)]
+                }
+            }
+
+            if !ranges.isEmpty {
+                results.append(CUEntry(stmtList: stmtList, ranges: ranges))
+            }
+
+            cursor.seek(to: unitEnd)
+        }
+
+        return results
+    }
+
+    // MARK: - Abbreviation table parsing
+
+    private struct Abbreviation {
+        let tag: UInt
+        let attributes: [(attr: UInt, form: UInt)]
+    }
+
+    private static func parseAbbrevTable(debugAbbrev: ArraySlice<UInt8>, offset: Int) throws -> [UInt: Abbreviation] {
+        var cursor = Cursor(data: debugAbbrev)
+        cursor.seek(to: debugAbbrev.startIndex + offset)
+
+        var table: [UInt: Abbreviation] = [:]
+
+        while cursor.hasMore {
+            let code = try cursor.readULEB128()
+            if code == 0 { break }
+
+            let tag = try cursor.readULEB128()
+            _ = try cursor.readU8() // children flag
+
+            var attributes: [(attr: UInt, form: UInt)] = []
+            while true {
+                let attr = try cursor.readULEB128()
+                let form = try cursor.readULEB128()
+                if attr == 0 && form == 0 { break }
+                attributes.append((attr: UInt(attr), form: UInt(form)))
+            }
+
+            table[UInt(code)] = Abbreviation(tag: UInt(tag), attributes: attributes)
+        }
+
+        return table
+    }
+
+    // MARK: - Attribute value reading
+
+    private enum AttributeValue {
+        case uint64(UInt64)
+        case int(Int)
+        case skipped
+
+        var asUInt64: UInt64? {
+            if case .uint64(let v) = self { return v }
+            if case .int(let v) = self { return UInt64(v) }
+            return nil
+        }
+
+        var asInt: Int? {
+            if case .int(let v) = self { return v }
+            if case .uint64(let v) = self { return Int(v) }
+            return nil
+        }
+    }
+
+    private static func readAttributeValue(_ cursor: inout Cursor, form: UInt, addressSize: UInt8) throws -> AttributeValue {
+        switch form {
+        case 0x01: // DW_FORM_addr
+            if addressSize == 8 { return .uint64(try cursor.readU64()) }
+            return .uint64(UInt64(try cursor.readU32()))
+        case 0x03: // DW_FORM_block2
+            let len = try cursor.readU16()
+            cursor.seek(to: cursor.offset + Int(len))
+            return .skipped
+        case 0x04: // DW_FORM_block4
+            let len = try cursor.readU32()
+            cursor.seek(to: cursor.offset + Int(len))
+            return .skipped
+        case 0x05: // DW_FORM_data2
+            return .int(Int(try cursor.readU16()))
+        case 0x06: // DW_FORM_data4
+            return .int(Int(try cursor.readU32()))
+        case 0x07: // DW_FORM_data8
+            return .uint64(try cursor.readU64())
+        case 0x08: // DW_FORM_string
+            _ = try cursor.readNullTerminatedString()
+            return .skipped
+        case 0x09: // DW_FORM_block
+            let len = try cursor.readULEB128()
+            cursor.seek(to: cursor.offset + Int(len))
+            return .skipped
+        case 0x0a: // DW_FORM_block1
+            let len = try cursor.readU8()
+            cursor.seek(to: cursor.offset + Int(len))
+            return .skipped
+        case 0x0b: // DW_FORM_data1
+            return .int(Int(try cursor.readU8()))
+        case 0x0c: // DW_FORM_flag
+            return .int(Int(try cursor.readU8()))
+        case 0x0d: // DW_FORM_sdata
+            return .int(Int(try cursor.readSLEB128()))
+        case 0x0e: // DW_FORM_strp
+            return .int(Int(try cursor.readU32()))
+        case 0x0f: // DW_FORM_udata
+            return .uint64(try cursor.readULEB128())
+        case 0x10: // DW_FORM_ref_addr
+            if addressSize == 8 { _ = try cursor.readU64() } else { _ = try cursor.readU32() }
+            return .skipped
+        case 0x11: // DW_FORM_ref1
+            return .int(Int(try cursor.readU8()))
+        case 0x12: // DW_FORM_ref2
+            return .int(Int(try cursor.readU16()))
+        case 0x13: // DW_FORM_ref4
+            return .int(Int(try cursor.readU32()))
+        case 0x14: // DW_FORM_ref8
+            return .uint64(try cursor.readU64())
+        case 0x15: // DW_FORM_ref_udata
+            return .uint64(try cursor.readULEB128())
+        case 0x17: // DW_FORM_sec_offset
+            return .int(Int(try cursor.readU32()))
+        case 0x18: // DW_FORM_exprloc
+            let len = try cursor.readULEB128()
+            cursor.seek(to: cursor.offset + Int(len))
+            return .skipped
+        case 0x19: // DW_FORM_flag_present
+            return .int(1)
+        case 0x20: // DW_FORM_ref_sig8
+            _ = try cursor.readU64()
+            return .skipped
+        default:
+            throw DWARFError.unsupportedForm(form)
+        }
+    }
+
+    // MARK: - Range list parsing
+
+    private static func parseRangeList(
+        debugRanges: ArraySlice<UInt8>,
+        offset: Int,
+        addressSize: UInt8,
+        baseAddress: UInt64
+    ) -> [(start: UInt64, end: UInt64)] {
+        var cursor = Cursor(data: debugRanges)
+        cursor.seek(to: debugRanges.startIndex + offset)
+
+        var ranges: [(start: UInt64, end: UInt64)] = []
+        var base = baseAddress
+        let maxAddr: UInt64 = addressSize == 8 ? UInt64.max : UInt64(UInt32.max)
+
+        while cursor.hasMore {
+            guard let start = try? (addressSize == 8 ? cursor.readU64() : UInt64(cursor.readU32())),
+                  let end = try? (addressSize == 8 ? cursor.readU64() : UInt64(cursor.readU32()))
+            else { break }
+
+            if start == 0 && end == 0 { break } // End of list
+            if start == maxAddr { // Base address selection
+                base = end
+                continue
+            }
+            ranges.append((start: base + start, end: base + end))
+        }
+
+        return ranges
+    }
+
+    // MARK: - DWARF v5 file table parsing
+
+    private static func parseV5FileTable(_ cursor: inout Cursor) throws -> (directories: [String], files: [String]) {
+        let dirFormatCount = try cursor.readU8()
+        var dirFormats: [(content: UInt, form: UInt)] = []
+        for _ in 0..<dirFormatCount {
+            dirFormats.append((content: UInt(try cursor.readULEB128()), form: UInt(try cursor.readULEB128())))
+        }
+        let dirCount = try cursor.readULEB128()
+        var directories: [String] = []
+        for _ in 0..<dirCount {
+            var dirPath = ""
+            for format in dirFormats {
+                let value = try readLineFormValue(&cursor, form: format.form)
+                if format.content == 1 { dirPath = value }
+            }
+            directories.append(dirPath)
+        }
+
+        let fileFormatCount = try cursor.readU8()
+        var fileFormats: [(content: UInt, form: UInt)] = []
+        for _ in 0..<fileFormatCount {
+            fileFormats.append((content: UInt(try cursor.readULEB128()), form: UInt(try cursor.readULEB128())))
+        }
+        let fileCount = try cursor.readULEB128()
+        var files: [String] = []
+        for _ in 0..<fileCount {
+            var fileName = ""
+            var dirIndex: UInt = 0
+            for format in fileFormats {
+                let value = try readLineFormValue(&cursor, form: format.form)
+                switch format.content {
+                case 1: fileName = value
+                case 2: dirIndex = UInt(value) ?? 0
+                default: break
+                }
+            }
+            let dir = dirIndex < directories.count ? directories[Int(dirIndex)] : ""
+            if dir.isEmpty || fileName.hasPrefix("/") {
+                files.append(fileName)
+            } else {
+                files.append(dir + "/" + fileName)
+            }
+        }
+        return (directories, files)
+    }
+
+    private static func readLineFormValue(_ cursor: inout Cursor, form: UInt) throws -> String {
+        switch form {
+        case 0x08: return try cursor.readNullTerminatedString()
+        case 0x0e, 0x1f: _ = try cursor.readU32(); return ""
+        case 0x0b: return String(try cursor.readU8())
+        case 0x05: return String(try cursor.readU16())
+        case 0x06: return String(try cursor.readU32())
+        case 0x0f: return String(try cursor.readULEB128())
+        default: throw DWARFError.unsupportedForm(form)
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum DWARFError: Error, CustomStringConvertible {
+    case unexpectedEnd
+    case unsupportedVersion(UInt16)
+    case unsupportedForm(UInt)
+
+    var description: String {
+        switch self {
+        case .unexpectedEnd:
+            return "Unexpected end of DWARF data"
+        case .unsupportedVersion(let v):
+            return "Unsupported DWARF line table version: \(v)"
+        case .unsupportedForm(let f):
+            return "Unsupported DWARF form: 0x\(String(f, radix: 16))"
+        }
+    }
+}
+
+// MARK: - Binary cursor for reading DWARF data
+
+private struct Cursor {
+    let data: ArraySlice<UInt8>
+    var offset: Int
+
+    init(data: ArraySlice<UInt8>) {
+        self.data = data
+        self.offset = data.startIndex
+    }
+
+    var hasMore: Bool { offset < data.endIndex }
+
+    mutating func seek(to position: Int) {
+        offset = position
+    }
+
+    mutating func readU8() throws -> UInt8 {
+        guard offset < data.endIndex else { throw DWARFError.unexpectedEnd }
+        let value = data[offset]
+        offset += 1
+        return value
+    }
+
+    mutating func readU16() throws -> UInt16 {
+        guard offset + 2 <= data.endIndex else { throw DWARFError.unexpectedEnd }
+        let value = UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+        offset += 2
+        return value
+    }
+
+    mutating func readU32() throws -> UInt32 {
+        guard offset + 4 <= data.endIndex else { throw DWARFError.unexpectedEnd }
+        let value = UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
+        offset += 4
+        return value
+    }
+
+    mutating func readU64() throws -> UInt64 {
+        guard offset + 8 <= data.endIndex else { throw DWARFError.unexpectedEnd }
+        let value = UInt64(data[offset])
+            | (UInt64(data[offset + 1]) << 8)
+            | (UInt64(data[offset + 2]) << 16)
+            | (UInt64(data[offset + 3]) << 24)
+            | (UInt64(data[offset + 4]) << 32)
+            | (UInt64(data[offset + 5]) << 40)
+            | (UInt64(data[offset + 6]) << 48)
+            | (UInt64(data[offset + 7]) << 56)
+        offset += 8
+        return value
+    }
+
+    mutating func readULEB128() throws -> UInt64 {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        while true {
+            guard offset < data.endIndex else { throw DWARFError.unexpectedEnd }
+            let byte = data[offset]
+            offset += 1
+            result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { break }
+            shift += 7
+        }
+        return result
+    }
+
+    mutating func readSLEB128() throws -> Int64 {
+        var result: Int64 = 0
+        var shift: UInt64 = 0
+        var byte: UInt8 = 0
+        repeat {
+            guard offset < data.endIndex else { throw DWARFError.unexpectedEnd }
+            byte = data[offset]
+            offset += 1
+            result |= Int64(byte & 0x7F) << shift
+            shift += 7
+        } while byte & 0x80 != 0
+        if shift < 64 && (byte & 0x40) != 0 {
+            result |= -(1 << shift)
+        }
+        return result
+    }
+
+    mutating func readNullTerminatedString() throws -> String {
+        let start = offset
+        while offset < data.endIndex && data[offset] != 0 {
+            offset += 1
+        }
+        guard offset < data.endIndex else { throw DWARFError.unexpectedEnd }
+        let bytes = data[start..<offset]
+        offset += 1
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}

--- a/Sources/WasmKit/Execution/Errors.swift
+++ b/Sources/WasmKit/Execution/Errors.swift
@@ -9,6 +9,8 @@ public struct Backtrace: CustomStringConvertible, Sendable {
         /// The name of the symbol.
         public let name: String?
         let address: Pc
+        /// The source location resolved from DWARF debug info, if available.
+        public let sourceLocation: DWARFLineTable.SourceLocation?
     }
 
     /// The symbols in the backtrace.
@@ -18,6 +20,9 @@ public struct Backtrace: CustomStringConvertible, Sendable {
     public var description: String {
         symbols.enumerated().map { (index, symbol) in
             let name = symbol.name ?? "unknown"
+            if let loc = symbol.sourceLocation {
+                return "    \(index): \(name) (\(loc))"
+            }
             return "    \(index): (\(symbol.address)) \(name)"
         }.joined(separator: "\n")
     }

--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -101,7 +101,7 @@ struct Execution: ~Copyable {
             var sourceLocation: DWARFLineTable.SourceLocation?
             #if WasmDebuggingSupport
                 if let instance = frame.sp.currentInstance,
-                   let lineTable = instance.dwarfLineTable
+                    let lineTable = instance.dwarfLineTable
                 {
                     // Get the function's file from its start address (reliable)
                     var functionStart: DWARFLineTable.SourceLocation?
@@ -116,7 +116,7 @@ struct Execution: ~Copyable {
                     // Instruction mapping stores file-level offsets (corrected in Translator).
                     let pcForLocation: Pc? = (i > 0) ? frames[i - 1].pc : nil
                     if let pc = pcForLocation,
-                       let wasmOffset = instance.instructionMapping.findWasm(forIseqAddress: pc)
+                        let wasmOffset = instance.instructionMapping.findWasm(forIseqAddress: pc)
                     {
                         let precise = lineTable.lookup(fileOffset: wasmOffset)
                         if let precise, let functionStart, precise.file == functionStart.file {

--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -77,15 +77,61 @@ struct Execution: ~Copyable {
 
     static func captureBacktrace(sp: Sp, store: Store) -> Backtrace {
         let callStack = CallStack(sp: sp)
-        var symbols: [Backtrace.Symbol] = []
 
-        for frame in callStack {
+        // Collect all frames. Each frame has:
+        //   - sp.currentFunction: the function executing in this frame
+        //   - pc (= sp.returnPC): the return address, in the CALLER's code
+        // So frame[i].pc points to code inside frame[i+1]'s function.
+        let frames = Array(callStack)
+
+        var symbols: [Backtrace.Symbol] = []
+        for i in 0..<frames.count {
+            let frame = frames[i]
             guard let function = frame.sp.currentFunction else {
-                symbols.append(.init(name: nil, address: frame.pc))
+                symbols.append(.init(name: nil, address: frame.pc, sourceLocation: nil))
                 continue
             }
             let symbolName = store.nameRegistry.symbolicate(.wasm(function))
-            symbols.append(.init(name: symbolName, address: frame.pc))
+
+            // Resolve source location from DWARF line table.
+            // Two strategies:
+            //   1. Function start address (Code.originalAddress) → correct file, first line
+            //   2. Instruction mapping PC → precise line, but may attribute to wrong file
+            // Use #1 for the file, and #2 for the line if it agrees on the file.
+            var sourceLocation: DWARFLineTable.SourceLocation?
+            #if WasmDebuggingSupport
+                if let instance = frame.sp.currentInstance,
+                   let lineTable = instance.dwarfLineTable
+                {
+                    // Get the function's file from its start address (reliable)
+                    var functionStart: DWARFLineTable.SourceLocation?
+                    switch function.code {
+                    case .debuggable(let code, _), .uncompiled(let code):
+                        functionStart = lineTable.lookup(fileOffset: code.originalAddress)
+                    case .compiled:
+                        break
+                    }
+
+                    // Try precise location from instruction mapping.
+                    // Instruction mapping stores file-level offsets (corrected in Translator).
+                    let pcForLocation: Pc? = (i > 0) ? frames[i - 1].pc : nil
+                    if let pc = pcForLocation,
+                       let wasmOffset = instance.instructionMapping.findWasm(forIseqAddress: pc)
+                    {
+                        let precise = lineTable.lookup(fileOffset: wasmOffset)
+                        if let precise, let functionStart, precise.file == functionStart.file {
+                            sourceLocation = precise
+                        }
+                    }
+
+                    // Fall back to function start
+                    if sourceLocation == nil {
+                        sourceLocation = functionStart
+                    }
+                }
+            #endif
+
+            symbols.append(.init(name: symbolName, address: frame.pc, sourceLocation: sourceLocation))
         }
         return Backtrace(symbols: symbols)
     }

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -88,6 +88,9 @@ package struct InstanceEntity /* : ~Copyable */ {
 
     var instructionMapping: DebuggerInstructionMapping
 
+    /// DWARF line table for resolving code addresses to source locations.
+    var dwarfLineTable: DWARFLineTable?
+
     static var empty: InstanceEntity {
         InstanceEntity(
             types: [],
@@ -102,7 +105,8 @@ package struct InstanceEntity /* : ~Copyable */ {
             features: [],
             dataCount: nil,
             isDebuggable: false,
-            instructionMapping: .init()
+            instructionMapping: .init(),
+            dwarfLineTable: nil
         )
     }
 

--- a/Sources/WasmKit/Execution/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/StoreAllocator.swift
@@ -482,7 +482,8 @@ extension StoreAllocator {
             features: module.features,
             dataCount: module.dataCount,
             isDebuggable: isDebuggable,
-            instructionMapping: .init()
+            instructionMapping: .init(),
+            dwarfLineTable: nil
         )
         instancePointer.initialize(to: instanceEntity)
         instanceInitialized = true
@@ -591,7 +592,8 @@ extension StoreAllocator {
                 features: .default,
                 dataCount: nil,
                 isDebuggable: false,
-                instructionMapping: DebuggerInstructionMapping()
+                instructionMapping: DebuggerInstructionMapping(),
+                dwarfLineTable: nil
             )
             let pointer = instances.allocate(initializing: entity)
             return InternalInstance(unsafe: pointer)

--- a/Sources/WasmKit/Module.swift
+++ b/Sources/WasmKit/Module.swift
@@ -64,6 +64,10 @@ public struct Module {
     let features: WasmFeatureSet
     let dataCount: UInt32?
 
+    /// File-level byte offset of the Code section content (after section ID + size LEB).
+    /// Used to convert between file-level Code.offset values and DWARF code-section-relative addresses.
+    var codeSectionStart: Int = 0
+
     init(
         types: [FunctionType],
         functions: [GuestFunction],
@@ -128,33 +132,21 @@ public struct Module {
         return functions[Int(index) - self.moduleImports.numberOfFunctions].type
     }
 
-    /// Instantiate this module in the given imports.
+    /// Instantiate this module with the given imports.
     ///
     /// - Parameters:
     ///   - store: The ``Store`` to allocate the instance in.
     ///   - imports: The imports to use for instantiation. All imported entities
     ///     must be allocated in the given store.
-    public func instantiate(store: Store, imports: Imports = [:]) throws -> Instance {
-        Instance(handle: try self.instantiateHandle(store: store, imports: imports), store: store)
+    ///   - isDebuggable: Whether the module should support debugging actions
+    ///     (breakpoints, instruction mapping, source-level backtraces) after instantiation.
+    public func instantiate(store: Store, imports: Imports = [:], isDebuggable: Bool = false) throws -> Instance {
+        Instance(handle: try self.instantiateHandle(store: store, imports: imports, isDebuggable: isDebuggable), store: store)
     }
-
-    #if WasmDebuggingSupport
-        /// Instantiate this module with the given imports.
-        ///
-        /// - Parameters:
-        ///   - store: The ``Store`` to allocate the instance in.
-        ///   - imports: The imports to use for instantiation. All imported entities
-        ///     must be allocated in the given store.
-        ///   - isDebuggable: Whether the module should support debugging actions
-        ///     (breakpoints etc) after instantiation.
-        public func instantiate(store: Store, imports: Imports = [:], isDebuggable: Bool) throws -> Instance {
-            Instance(handle: try self.instantiateHandle(store: store, imports: imports, isDebuggable: isDebuggable), store: store)
-        }
-    #endif
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/exec/modules.html#instantiation>
-    private func instantiateHandle(store: Store, imports: Imports, isDebuggable: Bool = false) throws -> InternalInstance {
+    private func instantiateHandle(store: Store, imports: Imports, isDebuggable: Bool) throws -> InternalInstance {
         try ModuleValidator(module: self).validate()
 
         // Steps 5-8.
@@ -174,6 +166,22 @@ public struct Module {
             // FIXME?: Just ignore parsing error of name section for now.
             // Should emit warning instead of just discarding it?
             try? store.nameRegistry.register(instance: instance, nameSection: nameSection)
+        }
+
+        // Parse DWARF line table from debug custom sections if present
+        if let debugLineSection = customSections.first(where: { $0.name == ".debug_line" }) {
+            let sections = DWARFLineTable.Sections(
+                debugLine: debugLineSection.bytes,
+                debugInfo: customSections.first(where: { $0.name == ".debug_info" })?.bytes,
+                debugAbbrev: customSections.first(where: { $0.name == ".debug_abbrev" })?.bytes,
+                debugRanges: customSections.first(where: { $0.name == ".debug_ranges" })?.bytes
+            )
+            if let lineTable = try? DWARFLineTable(sections: sections) {
+                lineTable.codeSectionOffset = self.codeSectionStart
+                instance.withValue {
+                    $0.dwarfLineTable = lineTable
+                }
+            }
         }
 
         let constEvalContext = ConstEvaluationContext(instance: instance, moduleImports: moduleImports)

--- a/Sources/WasmKit/ModuleParser.swift
+++ b/Sources/WasmKit/ModuleParser.swift
@@ -45,6 +45,7 @@ func parseModule<Stream: ByteStream>(stream: Stream, features: WasmFeatureSet = 
     var types: [FunctionType] = []
     var typeIndices: [TypeIndex] = []
     var codes: [Code] = []
+    var codeSectionStart: Int = 0
     var tables: [TableType] = []
     var memories: [MemoryType] = []
     var globals: [WasmParser.Global] = []
@@ -83,8 +84,9 @@ func parseModule<Stream: ByteStream>(stream: Stream, features: WasmFeatureSet = 
             start = functionIndex
         case .elementSection(let elementSection):
             elements = elementSection
-        case .codeSection(let codeSection):
+        case .codeSection(let codeSection, let start):
             codes = codeSection
+            codeSectionStart = start
         case .dataSection(let dataSection):
             data = dataSection
         case .dataCount(let count):
@@ -118,7 +120,7 @@ func parseModule<Stream: ByteStream>(stream: Stream, features: WasmFeatureSet = 
         )
     }
 
-    return Module(
+    var module = Module(
         types: types,
         functions: functions,
         elements: elements,
@@ -133,4 +135,6 @@ func parseModule<Stream: ByteStream>(stream: Stream, features: WasmFeatureSet = 
         features: features,
         dataCount: dataCount
     )
+    module.codeSectionStart = codeSectionStart
+    return module
 }

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -1258,11 +1258,6 @@ struct InstructionTranslator: InstructionVisitor {
         var offset = parser.offset
         do {
             while try parser.visit(visitor: &self) {
-                // Record a mapping entry for every Wasm instruction, even those
-                // that don't emit iseq instructions (e.g., local.get, block, end).
-                // This ensures breakpoints can be set at any source line whose
-                // DWARF entry points at a folded/structural Wasm instruction.
-                self.updateInstructionMapping()
                 offset = parser.offset
             }
         } catch var error as ValidationError {

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -899,8 +899,14 @@ struct InstructionTranslator: InstructionVisitor {
 
     // Wasm debugging support.
 
-    /// Current offset to an instruction in the original Wasm binary processed by this translator.
+    /// Current offset of the Wasm instruction being translated.
+    /// Set by the decoder to a buffer-relative value; corrected to file-level
+    /// by adding `binaryOffsetCorrection` in `updateInstructionMapping()`.
     var binaryOffset: Int = 0
+
+    /// Correction to convert buffer-relative `binaryOffset` to file-level offset.
+    /// Computed once at the start of translation from the ExpressionParser's code offset.
+    var binaryOffsetCorrection: Int = 0
 
     /// Mapping from `self.iseqBuilder.instructions` to Wasm instructions.
     /// As mapping between iSeq to Wasm is many:many, but we only care about first mapping for overlapping address,
@@ -1230,7 +1236,7 @@ struct InstructionTranslator: InstructionVisitor {
         #if WasmDebuggingSupport
             guard self.module.isDebuggable else { return }
 
-            self.iseqToWasmMapping.append((self.iseqBuilder.insertingPC.offsetFromHead, self.binaryOffset))
+            self.iseqToWasmMapping.append((self.iseqBuilder.insertingPC.offsetFromHead, self.binaryOffset + self.binaryOffsetCorrection))
         #endif
     }
 
@@ -1243,9 +1249,20 @@ struct InstructionTranslator: InstructionVisitor {
             emit(.onEnter(functionIndex))
         }
         var parser = ExpressionParser(code: code)
+        #if WasmDebuggingSupport
+            // The decoder sets binaryOffset to buffer-relative positions (expression.startIndex-based).
+            // We need file-level offsets for the instruction mapping.
+            // Correction: file_offset = buffer_offset + (code.originalAddress - expression.startIndex)
+            self.binaryOffsetCorrection = code.originalAddress - Int(code.expression.startIndex)
+        #endif
         var offset = parser.offset
         do {
             while try parser.visit(visitor: &self) {
+                // Record a mapping entry for every Wasm instruction, even those
+                // that don't emit iseq instructions (e.g., local.get, block, end).
+                // This ensures breakpoints can be set at any source line whose
+                // DWARF entry points at a folded/structural Wasm instruction.
+                self.updateInstructionMapping()
                 offset = parser.offset
             }
         } catch var error as ValidationError {

--- a/Sources/WasmParser/Docs.docc/Docs.md
+++ b/Sources/WasmParser/Docs.docc/Docs.md
@@ -35,7 +35,7 @@ while let payload = try parser.parseNext() {
     case .exportSection(let exportSection): print("Export section: \(exportSection)")
     case .startSection(let functionIndex): print("Start section: \(functionIndex)")
     case .elementSection(let elementSection): print("Element section: \(elementSection)")
-    case .codeSection(let codeSection): print("Code section: \(codeSection)")
+    case .codeSection(let codeSection, _): print("Code section: \(codeSection)")
     case .dataSection(let dataSection): print("Data section: \(dataSection)")
     case .dataCount(let count): print("Data count: \(count)")
     }

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -1215,7 +1215,7 @@ public enum ParsingPayload {
     case exportSection([Export])
     case startSection(FunctionIndex)
     case elementSection([ElementSegment])
-    case codeSection([Code])
+    case codeSection([Code], sectionStart: Int)
     case dataSection([DataSegment])
     case dataCount(UInt32)
 }
@@ -1355,7 +1355,7 @@ extension Parser {
                 payload = .elementSection(try parseElementSection())
             case 10:
                 order = .code
-                payload = .codeSection(try parseCodeSection())
+                payload = .codeSection(try parseCodeSection(), sectionStart: sectionStart)
             case 11:
                 order = .data
                 payload = .dataSection(try parseDataSection())

--- a/Tests/WasmKitTests/DWARFLineTableTests.swift
+++ b/Tests/WasmKitTests/DWARFLineTableTests.swift
@@ -1,0 +1,426 @@
+import Testing
+
+@testable import WasmKit
+
+private func encodeSLEB128(_ value: Int) -> [UInt8] {
+    var bytes: [UInt8] = []
+    var v = value
+    var more = true
+    while more {
+        var byte = UInt8(v & 0x7F)
+        v >>= 7
+        if (v == 0 && byte & 0x40 == 0) || (v == -1 && byte & 0x40 != 0) {
+            more = false
+        } else {
+            byte |= 0x80
+        }
+        bytes.append(byte)
+    }
+    return bytes
+}
+
+private func encodeULEB128(_ value: UInt) -> [UInt8] {
+    var bytes: [UInt8] = []
+    var v = value
+    repeat {
+        var byte = UInt8(v & 0x7F)
+        v >>= 7
+        if v != 0 { byte |= 0x80 }
+        bytes.append(byte)
+    } while v != 0
+    return bytes
+}
+
+/// Compute a special opcode for a given address and line advance.
+private func specialOpcode(
+    addressAdvance: Int, lineAdvance: Int,
+    opcodeBase: UInt8, lineRange: UInt8, lineBase: Int8
+) -> UInt8? {
+    let adjustedLineAdvance = lineAdvance - Int(lineBase)
+    guard adjustedLineAdvance >= 0 && adjustedLineAdvance < Int(lineRange) else { return nil }
+    let adjustedOpcode = addressAdvance * Int(lineRange) + adjustedLineAdvance
+    let opcode = adjustedOpcode + Int(opcodeBase)
+    guard opcode >= Int(opcodeBase) && opcode <= 255 else { return nil }
+    return UInt8(opcode)
+}
+
+@Suite("DWARF Line Table Parser")
+struct DWARFLineTableTests {
+
+    // MARK: - Test helpers
+
+    /// Builds a DWARF v4 .debug_line section from a builder closure that emits
+    /// line number program opcodes into the provided byte array.
+    private static func buildV4Section(
+        lineBase: Int8 = -5,
+        lineRange: UInt8 = 14,
+        opcodeBase: UInt8 = 13,
+        directories: [String] = ["/src"],
+        files: [(name: String, dirIndex: UInt8)] = [("test.swift", 1)],
+        program: (inout [UInt8], _ opcodeBase: UInt8, _ lineRange: UInt8, _ lineBase: Int8) -> Void
+    ) -> [UInt8] {
+        var bytes: [UInt8] = []
+
+        let unitLengthOffset = bytes.count
+        bytes.append(contentsOf: [0, 0, 0, 0]) // unit_length placeholder
+        let afterUnitLength = bytes.count
+
+        bytes.append(contentsOf: [4, 0]) // version: 4
+
+        let prologueLengthOffset = bytes.count
+        bytes.append(contentsOf: [0, 0, 0, 0]) // prologue_length placeholder
+        let afterPrologueLength = bytes.count
+
+        bytes.append(1) // minimum_instruction_length
+        bytes.append(1) // maximum_operations_per_instruction
+        bytes.append(1) // default_is_stmt
+        bytes.append(UInt8(bitPattern: lineBase))
+        bytes.append(lineRange)
+        bytes.append(opcodeBase)
+
+        // standard_opcode_lengths for opcodes 1..12
+        bytes.append(contentsOf: [0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1])
+
+        // Directories
+        for dir in directories {
+            bytes.append(contentsOf: Array(dir.utf8))
+            bytes.append(0)
+        }
+        bytes.append(0) // end of directories
+
+        // Files
+        for file in files {
+            bytes.append(contentsOf: Array(file.name.utf8))
+            bytes.append(0)
+            bytes.append(file.dirIndex) // dir_index
+            bytes.append(0) // mod_time
+            bytes.append(0) // length
+        }
+        bytes.append(0) // end of files
+
+        // Patch prologue_length
+        let prologueEnd = bytes.count
+        let prologueLength = UInt32(prologueEnd - afterPrologueLength)
+        bytes[prologueLengthOffset] = UInt8(prologueLength & 0xFF)
+        bytes[prologueLengthOffset + 1] = UInt8((prologueLength >> 8) & 0xFF)
+        bytes[prologueLengthOffset + 2] = UInt8((prologueLength >> 16) & 0xFF)
+        bytes[prologueLengthOffset + 3] = UInt8((prologueLength >> 24) & 0xFF)
+
+        // Emit the line number program
+        program(&bytes, opcodeBase, lineRange, lineBase)
+
+        // Patch unit_length
+        let unitEnd = bytes.count
+        let unitLength = UInt32(unitEnd - afterUnitLength)
+        bytes[unitLengthOffset] = UInt8(unitLength & 0xFF)
+        bytes[unitLengthOffset + 1] = UInt8((unitLength >> 8) & 0xFF)
+        bytes[unitLengthOffset + 2] = UInt8((unitLength >> 16) & 0xFF)
+        bytes[unitLengthOffset + 3] = UInt8((unitLength >> 24) & 0xFF)
+
+        return bytes
+    }
+
+    /// Emit DW_LNE_set_address (extended opcode 2)
+    private static func emitSetAddress(_ bytes: inout [UInt8], _ address: UInt32) {
+        bytes.append(0) // extended opcode marker
+        bytes.append(5) // length: 1 byte opcode + 4 byte address
+        bytes.append(2) // DW_LNE_set_address
+        bytes.append(UInt8(address & 0xFF))
+        bytes.append(UInt8((address >> 8) & 0xFF))
+        bytes.append(UInt8((address >> 16) & 0xFF))
+        bytes.append(UInt8((address >> 24) & 0xFF))
+    }
+
+    /// Emit DW_LNE_end_sequence preceded by advancing the PC past the last instruction.
+    /// In real DWARF, end_sequence marks the first address *not* in the sequence.
+    private static func emitEndSequence(_ bytes: inout [UInt8], advancePC: UInt = 1) {
+        // DW_LNS_advance_pc
+        bytes.append(2)
+        bytes.append(contentsOf: encodeULEB128(advancePC))
+        // DW_LNE_end_sequence
+        bytes.append(0)
+        bytes.append(1)
+        bytes.append(1)
+    }
+
+    // MARK: - Tests
+
+    @Test func parsesBasicSequence() throws {
+        let bytes = Self.buildV4Section { bytes, opcodeBase, lineRange, lineBase in
+            // Set address to 0x100
+            Self.emitSetAddress(&bytes, 0x100)
+
+            // Advance line to 10 (from default 1, advance by 9)
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(9))
+
+            // Copy -> emit row at 0x100, line 10
+            bytes.append(1) // DW_LNS_copy
+
+            // Special opcode: address +5, line +2
+            bytes.append(specialOpcode(addressAdvance: 5, lineAdvance: 2, opcodeBase: opcodeBase, lineRange: lineRange, lineBase: lineBase)!)
+            // -> 0x105, line 12
+
+            // Special opcode: address +3, line +1
+            bytes.append(specialOpcode(addressAdvance: 3, lineAdvance: 1, opcodeBase: opcodeBase, lineRange: lineRange, lineBase: lineBase)!)
+            // -> 0x108, line 13
+
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+
+        let loc1 = table.lookup(address: 0x100)
+        #expect(loc1?.file == "/src/test.swift")
+        #expect(loc1?.line == 10)
+
+        let loc2 = table.lookup(address: 0x105)
+        #expect(loc2?.line == 12)
+
+        let loc3 = table.lookup(address: 0x108)
+        #expect(loc3?.line == 13)
+    }
+
+    @Test func addressBetweenRowsResolvesToPreviousRow() throws {
+        let bytes = Self.buildV4Section { bytes, opcodeBase, lineRange, lineBase in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(9))
+            bytes.append(1) // DW_LNS_copy — row at 0x100, line 10
+
+            bytes.append(specialOpcode(addressAdvance: 10, lineAdvance: 5, opcodeBase: opcodeBase, lineRange: lineRange, lineBase: lineBase)!)
+            // -> 0x10A, line 15
+
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+
+        // Address 0x103 is between 0x100 and 0x10A, should resolve to line 10
+        let loc = table.lookup(address: 0x103)
+        #expect(loc?.line == 10)
+    }
+
+    @Test func addressBeforeFirstEntryReturnsNil() throws {
+        let bytes = Self.buildV4Section { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(9))
+            bytes.append(1) // row at 0x100, line 10
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+        #expect(table.lookup(address: 0x50) == nil)
+    }
+
+    @Test func addressAfterEndSequenceReturnsNil() throws {
+        let bytes = Self.buildV4Section { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(9))
+            bytes.append(1) // row at 0x100, line 10
+            Self.emitEndSequence(&bytes) // end_sequence at 0x100
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+        // Well past the sequence
+        #expect(table.lookup(address: 0x200) == nil)
+    }
+
+    @Test func columnTracking() throws {
+        let bytes = Self.buildV4Section { bytes, opcodeBase, lineRange, lineBase in
+            Self.emitSetAddress(&bytes, 0x200)
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(19)) // line 20
+            bytes.append(5) // DW_LNS_set_column
+            bytes.append(contentsOf: encodeULEB128(15)) // column 15
+            bytes.append(1) // DW_LNS_copy — row at 0x200, line 20, column 15
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+        let loc = table.lookup(address: 0x200)
+        #expect(loc?.line == 20)
+        #expect(loc?.column == 15)
+    }
+
+    @Test func setFileSwitch() throws {
+        let bytes = Self.buildV4Section(
+            directories: ["/src"],
+            files: [("alpha.swift", 1), ("beta.swift", 1)]
+        ) { bytes, opcodeBase, lineRange, lineBase in
+            Self.emitSetAddress(&bytes, 0x100)
+            // File 1 (alpha.swift), line 5
+            bytes.append(4) // DW_LNS_set_file
+            bytes.append(contentsOf: encodeULEB128(1))
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(4))
+            bytes.append(1) // copy -> 0x100, file 1, line 5
+
+            // Switch to file 2 (beta.swift)
+            bytes.append(2) // DW_LNS_advance_pc
+            bytes.append(contentsOf: encodeULEB128(8))
+            bytes.append(4) // DW_LNS_set_file
+            bytes.append(contentsOf: encodeULEB128(2))
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(5)) // line 10
+            bytes.append(1) // copy -> 0x108, file 2, line 10
+
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+
+        let loc1 = table.lookup(address: 0x100)
+        #expect(loc1?.file == "/src/alpha.swift")
+        #expect(loc1?.line == 5)
+
+        let loc2 = table.lookup(address: 0x108)
+        #expect(loc2?.file == "/src/beta.swift")
+        #expect(loc2?.line == 10)
+    }
+
+    @Test func constAddPc() throws {
+        let bytes = Self.buildV4Section { bytes, opcodeBase, lineRange, lineBase in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(9))
+            bytes.append(1) // row at 0x100, line 10
+
+            // DW_LNS_const_add_pc: advance by (255 - opcode_base) / line_range
+            // = (255 - 13) / 14 = 242 / 14 = 17
+            bytes.append(8) // DW_LNS_const_add_pc
+
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(5))
+            bytes.append(1) // row at 0x111, line 15
+
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+
+        let loc1 = table.lookup(address: 0x100)
+        #expect(loc1?.line == 10)
+
+        let loc2 = table.lookup(address: 0x111)
+        #expect(loc2?.line == 15)
+    }
+
+    @Test func fixedAdvancePc() throws {
+        let bytes = Self.buildV4Section { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(9))
+            bytes.append(1) // row at 0x100, line 10
+
+            // DW_LNS_fixed_advance_pc with 16-bit operand
+            bytes.append(9) // DW_LNS_fixed_advance_pc
+            bytes.append(0x00) // advance = 0x200 (little-endian)
+            bytes.append(0x02)
+
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(10))
+            bytes.append(1) // row at 0x300, line 20
+
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+        let loc = table.lookup(address: 0x300)
+        #expect(loc?.line == 20)
+    }
+
+    @Test func multipleCompilationUnits() throws {
+        // Build two separate units and concatenate them
+        let unit1 = Self.buildV4Section(
+            directories: ["/src"],
+            files: [("a.swift", 1)]
+        ) { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(4))
+            bytes.append(1) // 0x100, line 5
+            Self.emitEndSequence(&bytes)
+        }
+
+        let unit2 = Self.buildV4Section(
+            directories: ["/lib"],
+            files: [("b.swift", 1)]
+        ) { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x500)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(29))
+            bytes.append(1) // 0x500, line 30
+            Self.emitEndSequence(&bytes)
+        }
+
+        var combined = unit1
+        combined.append(contentsOf: unit2)
+
+        let table = try DWARFLineTable(data: ArraySlice(combined))
+
+        let loc1 = table.lookup(address: 0x100)
+        #expect(loc1?.file == "/src/a.swift")
+        #expect(loc1?.line == 5)
+
+        let loc2 = table.lookup(address: 0x500)
+        #expect(loc2?.file == "/lib/b.swift")
+        #expect(loc2?.line == 30)
+    }
+
+    @Test func lineZeroSkipped() throws {
+        // Line 0 means "no source mapping" — the lookup should skip it
+        let bytes = Self.buildV4Section { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x100)
+            // Line stays at default 1, then set to 0
+            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(-1)) // line = 0
+            bytes.append(1) // copy row at 0x100, line 0
+
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+        // Line 0 should not be returned
+        #expect(table.lookup(address: 0x100) == nil)
+    }
+
+    @Test func absolutePathIgnoresDirectory() throws {
+        let bytes = Self.buildV4Section(
+            directories: ["/should-be-ignored"],
+            files: [("/absolute/path/file.swift", 1)]
+        ) { bytes, _, _, _ in
+            Self.emitSetAddress(&bytes, 0x100)
+            bytes.append(3)
+            bytes.append(contentsOf: encodeSLEB128(4))
+            bytes.append(1) // 0x100, line 5
+            Self.emitEndSequence(&bytes)
+        }
+
+        let table = try DWARFLineTable(data: ArraySlice(bytes))
+        let loc = table.lookup(address: 0x100)
+        #expect(loc?.file == "/absolute/path/file.swift")
+    }
+
+    @Test func unsupportedVersionThrows() throws {
+        // Build bytes with version 3
+        var bytes: [UInt8] = []
+        bytes.append(contentsOf: [10, 0, 0, 0]) // unit_length = 10
+        bytes.append(contentsOf: [3, 0]) // version: 3
+        bytes.append(contentsOf: [0, 0, 0, 0, 0, 0, 0, 0]) // padding to fill
+
+        #expect(throws: DWARFError.self) {
+            try DWARFLineTable(data: ArraySlice(bytes))
+        }
+    }
+
+    @Test func sourceLocationDescription() {
+        let loc1 = DWARFLineTable.SourceLocation(file: "test.swift", line: 42, column: 10)
+        #expect(loc1.description == "test.swift:42:10")
+
+        let loc2 = DWARFLineTable.SourceLocation(file: "test.swift", line: 42, column: 0)
+        #expect(loc2.description == "test.swift:42")
+    }
+}

--- a/Tests/WasmKitTests/DWARFLineTableTests.swift
+++ b/Tests/WasmKitTests/DWARFLineTableTests.swift
@@ -62,18 +62,18 @@ struct DWARFLineTableTests {
         var bytes: [UInt8] = []
 
         let unitLengthOffset = bytes.count
-        bytes.append(contentsOf: [0, 0, 0, 0]) // unit_length placeholder
+        bytes.append(contentsOf: [0, 0, 0, 0])  // unit_length placeholder
         let afterUnitLength = bytes.count
 
-        bytes.append(contentsOf: [4, 0]) // version: 4
+        bytes.append(contentsOf: [4, 0])  // version: 4
 
         let prologueLengthOffset = bytes.count
-        bytes.append(contentsOf: [0, 0, 0, 0]) // prologue_length placeholder
+        bytes.append(contentsOf: [0, 0, 0, 0])  // prologue_length placeholder
         let afterPrologueLength = bytes.count
 
-        bytes.append(1) // minimum_instruction_length
-        bytes.append(1) // maximum_operations_per_instruction
-        bytes.append(1) // default_is_stmt
+        bytes.append(1)  // minimum_instruction_length
+        bytes.append(1)  // maximum_operations_per_instruction
+        bytes.append(1)  // default_is_stmt
         bytes.append(UInt8(bitPattern: lineBase))
         bytes.append(lineRange)
         bytes.append(opcodeBase)
@@ -86,17 +86,17 @@ struct DWARFLineTableTests {
             bytes.append(contentsOf: Array(dir.utf8))
             bytes.append(0)
         }
-        bytes.append(0) // end of directories
+        bytes.append(0)  // end of directories
 
         // Files
         for file in files {
             bytes.append(contentsOf: Array(file.name.utf8))
             bytes.append(0)
-            bytes.append(file.dirIndex) // dir_index
-            bytes.append(0) // mod_time
-            bytes.append(0) // length
+            bytes.append(file.dirIndex)  // dir_index
+            bytes.append(0)  // mod_time
+            bytes.append(0)  // length
         }
-        bytes.append(0) // end of files
+        bytes.append(0)  // end of files
 
         // Patch prologue_length
         let prologueEnd = bytes.count
@@ -122,9 +122,9 @@ struct DWARFLineTableTests {
 
     /// Emit DW_LNE_set_address (extended opcode 2)
     private static func emitSetAddress(_ bytes: inout [UInt8], _ address: UInt32) {
-        bytes.append(0) // extended opcode marker
-        bytes.append(5) // length: 1 byte opcode + 4 byte address
-        bytes.append(2) // DW_LNE_set_address
+        bytes.append(0)  // extended opcode marker
+        bytes.append(5)  // length: 1 byte opcode + 4 byte address
+        bytes.append(2)  // DW_LNE_set_address
         bytes.append(UInt8(address & 0xFF))
         bytes.append(UInt8((address >> 8) & 0xFF))
         bytes.append(UInt8((address >> 16) & 0xFF))
@@ -151,11 +151,11 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
 
             // Advance line to 10 (from default 1, advance by 9)
-            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(3)  // DW_LNS_advance_line
             bytes.append(contentsOf: encodeSLEB128(9))
 
             // Copy -> emit row at 0x100, line 10
-            bytes.append(1) // DW_LNS_copy
+            bytes.append(1)  // DW_LNS_copy
 
             // Special opcode: address +5, line +2
             bytes.append(specialOpcode(addressAdvance: 5, lineAdvance: 2, opcodeBase: opcodeBase, lineRange: lineRange, lineBase: lineBase)!)
@@ -184,9 +184,9 @@ struct DWARFLineTableTests {
     @Test func addressBetweenRowsResolvesToPreviousRow() throws {
         let bytes = Self.buildV4Section { bytes, opcodeBase, lineRange, lineBase in
             Self.emitSetAddress(&bytes, 0x100)
-            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(3)  // DW_LNS_advance_line
             bytes.append(contentsOf: encodeSLEB128(9))
-            bytes.append(1) // DW_LNS_copy — row at 0x100, line 10
+            bytes.append(1)  // DW_LNS_copy — row at 0x100, line 10
 
             bytes.append(specialOpcode(addressAdvance: 10, lineAdvance: 5, opcodeBase: opcodeBase, lineRange: lineRange, lineBase: lineBase)!)
             // -> 0x10A, line 15
@@ -206,7 +206,7 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(9))
-            bytes.append(1) // row at 0x100, line 10
+            bytes.append(1)  // row at 0x100, line 10
             Self.emitEndSequence(&bytes)
         }
 
@@ -219,8 +219,8 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(9))
-            bytes.append(1) // row at 0x100, line 10
-            Self.emitEndSequence(&bytes) // end_sequence at 0x100
+            bytes.append(1)  // row at 0x100, line 10
+            Self.emitEndSequence(&bytes)  // end_sequence at 0x100
         }
 
         let table = try DWARFLineTable(data: ArraySlice(bytes))
@@ -231,11 +231,11 @@ struct DWARFLineTableTests {
     @Test func columnTracking() throws {
         let bytes = Self.buildV4Section { bytes, opcodeBase, lineRange, lineBase in
             Self.emitSetAddress(&bytes, 0x200)
-            bytes.append(3) // DW_LNS_advance_line
-            bytes.append(contentsOf: encodeSLEB128(19)) // line 20
-            bytes.append(5) // DW_LNS_set_column
-            bytes.append(contentsOf: encodeULEB128(15)) // column 15
-            bytes.append(1) // DW_LNS_copy — row at 0x200, line 20, column 15
+            bytes.append(3)  // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(19))  // line 20
+            bytes.append(5)  // DW_LNS_set_column
+            bytes.append(contentsOf: encodeULEB128(15))  // column 15
+            bytes.append(1)  // DW_LNS_copy — row at 0x200, line 20, column 15
             Self.emitEndSequence(&bytes)
         }
 
@@ -252,20 +252,20 @@ struct DWARFLineTableTests {
         ) { bytes, opcodeBase, lineRange, lineBase in
             Self.emitSetAddress(&bytes, 0x100)
             // File 1 (alpha.swift), line 5
-            bytes.append(4) // DW_LNS_set_file
+            bytes.append(4)  // DW_LNS_set_file
             bytes.append(contentsOf: encodeULEB128(1))
-            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(3)  // DW_LNS_advance_line
             bytes.append(contentsOf: encodeSLEB128(4))
-            bytes.append(1) // copy -> 0x100, file 1, line 5
+            bytes.append(1)  // copy -> 0x100, file 1, line 5
 
             // Switch to file 2 (beta.swift)
-            bytes.append(2) // DW_LNS_advance_pc
+            bytes.append(2)  // DW_LNS_advance_pc
             bytes.append(contentsOf: encodeULEB128(8))
-            bytes.append(4) // DW_LNS_set_file
+            bytes.append(4)  // DW_LNS_set_file
             bytes.append(contentsOf: encodeULEB128(2))
-            bytes.append(3) // DW_LNS_advance_line
-            bytes.append(contentsOf: encodeSLEB128(5)) // line 10
-            bytes.append(1) // copy -> 0x108, file 2, line 10
+            bytes.append(3)  // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(5))  // line 10
+            bytes.append(1)  // copy -> 0x108, file 2, line 10
 
             Self.emitEndSequence(&bytes)
         }
@@ -286,15 +286,15 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(9))
-            bytes.append(1) // row at 0x100, line 10
+            bytes.append(1)  // row at 0x100, line 10
 
             // DW_LNS_const_add_pc: advance by (255 - opcode_base) / line_range
             // = (255 - 13) / 14 = 242 / 14 = 17
-            bytes.append(8) // DW_LNS_const_add_pc
+            bytes.append(8)  // DW_LNS_const_add_pc
 
-            bytes.append(3) // DW_LNS_advance_line
+            bytes.append(3)  // DW_LNS_advance_line
             bytes.append(contentsOf: encodeSLEB128(5))
-            bytes.append(1) // row at 0x111, line 15
+            bytes.append(1)  // row at 0x111, line 15
 
             Self.emitEndSequence(&bytes)
         }
@@ -313,16 +313,16 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(9))
-            bytes.append(1) // row at 0x100, line 10
+            bytes.append(1)  // row at 0x100, line 10
 
             // DW_LNS_fixed_advance_pc with 16-bit operand
-            bytes.append(9) // DW_LNS_fixed_advance_pc
-            bytes.append(0x00) // advance = 0x200 (little-endian)
+            bytes.append(9)  // DW_LNS_fixed_advance_pc
+            bytes.append(0x00)  // advance = 0x200 (little-endian)
             bytes.append(0x02)
 
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(10))
-            bytes.append(1) // row at 0x300, line 20
+            bytes.append(1)  // row at 0x300, line 20
 
             Self.emitEndSequence(&bytes)
         }
@@ -341,7 +341,7 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(4))
-            bytes.append(1) // 0x100, line 5
+            bytes.append(1)  // 0x100, line 5
             Self.emitEndSequence(&bytes)
         }
 
@@ -352,7 +352,7 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x500)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(29))
-            bytes.append(1) // 0x500, line 30
+            bytes.append(1)  // 0x500, line 30
             Self.emitEndSequence(&bytes)
         }
 
@@ -375,9 +375,9 @@ struct DWARFLineTableTests {
         let bytes = Self.buildV4Section { bytes, _, _, _ in
             Self.emitSetAddress(&bytes, 0x100)
             // Line stays at default 1, then set to 0
-            bytes.append(3) // DW_LNS_advance_line
-            bytes.append(contentsOf: encodeSLEB128(-1)) // line = 0
-            bytes.append(1) // copy row at 0x100, line 0
+            bytes.append(3)  // DW_LNS_advance_line
+            bytes.append(contentsOf: encodeSLEB128(-1))  // line = 0
+            bytes.append(1)  // copy row at 0x100, line 0
 
             Self.emitEndSequence(&bytes)
         }
@@ -395,7 +395,7 @@ struct DWARFLineTableTests {
             Self.emitSetAddress(&bytes, 0x100)
             bytes.append(3)
             bytes.append(contentsOf: encodeSLEB128(4))
-            bytes.append(1) // 0x100, line 5
+            bytes.append(1)  // 0x100, line 5
             Self.emitEndSequence(&bytes)
         }
 
@@ -407,9 +407,9 @@ struct DWARFLineTableTests {
     @Test func unsupportedVersionThrows() throws {
         // Build bytes with version 3
         var bytes: [UInt8] = []
-        bytes.append(contentsOf: [10, 0, 0, 0]) // unit_length = 10
-        bytes.append(contentsOf: [3, 0]) // version: 3
-        bytes.append(contentsOf: [0, 0, 0, 0, 0, 0, 0, 0]) // padding to fill
+        bytes.append(contentsOf: [10, 0, 0, 0])  // unit_length = 10
+        bytes.append(contentsOf: [3, 0])  // version: 3
+        bytes.append(contentsOf: [0, 0, 0, 0, 0, 0, 0, 0])  // padding to fill
 
         #expect(throws: DWARFError.self) {
             try DWARFLineTable(data: ArraySlice(bytes))


### PR DESCRIPTION
Parse DWARF .debug_line, .debug_info, .debug_abbrev, and .debug_ranges sections from WASM custom sections to resolve code addresses to source file/line/column locations. Used by Caller.captureBacktrace() to provide source-level information in stack traces.

Key components:
- DWARFLineTable: parses DWARF v4/v5 line number programs with CU-aware resolution using .debug_info address ranges
- Code section offset conversion between file-level and DWARF addresses
- binaryOffsetCorrection in Translator to fix buffer-relative offsets
- Backtrace.Symbol.sourceLocation for resolved source locations
- Precise line resolution via instruction mapping with function-start fallback
- Translator fix from expose-debugging-api for folded instruction mapping
- codeSectionStart exposed via ParsingPayload.codeSection
- 13 unit tests for the DWARF parser