### PR TITLE
Update `actions/checkout` to `v6`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Re-generate auto-generated code checks
         run: |
           swift run -q --package-path Utilities WasmKitDevUtils
@@ -37,7 +37,7 @@ jobs:
           - toolchain: main-snapshot
             test-args: "-Xswiftc -DWASMKIT_CI_TOOLCHAIN_MAIN_NIGHTLY"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: setup-development
         run: |
           brew install wabt jemalloc
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: "build-macos (${{ matrix.xcode }})"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: setup-development
         run: |
           toolchain_path="/Library/Developer/Toolchains/${{ matrix.development-toolchain-tag }}.xctoolchain"
@@ -121,7 +121,7 @@ jobs:
   build-xcode:
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare Xcode platforms
         run: |
           set -euxo pipefail
@@ -192,7 +192,7 @@ jobs:
     name: "build-linux (${{ matrix.swift }}${{ matrix.label }})"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure container
         run: |
           docker run -dit --name build-container -v $PWD:/workspace -w /workspace ${{ matrix.swift }}
@@ -263,7 +263,7 @@ jobs:
             musl-swift-sdk-download: "https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"
             musl-swift-sdk-checksum: "f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure container
         run: |
           docker run -dit --name build-container -v $PWD:/workspace -w /workspace swift:${{ matrix.swift }}
@@ -289,7 +289,7 @@ jobs:
           - swift-version: nightly-main
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Free up disk space
         run: ./CI/gha-free-disk-space.sh
       - name: Run Tests on Android emulator
@@ -305,7 +305,7 @@ jobs:
         with:
           swift-version: swift-6.2-release
           swift-build: 6.2-RELEASE
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: python3 ./Vendor/checkout-dependency --category default
       # FIXME: CMake build is failing on CI due to "link: extra operand '/OUT:lib\\libXXXX.a'" error
       # # Check Windows build with CMake
@@ -325,7 +325,7 @@ jobs:
     container:
       image: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Ninja
         run: apt-get update && apt-get install -y ninja-build
       - name: Install CMake
@@ -341,7 +341,7 @@ jobs:
     container:
       image: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install jq
         run: apt-get update && apt-get install -y jq
       - name: Install Swift SDK


### PR DESCRIPTION
Addresses this warning:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.
```