### PR TITLE
Disable `main` branch of Android snapshots as regressed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,6 +286,7 @@ jobs:
         include:
           - swift-version: "6.2"
           - swift-version: "nightly-6.3"
+          # Regressed since `swift-DEVELOPMENT-SNAPSHOT-2026-04-01-a`
           # - swift-version: nightly-main
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,7 +286,7 @@ jobs:
         include:
           - swift-version: "6.2"
           - swift-version: "nightly-6.3"
-          - swift-version: nightly-main
+          # - swift-version: nightly-main
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
```
/usr/local/lib/android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/threads.h:38:10: error: could not build module 'pthread'
 36 | #include <sys/cdefs.h>
 37 | 
 38 | #include <pthread.h>
    |          `- error: could not build module 'pthread'
 39 | #include <time.h>
 40 | 
```