### PR TITLE
Remove `any GuestMemory` existential from `*Guest*Pointer` types

### DIFF
--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -1,4 +1,5 @@
 import SystemPackage
+import WasmTypes
 
 struct FileAccessMode: OptionSet {
     let rawValue: UInt32
@@ -30,17 +31,17 @@ protocol WASIFile: WASIEntry {
     func tell() throws -> WASIAbi.FileSize
     func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize
 
-    func write<Buffer: Sequence>(
-        vectored buffer: Buffer
+    func write<M: GuestMemory, Buffer: Sequence>(
+        vectored buffer: Buffer, memory: M
     ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
-    func pwrite<Buffer: Sequence>(
-        vectored buffer: Buffer, offset: WASIAbi.FileSize
+    func pwrite<M: GuestMemory, Buffer: Sequence>(
+        vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize
     ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
-    func read<Buffer: Sequence>(
-        into buffer: Buffer
+    func read<M: GuestMemory, Buffer: Sequence>(
+        into buffer: Buffer, memory: M
     ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
-    func pread<Buffer: Sequence>(
-        into buffer: Buffer, offset: WASIAbi.FileSize
+    func pread<M: GuestMemory, Buffer: Sequence>(
+        into buffer: Buffer, memory: M, offset: WASIAbi.FileSize
     ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
 }
 

--- a/Sources/WASI/GuestMemorySupport.swift
+++ b/Sources/WASI/GuestMemorySupport.swift
@@ -1,16 +1,16 @@
 import WasmTypes
 
 extension GuestPointee {
-    static func readFromGuest(_ pointer: inout UnsafeGuestRawPointer) -> Self {
+    static func readFromGuest<M: GuestMemory>(_ pointer: inout UnsafeGuestRawPointer, in memory: M) -> Self {
         pointer = pointer.alignedUp(toMultipleOf: Self.alignInGuest)
-        let value = readFromGuest(pointer)
+        let value = readFromGuest(pointer, in: memory)
         pointer = pointer.advanced(by: sizeInGuest)
         return value
     }
 
-    static func writeToGuest(at pointer: inout UnsafeGuestRawPointer, value: Self) {
+    static func writeToGuest<M: GuestMemory>(at pointer: inout UnsafeGuestRawPointer, in memory: M, value: Self) {
         pointer = pointer.alignedUp(toMultipleOf: Self.alignInGuest)
-        writeToGuest(at: pointer, value: value)
+        writeToGuest(at: pointer, in: memory, value: value)
         pointer = pointer.advanced(by: sizeInGuest)
     }
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
@@ -1,4 +1,5 @@
 import SystemPackage
+import WasmTypes
 
 /// Base protocol for all file system nodes in memory.
 protocol MemFSNode: AnyObject {
@@ -268,7 +269,7 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         throw WASIAbi.Errno.ESPIPE
     }
 
-    func write<Buffer: Sequence>(vectored buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -277,7 +278,7 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         case .null:
             var totalBytes: UInt32 = 0
             for iovec in buffer {
-                iovec.withHostBufferPointer { bufferPtr in
+                iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     totalBytes += UInt32(bufferPtr.count)
                 }
             }
@@ -285,11 +286,11 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         }
     }
 
-    func pwrite<Buffer: Sequence>(vectored buffer: Buffer, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         throw WASIAbi.Errno.ESPIPE
     }
 
-    func read<Buffer: Sequence>(into buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -300,7 +301,7 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         }
     }
 
-    func pread<Buffer: Sequence>(into buffer: Buffer, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         throw WASIAbi.Errno.ESPIPE
     }
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
@@ -1,5 +1,6 @@
 import SystemExtras
 import SystemPackage
+import WasmTypes
 
 /// A WASIFile implementation for regular files in the memory file system.
 final class MemoryFileEntry: WASIFile {
@@ -195,7 +196,7 @@ final class MemoryFileEntry: WASIFile {
         return WASIAbi.FileSize(newPosition)
     }
 
-    func write<Buffer: Sequence>(vectored buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -206,7 +207,7 @@ final class MemoryFileEntry: WASIFile {
         case .bytes(var bytes):
             var currentPosition = position
             for iovec in buffer {
-                iovec.withHostBufferPointer { bufferPtr in
+                iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     let bytesToWrite = bufferPtr.count
                     let requiredSize = currentPosition + bytesToWrite
 
@@ -226,7 +227,7 @@ final class MemoryFileEntry: WASIFile {
         case .handle(let handle):
             var currentOffset = Int64(position)
             for iovec in buffer {
-                let nwritten = try iovec.withHostBufferPointer { bufferPtr in
+                let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
                 }
                 currentOffset += Int64(nwritten)
@@ -238,7 +239,7 @@ final class MemoryFileEntry: WASIFile {
         return totalWritten
     }
 
-    func pwrite<Buffer: Sequence>(vectored buffer: Buffer, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -249,7 +250,7 @@ final class MemoryFileEntry: WASIFile {
         case .bytes(var bytes):
             var currentOffset = Int(offset)
             for iovec in buffer {
-                iovec.withHostBufferPointer { bufferPtr in
+                iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     let bytesToWrite = bufferPtr.count
                     let requiredSize = currentOffset + bytesToWrite
 
@@ -268,7 +269,7 @@ final class MemoryFileEntry: WASIFile {
         case .handle(let handle):
             var currentOffset = Int64(offset)
             for iovec in buffer {
-                let nwritten = try iovec.withHostBufferPointer { bufferPtr in
+                let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
                 }
                 currentOffset += Int64(nwritten)
@@ -279,7 +280,7 @@ final class MemoryFileEntry: WASIFile {
         return totalWritten
     }
 
-    func read<Buffer: Sequence>(into buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -290,7 +291,7 @@ final class MemoryFileEntry: WASIFile {
         case .bytes(let bytes):
             var currentPosition = position
             for iovec in buffer {
-                iovec.withHostBufferPointer { bufferPtr in
+                iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     let available = max(0, bytes.count - currentPosition)
                     let toRead = min(bufferPtr.count, available)
 
@@ -311,7 +312,7 @@ final class MemoryFileEntry: WASIFile {
         case .handle(let handle):
             var currentOffset = Int64(position)
             for iovec in buffer {
-                let nread = try iovec.withHostBufferPointer { bufferPtr in
+                let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
                 }
                 currentOffset += Int64(nread)
@@ -323,7 +324,7 @@ final class MemoryFileEntry: WASIFile {
         return totalRead
     }
 
-    func pread<Buffer: Sequence>(into buffer: Buffer, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -334,7 +335,7 @@ final class MemoryFileEntry: WASIFile {
         case .bytes(let bytes):
             var currentOffset = Int(offset)
             for iovec in buffer {
-                iovec.withHostBufferPointer { bufferPtr in
+                iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     let available = max(0, bytes.count - currentOffset)
                     let toRead = min(bufferPtr.count, available)
 
@@ -354,7 +355,7 @@ final class MemoryFileEntry: WASIFile {
         case .handle(let handle):
             var currentOffset = Int64(offset)
             for iovec in buffer {
-                let nread = try iovec.withHostBufferPointer { bufferPtr in
+                let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
                     try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
                 }
                 currentOffset += Int64(nread)

--- a/Sources/WASI/Platform/File.swift
+++ b/Sources/WASI/Platform/File.swift
@@ -1,4 +1,5 @@
 import SystemPackage
+import WasmTypes
 
 protocol FdWASIEntry: WASIEntry {
     var fd: FileDescriptor { get }
@@ -37,14 +38,14 @@ extension FdWASIFile {
     }
 
     @inlinable
-    func write<Buffer: Sequence>(vectored buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
         // TODO: Use `writev`
         var bytesWritten: UInt32 = 0
         for iovec in buffer {
-            bytesWritten += try iovec.withHostBufferPointer {
+            bytesWritten += try iovec.withHostBufferPointer(in: memory) {
                 UInt32(try fd.write(UnsafeRawBufferPointer($0)))
             }
         }
@@ -52,11 +53,11 @@ extension FdWASIFile {
     }
 
     @inlinable
-    func pwrite<Buffer: Sequence>(vectored buffer: Buffer, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         // TODO: Use `pwritev`
         var currentOffset: Int64 = Int64(offset)
         for iovec in buffer {
-            currentOffset += try iovec.withHostBufferPointer {
+            currentOffset += try iovec.withHostBufferPointer(in: memory) {
                 Int64(try fd.writeAll(toAbsoluteOffset: currentOffset, $0))
             }
         }
@@ -65,10 +66,10 @@ extension FdWASIFile {
     }
 
     @inlinable
-    func read<Buffer: Sequence>(into buffer: Buffer) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         var nread: UInt32 = 0
         for iovec in buffer {
-            nread += try iovec.withHostBufferPointer {
+            nread += try iovec.withHostBufferPointer(in: memory) {
                 try UInt32(fd.read(into: $0))
             }
         }
@@ -76,11 +77,11 @@ extension FdWASIFile {
     }
 
     @inlinable
-    func pread<Buffer: Sequence>(into buffer: Buffer, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         // TODO: Use `preadv`
         var nread: UInt32 = 0
         for iovec in buffer {
-            nread += try iovec.withHostBufferPointer {
+            nread += try iovec.withHostBufferPointer(in: memory) {
                 try UInt32(fd.read(fromAbsoluteOffset: Int64(offset + UInt64(nread)), into: $0))
             }
         }

--- a/Sources/WASI/Poll.swift
+++ b/Sources/WASI/Poll.swift
@@ -27,10 +27,11 @@ extension FdTable {
     }
 }
 
-func poll(
+func poll<M: GuestMemory>(
     subscriptions: some Sequence<WASIAbi.Subscription>,
     events: UnsafeGuestBufferPointer<WASIAbi.Event>,
-    _ fdTable: FdTable
+    _ fdTable: FdTable,
+    memory: M
 ) throws -> WASIAbi.Size {
     #if os(Windows)
         throw WASIAbi.Errno.ENOTSUP
@@ -60,7 +61,7 @@ func poll(
         var updatedEvents: WASIAbi.Size = 0
         if result == 0, let clockUserData {
             updatedEvents += 1
-            events[0] = .init(userData: clockUserData, error: .SUCCESS, eventType: .clock, fdReadWrite: .init(nBytes: 0, flags: .init(rawValue: 0)))
+            events.write(at: 0, .init(userData: clockUserData, error: .SUCCESS, eventType: .clock, fdReadWrite: .init(nBytes: 0, flags: .init(rawValue: 0))), to: memory)
         } else if result > 0 {
             for (i, fd) in pollfds.enumerated() {
                 guard fd.revents != 0 else { continue }
@@ -68,12 +69,12 @@ func poll(
                 updatedEvents += 1
                 let hangup: WASIAbi.Event.FdReadWrite.Flags = fd.revents & Int16(POLLHUP) != 0 ? [.hangup] : []
                 if fd.revents & Int16(POLLIN) != 0 || (fd.events & Int16(POLLIN) != 0 && fd.revents & Int16(POLLHUP) != 0) {
-                    events[.init(eventIndex)] = .init(userData: fdUserData[i], error: .SUCCESS, eventType: .fdRead, fdReadWrite: .init(nBytes: 0, flags: hangup))
+                    events.write(at: .init(eventIndex), .init(userData: fdUserData[i], error: .SUCCESS, eventType: .fdRead, fdReadWrite: .init(nBytes: 0, flags: hangup)), to: memory)
                 } else if fd.revents & Int16(POLLOUT) != 0 || (fd.events & Int16(POLLOUT) != 0 && fd.revents & Int16(POLLHUP) != 0) {
-                    events[.init(eventIndex)] = .init(userData: fdUserData[i], error: .SUCCESS, eventType: .fdWrite, fdReadWrite: .init(nBytes: 0, flags: hangup))
+                    events.write(at: .init(eventIndex), .init(userData: fdUserData[i], error: .SUCCESS, eventType: .fdWrite, fdReadWrite: .init(nBytes: 0, flags: hangup)), to: memory)
                 } else if fd.revents & Int16(POLLERR | POLLNVAL) != 0 {
                     let eventType: WASIAbi.EventType = fd.events & Int16(POLLIN) != 0 ? .fdRead : .fdWrite
-                    events[.init(eventIndex)] = .init(userData: fdUserData[i], error: .EBADF, eventType: eventType, fdReadWrite: .init(nBytes: 0, flags: []))
+                    events.write(at: .init(eventIndex), .init(userData: fdUserData[i], error: .EBADF, eventType: eventType, fdReadWrite: .init(nBytes: 0, flags: [])), to: memory)
                 }
             }
         } else {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -194,8 +194,8 @@ enum WASIAbi {
         let buffer: UnsafeGuestRawPointer
         let length: WASIAbi.Size
 
-        func withHostBufferPointer<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
-            try buffer.withHostPointer(count: Int(length)) { hostPointer in
+        func withHostBufferPointer<M: GuestMemory, R>(in memory: M, _ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
+            try buffer.withHostPointer(in: memory, count: Int(length)) { hostPointer in
                 try body(hostPointer)
             }
         }
@@ -208,16 +208,16 @@ enum WASIAbi {
             max(UnsafeGuestRawPointer.alignInGuest, WASIAbi.Size.alignInGuest)
         }
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> IOVec {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> IOVec {
             return IOVec(
-                buffer: .readFromGuest(pointer),
-                length: .readFromGuest(pointer.advanced(by: UnsafeGuestRawPointer.sizeInGuest))
+                buffer: .readFromGuest(pointer, in: memory),
+                length: .readFromGuest(pointer.advanced(by: UnsafeGuestRawPointer.sizeInGuest), in: memory)
             )
         }
 
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: IOVec) {
-            UnsafeGuestRawPointer.writeToGuest(at: pointer, value: value.buffer)
-            WASIAbi.Size.writeToGuest(at: pointer.advanced(by: UnsafeGuestRawPointer.sizeInGuest), value: value.length)
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: IOVec) {
+            UnsafeGuestRawPointer.writeToGuest(at: pointer, in: memory, value: value.buffer)
+            WASIAbi.Size.writeToGuest(at: pointer.advanced(by: UnsafeGuestRawPointer.sizeInGuest), in: memory, value: value.length)
         }
     }
 
@@ -249,22 +249,22 @@ enum WASIAbi {
         static let sizeInGuest: UInt32 = 32
         static let alignInGuest: UInt32 = max(ClockId.alignInGuest, Timestamp.alignInGuest, Flags.alignInGuest)
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self {
             var pointer = pointer
             return .init(
-                id: .readFromGuest(&pointer),
-                timeout: .readFromGuest(&pointer),
-                precision: .readFromGuest(&pointer),
-                flags: .readFromGuest(&pointer)
+                id: .readFromGuest(&pointer, in: memory),
+                timeout: .readFromGuest(&pointer, in: memory),
+                precision: .readFromGuest(&pointer, in: memory),
+                flags: .readFromGuest(&pointer, in: memory)
             )
         }
 
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self) {
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self) {
             var pointer = pointer
-            ClockId.writeToGuest(at: &pointer, value: value.id)
-            Timestamp.writeToGuest(at: &pointer, value: value.timeout)
-            Timestamp.writeToGuest(at: &pointer, value: value.precision)
-            Flags.writeToGuest(at: &pointer, value: value.flags)
+            ClockId.writeToGuest(at: &pointer, in: memory, value: value.id)
+            Timestamp.writeToGuest(at: &pointer, in: memory, value: value.timeout)
+            Timestamp.writeToGuest(at: &pointer, in: memory, value: value.precision)
+            Flags.writeToGuest(at: &pointer, in: memory, value: value.flags)
         }
     }
 
@@ -285,21 +285,21 @@ enum WASIAbi {
             static let sizeInGuest: UInt32 = 40
             static let alignInGuest: UInt32 = max(Clock.alignInGuest, Fd.alignInGuest)
 
-            static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self {
+            static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self {
                 var pointer = pointer
-                let tag = UInt8.readFromGuest(&pointer)
+                let tag = UInt8.readFromGuest(&pointer, in: memory)
                 // Align to variant content area (max alignment of all variant payloads)
                 pointer = pointer.alignedUp(toMultipleOf: Clock.alignInGuest)
 
                 switch tag {
                 case 0:
-                    return .clock(.readFromGuest(&pointer))
+                    return .clock(.readFromGuest(&pointer, in: memory))
 
                 case 1:
-                    return .fdRead(.readFromGuest(&pointer))
+                    return .fdRead(.readFromGuest(&pointer, in: memory))
 
                 case 2:
-                    return .fdWrite(.readFromGuest(&pointer))
+                    return .fdWrite(.readFromGuest(&pointer, in: memory))
 
                 default:
                     // FIXME: should this throw?
@@ -307,21 +307,21 @@ enum WASIAbi {
                 }
             }
 
-            static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self) {
+            static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self) {
                 var pointer = pointer
                 switch value {
                 case .clock(let clock):
-                    UInt8.writeToGuest(at: &pointer, value: 0)
+                    UInt8.writeToGuest(at: &pointer, in: memory, value: 0)
                     pointer = pointer.alignedUp(toMultipleOf: Clock.alignInGuest)
-                    Clock.writeToGuest(at: &pointer, value: clock)
+                    Clock.writeToGuest(at: &pointer, in: memory, value: clock)
                 case .fdRead(let fd):
-                    UInt8.writeToGuest(at: &pointer, value: 1)
+                    UInt8.writeToGuest(at: &pointer, in: memory, value: 1)
                     pointer = pointer.alignedUp(toMultipleOf: Clock.alignInGuest)
-                    Fd.writeToGuest(at: &pointer, value: fd)
+                    Fd.writeToGuest(at: &pointer, in: memory, value: fd)
                 case .fdWrite(let fd):
-                    UInt8.writeToGuest(at: &pointer, value: 2)
+                    UInt8.writeToGuest(at: &pointer, in: memory, value: 2)
                     pointer = pointer.alignedUp(toMultipleOf: Clock.alignInGuest)
-                    Fd.writeToGuest(at: &pointer, value: fd)
+                    Fd.writeToGuest(at: &pointer, in: memory, value: fd)
                 }
             }
         }
@@ -331,15 +331,15 @@ enum WASIAbi {
         static let sizeInGuest: UInt32 = 48
         static let alignInGuest: UInt32 = max(UserData.alignInGuest, Union.alignInGuest)
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self {
             var pointer = pointer
-            return .init(userData: .readFromGuest(&pointer), union: .readFromGuest(&pointer))
+            return .init(userData: .readFromGuest(&pointer, in: memory), union: .readFromGuest(&pointer, in: memory))
         }
 
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self) {
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self) {
             var pointer = pointer
-            UserData.writeToGuest(at: &pointer, value: value.userData)
-            Union.writeToGuest(at: &pointer, value: value.union)
+            UserData.writeToGuest(at: &pointer, in: memory, value: value.userData)
+            Union.writeToGuest(at: &pointer, in: memory, value: value.union)
         }
     }
 
@@ -354,14 +354,14 @@ enum WASIAbi {
             static let sizeInGuest: UInt32 = 16
             static let alignInGuest: UInt32 = 8
 
-            static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self {
+            static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self {
                 var pointer = pointer
-                return .init(nBytes: FileSize.readFromGuest(&pointer), flags: Flags.readFromGuest(&pointer))
+                return .init(nBytes: FileSize.readFromGuest(&pointer, in: memory), flags: Flags.readFromGuest(&pointer, in: memory))
             }
-            static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self) {
+            static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self) {
                 var pointer = pointer
-                FileSize.writeToGuest(at: &pointer, value: value.nBytes)
-                Flags.writeToGuest(at: &pointer, value: value.flags)
+                FileSize.writeToGuest(at: &pointer, in: memory, value: value.nBytes)
+                Flags.writeToGuest(at: &pointer, in: memory, value: value.flags)
             }
         }
 
@@ -372,21 +372,21 @@ enum WASIAbi {
         static let sizeInGuest: UInt32 = 32
         static let alignInGuest: UInt32 = 8
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self {
             var pointer = pointer
             return .init(
-                userData: .readFromGuest(&pointer),
-                error: .readFromGuest(&pointer),
-                eventType: .readFromGuest(&pointer),
-                fdReadWrite: .readFromGuest(&pointer)
+                userData: .readFromGuest(&pointer, in: memory),
+                error: .readFromGuest(&pointer, in: memory),
+                eventType: .readFromGuest(&pointer, in: memory),
+                fdReadWrite: .readFromGuest(&pointer, in: memory)
             )
         }
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self) {
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self) {
             var pointer = pointer
-            UserData.writeToGuest(at: &pointer, value: value.userData)
-            Errno.writeToGuest(at: &pointer, value: value.error)
-            EventType.writeToGuest(at: &pointer, value: value.eventType)
-            FdReadWrite.writeToGuest(at: &pointer, value: value.fdReadWrite)
+            UserData.writeToGuest(at: &pointer, in: memory, value: value.userData)
+            Errno.writeToGuest(at: &pointer, in: memory, value: value.error)
+            EventType.writeToGuest(at: &pointer, in: memory, value: value.eventType)
+            FdReadWrite.writeToGuest(at: &pointer, in: memory, value: value.fdReadWrite)
         }
     }
 
@@ -582,22 +582,22 @@ enum WASIAbi {
             24
         }
 
-        static func writeToGuest(unalignedAt pointer: UnsafeGuestRawPointer, end: UnsafeGuestRawPointer, value: Dirent) {
+        static func writeToGuest<M: GuestMemory>(unalignedAt pointer: UnsafeGuestRawPointer, end: UnsafeGuestRawPointer, in memory: M, value: Dirent) {
             var pointer = pointer
             guard pointer < end else { return }
-            DirCookie.writeToGuest(at: pointer, value: value.dNext)
+            DirCookie.writeToGuest(at: pointer, in: memory, value: value.dNext)
             pointer = pointer.advanced(by: DirCookie.sizeInGuest)
 
             guard pointer < end else { return }
-            Inode.writeToGuest(at: pointer, value: value.dIno)
+            Inode.writeToGuest(at: pointer, in: memory, value: value.dIno)
             pointer = pointer.advanced(by: Inode.sizeInGuest)
 
             guard pointer < end else { return }
-            DirNameLen.writeToGuest(at: pointer, value: value.dirNameLen)
+            DirNameLen.writeToGuest(at: pointer, in: memory, value: value.dirNameLen)
             pointer = pointer.advanced(by: DirNameLen.sizeInGuest)
 
             guard pointer < end else { return }
-            FileType.writeToGuest(at: pointer, value: value.dType)
+            FileType.writeToGuest(at: pointer, in: memory, value: value.dType)
             pointer = pointer.advanced(by: FileType.sizeInGuest)
         }
     }
@@ -627,22 +627,22 @@ enum WASIAbi {
             FileType.sizeInGuest + Fdflags.sizeInGuest + Rights.sizeInGuest * 2
         }
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> FdStat {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> FdStat {
             var pointer = pointer
             return FdStat(
-                fsFileType: .readFromGuest(&pointer),
-                fsFlags: .readFromGuest(&pointer),
-                fsRightsBase: .readFromGuest(&pointer),
-                fsRightsInheriting: .readFromGuest(&pointer)
+                fsFileType: .readFromGuest(&pointer, in: memory),
+                fsFlags: .readFromGuest(&pointer, in: memory),
+                fsRightsBase: .readFromGuest(&pointer, in: memory),
+                fsRightsInheriting: .readFromGuest(&pointer, in: memory)
             )
         }
 
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: FdStat) {
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: FdStat) {
             var pointer = pointer
-            FileType.writeToGuest(at: &pointer, value: value.fsFileType)
-            Fdflags.writeToGuest(at: &pointer, value: value.fsFlags)
-            Rights.writeToGuest(at: &pointer, value: value.fsRightsBase)
-            Rights.writeToGuest(at: &pointer, value: value.fsRightsInheriting)
+            FileType.writeToGuest(at: &pointer, in: memory, value: value.fsFileType)
+            Fdflags.writeToGuest(at: &pointer, in: memory, value: value.fsFlags)
+            Rights.writeToGuest(at: &pointer, in: memory, value: value.fsRightsBase)
+            Rights.writeToGuest(at: &pointer, in: memory, value: value.fsRightsInheriting)
         }
     }
 
@@ -705,26 +705,26 @@ enum WASIAbi {
         /// Last file status change timestamp.
         let ctim: Timestamp
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> WASIAbi.Filestat {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> WASIAbi.Filestat {
             var pointer = pointer
             return Filestat(
-                dev: .readFromGuest(&pointer), ino: .readFromGuest(&pointer),
-                filetype: .readFromGuest(&pointer), nlink: .readFromGuest(&pointer),
-                size: .readFromGuest(&pointer), atim: .readFromGuest(&pointer),
-                mtim: .readFromGuest(&pointer), ctim: .readFromGuest(&pointer)
+                dev: .readFromGuest(&pointer, in: memory), ino: .readFromGuest(&pointer, in: memory),
+                filetype: .readFromGuest(&pointer, in: memory), nlink: .readFromGuest(&pointer, in: memory),
+                size: .readFromGuest(&pointer, in: memory), atim: .readFromGuest(&pointer, in: memory),
+                mtim: .readFromGuest(&pointer, in: memory), ctim: .readFromGuest(&pointer, in: memory)
             )
         }
 
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: WASIAbi.Filestat) {
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: WASIAbi.Filestat) {
             var pointer = pointer
-            Device.writeToGuest(at: &pointer, value: value.dev)
-            Inode.writeToGuest(at: &pointer, value: value.ino)
-            FileType.writeToGuest(at: &pointer, value: value.filetype)
-            LinkCount.writeToGuest(at: &pointer, value: value.nlink)
-            FileSize.writeToGuest(at: &pointer, value: value.size)
-            Timestamp.writeToGuest(at: &pointer, value: value.atim)
-            Timestamp.writeToGuest(at: &pointer, value: value.mtim)
-            Timestamp.writeToGuest(at: &pointer, value: value.ctim)
+            Device.writeToGuest(at: &pointer, in: memory, value: value.dev)
+            Inode.writeToGuest(at: &pointer, in: memory, value: value.ino)
+            FileType.writeToGuest(at: &pointer, in: memory, value: value.filetype)
+            LinkCount.writeToGuest(at: &pointer, in: memory, value: value.nlink)
+            FileSize.writeToGuest(at: &pointer, in: memory, value: value.size)
+            Timestamp.writeToGuest(at: &pointer, in: memory, value: value.atim)
+            Timestamp.writeToGuest(at: &pointer, in: memory, value: value.mtim)
+            Timestamp.writeToGuest(at: &pointer, in: memory, value: value.ctim)
         }
     }
 
@@ -735,21 +735,21 @@ enum WASIAbi {
         static var sizeInGuest: UInt32 { 8 }
         static var alignInGuest: UInt32 { 4 }
 
-        static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> WASIAbi.Prestat {
+        static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> WASIAbi.Prestat {
             var pointer = pointer
-            switch UInt8.readFromGuest(&pointer) {
+            switch UInt8.readFromGuest(&pointer, in: memory) {
             case 0:
-                return .dir(.readFromGuest(&pointer))
+                return .dir(.readFromGuest(&pointer, in: memory))
             default: fatalError()
             }
         }
 
-        static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: WASIAbi.Prestat) {
+        static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: WASIAbi.Prestat) {
             var pointer = pointer
             switch value {
             case .dir(let dir):
-                UInt8.writeToGuest(at: &pointer, value: 0)
-                PrestatDir.writeToGuest(at: &pointer, value: dir)
+                UInt8.writeToGuest(at: &pointer, in: memory, value: 0)
+                PrestatDir.writeToGuest(at: &pointer, in: memory, value: dir)
             }
         }
     }
@@ -802,10 +802,10 @@ extension WASIImplementation {
 
         func readString(pointer: UInt32, length: UInt32, buffer: GuestMemory) throws -> String {
             let pointer = UnsafeGuestBufferPointer<UInt8>(
-                baseAddress: UnsafeGuestPointer(memorySpace: buffer, offset: pointer),
+                baseAddress: UnsafeGuestPointer(offset: pointer),
                 count: length
             )
-            return try pointer.withHostPointer { hostBuffer in
+            return try pointer.withHostPointer(in: buffer) { hostBuffer in
                 guard let baseAddress = hostBuffer.baseAddress,
                     memchr(baseAddress, 0x00, Int(pointer.count)) == nil
                 else {
@@ -832,8 +832,9 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 self.args_get(
-                    argv: .init(memorySpace: buffer, offset: arguments[0].i32),
-                    argvBuffer: .init(memorySpace: buffer, offset: arguments[1].i32)
+                    argv: .init(offset: arguments[0].i32),
+                    argvBuffer: .init(offset: arguments[1].i32),
+                    memory: buffer
                 )
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
@@ -844,10 +845,10 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 let (argc, bufferSize) = self.args_sizes_get()
-                let argcPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[0].i32)
-                argcPointer.pointee = argc
-                let bufferSizePointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[1].i32)
-                bufferSizePointer.pointee = bufferSize
+                let argcPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[0].i32)
+                argcPointer.write(argc, to: buffer)
+                let bufferSizePointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[1].i32)
+                bufferSizePointer.write(bufferSize, to: buffer)
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
         }
@@ -857,8 +858,9 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 self.environ_get(
-                    environ: .init(memorySpace: buffer, offset: arguments[0].i32),
-                    environBuffer: .init(memorySpace: buffer, offset: arguments[1].i32)
+                    environ: .init(offset: arguments[0].i32),
+                    environBuffer: .init(offset: arguments[1].i32),
+                    memory: buffer
                 )
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
@@ -869,10 +871,10 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 let (environSize, bufferSize) = self.environ_sizes_get()
-                let environSizePointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[0].i32)
-                environSizePointer.pointee = environSize
-                let bufferSizePointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[1].i32)
-                bufferSizePointer.pointee = bufferSize
+                let environSizePointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[0].i32)
+                environSizePointer.write(environSize, to: buffer)
+                let bufferSizePointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[1].i32)
+                bufferSizePointer.write(bufferSize, to: buffer)
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
         }
@@ -884,9 +886,9 @@ extension WASIImplementation {
             let res = try self.clock_res_get(id: id)
             try withMemoryBuffer(caller: caller) { buffer in
                 let resPointer = UnsafeGuestPointer<WASIAbi.Timestamp>(
-                    memorySpace: buffer, offset: arguments[1].i32
+                    offset: arguments[1].i32
                 )
-                resPointer.pointee = res
+                resPointer.write(res, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -898,9 +900,9 @@ extension WASIImplementation {
             let time = try self.clock_time_get(id: id, precision: WASIAbi.Timestamp(arguments[1].i64))
             try withMemoryBuffer(caller: caller) { buffer in
                 let resPointer = UnsafeGuestPointer<WASIAbi.Timestamp>(
-                    memorySpace: buffer, offset: arguments[2].i32
+                    offset: arguments[2].i32
                 )
-                resPointer.pointee = time
+                resPointer.write(time, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -948,8 +950,8 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 let stat = try self.fd_fdstat_get(fileDescriptor: arguments[0].i32)
-                let statPointer = UnsafeGuestPointer<WASIAbi.FdStat>(memorySpace: buffer, offset: arguments[1].i32)
-                statPointer.pointee = stat
+                let statPointer = UnsafeGuestPointer<WASIAbi.FdStat>(offset: arguments[1].i32)
+                statPointer.write(stat, to: buffer)
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
         }
@@ -982,8 +984,8 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 let filestat = try self.fd_filestat_get(fd: arguments[0].i32)
-                let filestatPointer = UnsafeGuestPointer<WASIAbi.Filestat>(memorySpace: buffer, offset: arguments[1].i32)
-                filestatPointer.pointee = filestat
+                let filestatPointer = UnsafeGuestPointer<WASIAbi.Filestat>(offset: arguments[1].i32)
+                filestatPointer.write(filestat, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1016,21 +1018,22 @@ extension WASIImplementation {
                 let nread = try self.fd_pread(
                     fd: arguments[0].i32,
                     iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>(
-                        baseAddress: .init(memorySpace: buffer, offset: arguments[1].i32),
+                        baseAddress: .init(offset: arguments[1].i32),
                         count: arguments[2].i32
                     ),
-                    offset: arguments[3].i64
+                    offset: arguments[3].i64,
+                    memory: buffer
                 )
-                let nreadPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[4].i32)
-                nreadPointer.pointee = nread
+                let nreadPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[4].i32)
+                nreadPointer.write(nread, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
         preview1["fd_prestat_get"] = wasiFunction(type: .init(parameters: [.i32, .i32], results: [.i32])) { caller, arguments in
             let prestat = try self.fd_prestat_get(fd: arguments[0].i32)
             try withMemoryBuffer(caller: caller) { buffer in
-                let prestatPointer = UnsafeGuestPointer<WASIAbi.Prestat>(memorySpace: buffer, offset: arguments[1].i32)
-                prestatPointer.pointee = prestat
+                let prestatPointer = UnsafeGuestPointer<WASIAbi.Prestat>(offset: arguments[1].i32)
+                prestatPointer.write(prestat, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1039,8 +1042,9 @@ extension WASIImplementation {
             try withMemoryBuffer(caller: caller) { buffer in
                 try self.fd_prestat_dir_name(
                     fd: arguments[0].i32,
-                    path: UnsafeGuestPointer(memorySpace: buffer, offset: arguments[1].i32),
-                    maxPathLength: arguments[2].i32
+                    path: UnsafeGuestPointer(offset: arguments[1].i32),
+                    maxPathLength: arguments[2].i32,
+                    memory: buffer
                 )
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
@@ -1053,13 +1057,14 @@ extension WASIImplementation {
                 let nwritten = try self.fd_pwrite(
                     fd: arguments[0].i32,
                     iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>(
-                        baseAddress: .init(memorySpace: buffer, offset: arguments[1].i32),
+                        baseAddress: .init(offset: arguments[1].i32),
                         count: arguments[2].i32
                     ),
-                    offset: arguments[3].i64
+                    offset: arguments[3].i64,
+                    memory: buffer
                 )
-                let nwrittenPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[4].i32)
-                nwrittenPointer.pointee = nwritten
+                let nwrittenPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[4].i32)
+                nwrittenPointer.write(nwritten, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1071,12 +1076,13 @@ extension WASIImplementation {
                 let nread = try self.fd_read(
                     fd: arguments[0].i32,
                     iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>(
-                        baseAddress: .init(memorySpace: buffer, offset: arguments[1].i32),
+                        baseAddress: .init(offset: arguments[1].i32),
                         count: arguments[2].i32
-                    )
+                    ),
+                    memory: buffer
                 )
-                let nreadPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[3].i32)
-                nreadPointer.pointee = nread
+                let nreadPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[3].i32)
+                nreadPointer.write(nread, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1086,13 +1092,14 @@ extension WASIImplementation {
                 let nwritten = try self.fd_readdir(
                     fd: arguments[0].i32,
                     buffer: UnsafeGuestBufferPointer<UInt8>(
-                        baseAddress: UnsafeGuestPointer<UInt8>(memorySpace: buffer, offset: arguments[1].i32),
+                        baseAddress: UnsafeGuestPointer<UInt8>(offset: arguments[1].i32),
                         count: arguments[2].i32
                     ),
-                    cookie: arguments[3].i64
+                    cookie: arguments[3].i64,
+                    memory: buffer
                 )
-                let nwrittenPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[4].i32)
-                nwrittenPointer.pointee = nwritten
+                let nwrittenPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[4].i32)
+                nwrittenPointer.write(nwritten, to: buffer)
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
         }
@@ -1114,8 +1121,8 @@ extension WASIImplementation {
                 fd: arguments[0].i32, offset: WASIAbi.FileDelta(bitPattern: arguments[1].i64), whence: whence
             )
             try withMemoryBuffer(caller: caller) { buffer in
-                let retPointer = UnsafeGuestPointer<WASIAbi.FileSize>(memorySpace: buffer, offset: arguments[3].i32)
-                retPointer.pointee = ret
+                let retPointer = UnsafeGuestPointer<WASIAbi.FileSize>(offset: arguments[3].i32)
+                retPointer.write(ret, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1128,8 +1135,8 @@ extension WASIImplementation {
         preview1["fd_tell"] = wasiFunction(type: .init(parameters: [.i32, .i32], results: [.i32])) { caller, arguments in
             let ret = try self.fd_tell(fd: arguments[0].i32)
             try withMemoryBuffer(caller: caller) { buffer in
-                let retPointer = UnsafeGuestPointer<WASIAbi.FileSize>(memorySpace: buffer, offset: arguments[1].i32)
-                retPointer.pointee = ret
+                let retPointer = UnsafeGuestPointer<WASIAbi.FileSize>(offset: arguments[1].i32)
+                retPointer.write(ret, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1141,12 +1148,13 @@ extension WASIImplementation {
                 let nwritten = try self.fd_write(
                     fileDescriptor: arguments[0].i32,
                     ioVectors: UnsafeGuestBufferPointer<WASIAbi.IOVec>(
-                        baseAddress: .init(memorySpace: buffer, offset: arguments[1].i32),
+                        baseAddress: .init(offset: arguments[1].i32),
                         count: arguments[2].i32
-                    )
+                    ),
+                    memory: buffer
                 )
-                let nwrittenPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[3].i32)
-                nwrittenPointer.pointee = nwritten
+                let nwrittenPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[3].i32)
+                nwrittenPointer.write(nwritten, to: buffer)
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
         }
@@ -1170,8 +1178,8 @@ extension WASIImplementation {
                     dirFd: arguments[0].i32, flags: .init(rawValue: arguments[1].i32),
                     path: readString(pointer: arguments[2].i32, length: arguments[3].i32, buffer: buffer)
                 )
-                let filestatPointer = UnsafeGuestPointer<WASIAbi.Filestat>(memorySpace: buffer, offset: arguments[4].i32)
-                filestatPointer.pointee = filestat
+                let filestatPointer = UnsafeGuestPointer<WASIAbi.Filestat>(offset: arguments[4].i32)
+                filestatPointer.write(filestat, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1220,8 +1228,8 @@ extension WASIImplementation {
                     fsRightsInheriting: .init(rawValue: arguments[6].i64),
                     fdflags: .init(rawValue: UInt16(arguments[7].i32))
                 )
-                let newFdPointer = UnsafeGuestPointer<WASIAbi.Fd>(memorySpace: buffer, offset: arguments[8].i32)
-                newFdPointer.pointee = newFd
+                let newFdPointer = UnsafeGuestPointer<WASIAbi.Fd>(offset: arguments[8].i32)
+                newFdPointer.write(newFd, to: buffer)
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
         }
@@ -1234,12 +1242,13 @@ extension WASIImplementation {
                     fd: arguments[0].i32,
                     path: readString(pointer: arguments[1].i32, length: arguments[2].i32, buffer: buffer),
                     buffer: UnsafeGuestBufferPointer<UInt8>(
-                        baseAddress: .init(memorySpace: buffer, offset: arguments[3].i32),
+                        baseAddress: .init(offset: arguments[3].i32),
                         count: arguments[4].i32
-                    )
+                    ),
+                    memory: buffer
                 )
-                let retPointer = UnsafeGuestPointer<WASIAbi.Size>(memorySpace: buffer, offset: arguments[5].i32)
-                retPointer.pointee = ret
+                let retPointer = UnsafeGuestPointer<WASIAbi.Size>(offset: arguments[5].i32)
+                retPointer.write(ret, to: buffer)
             }
             return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
         }
@@ -1312,8 +1321,9 @@ extension WASIImplementation {
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
                 self.random_get(
-                    buffer: UnsafeGuestPointer<UInt8>(memorySpace: buffer, offset: arguments[0].i32),
-                    length: arguments[1].i32
+                    buffer: UnsafeGuestPointer<UInt8>(offset: arguments[0].i32),
+                    length: arguments[1].i32,
+                    memory: buffer
                 )
                 return [.i32(.init(WASIAbi.Errno.SUCCESS.rawValue))]
             }
@@ -1323,11 +1333,12 @@ extension WASIImplementation {
             type: .init(parameters: [.i32, .i32, .i32, .i32], results: [.i32])
         ) { caller, arguments in
             try withMemoryBuffer(caller: caller) { buffer in
-                let subscriptionsBaseAddress = UnsafeGuestPointer<WASIAbi.Subscription>(memorySpace: buffer, offset: arguments[0].i32)
-                let eventsBaseAddress = UnsafeGuestPointer<WASIAbi.Event>(memorySpace: buffer, offset: arguments[1].i32)
+                let subscriptionsBaseAddress = UnsafeGuestPointer<WASIAbi.Subscription>(offset: arguments[0].i32)
+                let eventsBaseAddress = UnsafeGuestPointer<WASIAbi.Event>(offset: arguments[1].i32)
                 let size = try self.poll_oneoff(
                     subscriptions: .init(baseAddress: subscriptionsBaseAddress, count: arguments[2].i32),
-                    events: .init(baseAddress: eventsBaseAddress, count: arguments[2].i32)
+                    events: .init(baseAddress: eventsBaseAddress, count: arguments[2].i32),
+                    memory: buffer
                 )
                 buffer.withUnsafeMutableBufferPointer(offset: .init(arguments[3].i32), count: MemoryLayout<UInt32>.size) { raw in
                     raw.withMemoryRebound(to: UInt32.self) { rebound in rebound[0] = size.littleEndian }
@@ -1381,18 +1392,19 @@ final class WASIImplementation {
     /// - Parameters:
     ///   - argv: Pointer to an array of argument strings to be written
     ///   - argvBuffer: Pointer to a buffer of argument strings to be written
-    func args_get(
+    func args_get<M: GuestMemory>(
         argv: UnsafeGuestPointer<UnsafeGuestPointer<UInt8>>,
-        argvBuffer: UnsafeGuestPointer<UInt8>
+        argvBuffer: UnsafeGuestPointer<UInt8>,
+        memory: M
     ) {
         var offsets = argv
         var buffer = argvBuffer
         for arg in args {
-            offsets.pointee = buffer
+            offsets.write(buffer, to: memory)
             offsets += 1
             let count = arg.utf8CString.withUnsafeBytes { bytes in
                 let count = UInt32(bytes.count)
-                buffer.raw.withHostPointer(count: bytes.count) { hostDestBuffer in
+                buffer.raw.withHostPointer(in: memory, count: bytes.count) { hostDestBuffer in
                     hostDestBuffer.copyMemory(from: bytes)
                 }
                 return count
@@ -1412,15 +1424,15 @@ final class WASIImplementation {
     }
 
     /// Read environment variable data.
-    func environ_get(environ: UnsafeGuestPointer<UnsafeGuestPointer<UInt8>>, environBuffer: UnsafeGuestPointer<UInt8>) {
+    func environ_get<M: GuestMemory>(environ: UnsafeGuestPointer<UnsafeGuestPointer<UInt8>>, environBuffer: UnsafeGuestPointer<UInt8>, memory: M) {
         var offsets = environ
         var buffer = environBuffer
         for (key, value) in environment {
-            offsets.pointee = buffer
+            offsets.write(buffer, to: memory)
             offsets += 1
             let count = "\(key)=\(value)".utf8CString.withUnsafeBytes { bytes in
                 let count = UInt32(bytes.count)
-                buffer.raw.withHostPointer(count: bytes.count) { hostDestBuffer in
+                buffer.raw.withHostPointer(in: memory, count: bytes.count) { hostDestBuffer in
                     hostDestBuffer.copyMemory(from: bytes)
                 }
                 return count
@@ -1564,14 +1576,15 @@ final class WASIImplementation {
     }
 
     /// Read from a file descriptor, without using and updating the file descriptor's offset.
-    func fd_pread(
+    func fd_pread<M: GuestMemory>(
         fd: WASIAbi.Fd, iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>,
-        offset: WASIAbi.FileSize
+        offset: WASIAbi.FileSize,
+        memory: M
     ) throws -> WASIAbi.Size {
         guard case .file(let fileEntry) = fdTable[fd] else {
             throw WASIAbi.Errno.EBADF
         }
-        return try fileEntry.pread(into: iovs, offset: offset)
+        return try fileEntry.pread(into: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory, offset: offset)
     }
 
     /// Return a description of the given preopened file descriptor.
@@ -1585,7 +1598,7 @@ final class WASIImplementation {
     }
 
     /// Return a directory name of the given preopened file descriptor
-    func fd_prestat_dir_name(fd: WASIAbi.Fd, path: UnsafeGuestPointer<UInt8>, maxPathLength: WASIAbi.Size) throws {
+    func fd_prestat_dir_name<M: GuestMemory>(fd: WASIAbi.Fd, path: UnsafeGuestPointer<UInt8>, maxPathLength: WASIAbi.Size, memory: M) throws {
         guard case .directory(let entry) = fdTable[fd],
             var preopenPath = entry.preopenPath
         else {
@@ -1596,39 +1609,42 @@ final class WASIImplementation {
             guard bytes.count <= maxPathLength else {
                 throw WASIAbi.Errno.ENAMETOOLONG
             }
-            path.withHostPointer(count: Int(maxPathLength)) { buffer in
+            path.withHostPointer(in: memory, count: Int(maxPathLength)) { buffer in
                 UnsafeMutableRawBufferPointer(buffer).copyBytes(from: bytes)
             }
         }
     }
 
     /// Write to a file descriptor, without using and updating the file descriptor's offset.
-    func fd_pwrite(
+    func fd_pwrite<M: GuestMemory>(
         fd: WASIAbi.Fd, iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>,
-        offset: WASIAbi.FileSize
+        offset: WASIAbi.FileSize,
+        memory: M
     ) throws -> WASIAbi.Size {
         guard case .file(let fileEntry) = fdTable[fd] else {
             throw WASIAbi.Errno.EBADF
         }
-        return try fileEntry.pwrite(vectored: iovs, offset: offset)
+        return try fileEntry.pwrite(vectored: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory, offset: offset)
     }
 
     /// Read from a file descriptor.
-    func fd_read(
+    func fd_read<M: GuestMemory>(
         fd: WASIAbi.Fd,
-        iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>
+        iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>,
+        memory: M
     ) throws -> WASIAbi.Size {
         guard case .file(let fileEntry) = fdTable[fd] else {
             throw WASIAbi.Errno.EBADF
         }
-        return try fileEntry.read(into: iovs)
+        return try fileEntry.read(into: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory)
     }
 
     /// Read directory entries from a directory.
-    func fd_readdir(
+    func fd_readdir<M: GuestMemory>(
         fd: WASIAbi.Fd,
         buffer: UnsafeGuestBufferPointer<UInt8>,
-        cookie: WASIAbi.DirCookie
+        cookie: WASIAbi.DirCookie,
+        memory: M
     ) throws -> WASIAbi.Size {
         guard case .directory(let dirEntry) = fdTable[fd] else {
             throw WASIAbi.Errno.EBADF
@@ -1645,7 +1661,7 @@ final class WASIImplementation {
                 let copyingBytes = min(WASIAbi.Dirent.sizeInGuest, totalBufferSize - bufferUsed)
                 let rangeStart = buffer.baseAddress.raw.advanced(by: bufferUsed)
                 let rangeEnd = rangeStart.advanced(by: copyingBytes)
-                WASIAbi.Dirent.writeToGuest(unalignedAt: rangeStart, end: rangeEnd, value: entry)
+                WASIAbi.Dirent.writeToGuest(unalignedAt: rangeStart, end: rangeEnd, in: memory, value: entry)
                 bufferUsed += copyingBytes
 
                 // bail out if the remaining buffer space is not enough
@@ -1660,7 +1676,7 @@ final class WASIImplementation {
                 let copyingBytes = min(entry.dirNameLen, totalBufferSize - bufferUsed)
                 let rangeStart = buffer.baseAddress.raw.advanced(by: bufferUsed)
                 name.withUTF8 { bytes in
-                    rangeStart.withHostPointer(count: Int(copyingBytes)) { hostBuffer in
+                    rangeStart.withHostPointer(in: memory, count: Int(copyingBytes)) { hostBuffer in
                         hostBuffer.copyMemory(
                             from: UnsafeRawBufferPointer(start: bytes.baseAddress, count: Int(copyingBytes))
                         )
@@ -1719,14 +1735,15 @@ final class WASIImplementation {
     ///   - fileDescriptor: File descriptor to write to.
     ///   - ioVectors: Buffer pointer to an array of byte buffers to write.
     /// - Returns: Number of bytes written.
-    func fd_write(
+    func fd_write<M: GuestMemory>(
         fileDescriptor: WASIAbi.Fd,
-        ioVectors: UnsafeGuestBufferPointer<WASIAbi.IOVec>
+        ioVectors: UnsafeGuestBufferPointer<WASIAbi.IOVec>,
+        memory: M
     ) throws -> UInt32 {
         guard case .file(let entry) = self.fdTable[fileDescriptor] else {
             throw WASIAbi.Errno.EBADF
         }
-        return try entry.write(vectored: ioVectors)
+        return try entry.write(vectored: (0..<ioVectors.count).map { ioVectors.read(at: $0, in: memory) }, memory: memory)
     }
 
     /// Create a directory.
@@ -1802,7 +1819,7 @@ final class WASIImplementation {
     }
 
     /// Read the contents of a symbolic link.
-    func path_readlink(fd: WASIAbi.Fd, path: String, buffer: UnsafeGuestBufferPointer<UInt8>) throws -> WASIAbi.Size {
+    func path_readlink<M: GuestMemory>(fd: WASIAbi.Fd, path: String, buffer: UnsafeGuestBufferPointer<UInt8>, memory: M) throws -> WASIAbi.Size {
         guard case .directory(let dirEntry) = fdTable[fd] else {
             throw WASIAbi.Errno.ENOTDIR
         }
@@ -1810,7 +1827,7 @@ final class WASIImplementation {
         let linkBytes = try dirEntry.readlink(atPath: path)
         let bytesWritten = min(Int(buffer.count), linkBytes.count)
         if bytesWritten > 0 {
-            buffer.withHostPointer { hostBuffer in
+            buffer.withHostPointer(in: memory) { hostBuffer in
                 linkBytes.withUnsafeBytes { linkBytes in
                     guard let source = linkBytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
                     hostBuffer.baseAddress?.update(from: source, count: bytesWritten)
@@ -1859,12 +1876,14 @@ final class WASIImplementation {
     }
 
     /// Concurrently poll for the occurrence of a set of events.
-    func poll_oneoff(
+    func poll_oneoff<M: GuestMemory>(
         subscriptions: UnsafeGuestBufferPointer<WASIAbi.Subscription>,
-        events: UnsafeGuestBufferPointer<WASIAbi.Event>
+        events: UnsafeGuestBufferPointer<WASIAbi.Event>,
+        memory: M
     ) throws -> WASIAbi.Size {
         guard !subscriptions.isEmpty else { throw WASIAbi.Errno.EINVAL }
-        return try poll(subscriptions: subscriptions, events: events, self.fdTable)
+        let materializedSubscriptions = (0..<subscriptions.count).map { subscriptions.read(at: $0, in: memory) }
+        return try poll(subscriptions: materializedSubscriptions, events: events, self.fdTable, memory: memory)
     }
 
     /// Shut down socket send and receive channels.
@@ -1889,9 +1908,9 @@ final class WASIImplementation {
     }
 
     /// Write high-quality random data into a buffer.
-    func random_get(buffer: UnsafeGuestPointer<UInt8>, length: WASIAbi.Size) {
+    func random_get<M: GuestMemory>(buffer: UnsafeGuestPointer<UInt8>, length: WASIAbi.Size, memory: M) {
         guard length > 0 else { return }
-        buffer.withHostPointer(count: Int(length)) {
+        buffer.withHostPointer(in: memory, count: Int(length)) {
             self.randomGenerator.fill(buffer: $0)
         }
     }

--- a/Sources/WITOverlayGenerator/CanonicalABI/StaticCanonicalLoading.swift
+++ b/Sources/WITOverlayGenerator/CanonicalABI/StaticCanonicalLoading.swift
@@ -6,11 +6,23 @@ struct StaticCanonicalLoading: CanonicalLoading {
 
     let printer: SourcePrinter
     let builder: SwiftFunctionBuilder
+    /// When non-nil, generated code uses `ptr.read(from: <contextVarName>.guestMemory)` instead of `ptr.pointee`
+    let contextVarName: String?
+
+    init(printer: SourcePrinter, builder: SwiftFunctionBuilder, contextVarName: String? = nil) {
+        self.printer = printer
+        self.builder = builder
+        self.contextVarName = contextVarName
+    }
 
     private func loadByteSwappable(at pointer: Pointer, type: String) -> Operand {
         let boundPointer = "\(pointer).assumingMemoryBound(to: \(type).self)"
         let loadedVar = builder.variable("loaded")
-        printer.write(line: "let \(loadedVar) = \(boundPointer).pointee")
+        if let contextVarName {
+            printer.write(line: "let \(loadedVar) = \(boundPointer).read(from: \(contextVarName).guestMemory)")
+        } else {
+            printer.write(line: "let \(loadedVar) = \(boundPointer).pointee")
+        }
         return .variable(loadedVar)
     }
 

--- a/Sources/WITOverlayGenerator/CanonicalABI/StaticCanonicalStoring.swift
+++ b/Sources/WITOverlayGenerator/CanonicalABI/StaticCanonicalStoring.swift
@@ -7,10 +7,23 @@ struct StaticCanonicalStoring: CanonicalStoring {
     let printer: SourcePrinter
     let builder: SwiftFunctionBuilder
     let definitionMapping: DefinitionMapping
+    /// When non-nil, generated code uses `ptr.write(value, to: <contextVarName>.guestMemory)` instead of `ptr.pointee = value`
+    let contextVarName: String?
+
+    init(printer: SourcePrinter, builder: SwiftFunctionBuilder, definitionMapping: DefinitionMapping, contextVarName: String? = nil) {
+        self.printer = printer
+        self.builder = builder
+        self.definitionMapping = definitionMapping
+        self.contextVarName = contextVarName
+    }
 
     private func storeByteSwappable(at pointer: Pointer, value: Operand, type: String) {
         let boundPointer = "\(pointer).assumingMemoryBound(to: \(type).self)"
-        printer.write(line: "\(boundPointer).pointee = \(type)(\(value))")
+        if let contextVarName {
+            printer.write(line: "\(boundPointer).write(\(type)(\(value)), to: \(contextVarName).guestMemory)")
+        } else {
+            printer.write(line: "\(boundPointer).pointee = \(type)(\(value))")
+        }
     }
 
     private func storeUInt(at pointer: Pointer, value: Operand, bitWidth: Int) {

--- a/Sources/WITOverlayGenerator/HostGenerators/HostExportFunction.swift
+++ b/Sources/WITOverlayGenerator/HostGenerators/HostExportFunction.swift
@@ -26,7 +26,7 @@ struct HostStaticCanonicalLifting: StaticCanonicalLifting {
         return .call(
             "UnsafeGuestPointer<\(pointeeTypeName)>",
             arguments: [
-                ("offset", value),
+                ("offset", value)
             ])
     }
 

--- a/Sources/WITOverlayGenerator/HostGenerators/HostExportFunction.swift
+++ b/Sources/WITOverlayGenerator/HostGenerators/HostExportFunction.swift
@@ -26,7 +26,6 @@ struct HostStaticCanonicalLifting: StaticCanonicalLifting {
         return .call(
             "UnsafeGuestPointer<\(pointeeTypeName)>",
             arguments: [
-                ("memorySpace", .accessField(.variable(context.contextVar), name: "guestMemory")),
                 ("offset", value),
             ])
     }
@@ -37,6 +36,13 @@ struct HostStaticCanonicalLifting: StaticCanonicalLifting {
             arguments: [
                 ("baseAddress", value), ("count", length),
             ])
+    }
+
+    func liftString(pointer: Operand, length: Operand, encoding: String) throws -> Operand {
+        let bufferPointer = liftBufferPointer(liftPointer(pointer, pointeeTypeName: "UInt8"), length: length)
+        let liftedVar = builder.variable("stringLifted")
+        printer.write(line: "let \(liftedVar) = \(bufferPointer).withHostPointer(in: \(context.contextVar).guestMemory) { String(decoding: $0, as: UTF8.self) }")
+        return .variable(liftedVar)
     }
 
     func liftList(
@@ -150,7 +156,7 @@ struct HostExportFunction {
         var coreParameters = coreSignature.parameters.makeIterator()
 
         var lowering = HostStaticCanonicalLowering(printer: printer, builder: builder, context: context, definitionMapping: definitionMapping)
-        var storing = StaticCanonicalStoring(printer: printer, builder: builder, definitionMapping: definitionMapping)
+        var storing = StaticCanonicalStoring(printer: printer, builder: builder, definitionMapping: definitionMapping, contextVarName: context.contextVar)
 
         for (parameter, parameterName) in zip(function.parameters, parameterNames) {
             let type = try typeResolver(parameter.type)
@@ -175,7 +181,7 @@ struct HostExportFunction {
         printer: SourcePrinter
     ) throws {
         let resultPtrVar = builder.variable("resultPtr")
-        var loading = StaticCanonicalLoading(printer: printer, builder: builder)
+        var loading = StaticCanonicalLoading(printer: printer, builder: builder, contextVarName: context.contextVar)
         printer.write(line: "let \(resultPtrVar) = \(call)[0].i32")
 
         var lifting = HostStaticCanonicalLifting(
@@ -184,7 +190,7 @@ struct HostExportFunction {
         )
         let hostPointerVar = builder.variable("guestPointer")
         printer.write(
-            line: "let \(hostPointerVar) = UnsafeGuestRawPointer(memorySpace: \(context.contextVar).guestMemory, offset: \(resultPtrVar))"
+            line: "let \(hostPointerVar) = UnsafeGuestRawPointer(offset: \(resultPtrVar))"
         )
 
         var loadedResults: [StaticMetaOperand] = []
@@ -225,7 +231,7 @@ struct HostExportFunction {
             printer: printer, builder: builder, context: context,
             definitionMapping: definitionMapping
         )
-        var loading = StaticCanonicalLoading(printer: printer, builder: builder)
+        var loading = StaticCanonicalLoading(printer: printer, builder: builder, contextVarName: context.contextVar)
         for resultType in function.results.types {
             let resolvedResultType = try typeResolver(resultType)
             let lifted = try WIT.CanonicalABI.lift(

--- a/Sources/WasmKit/Component/CanonicalCall.swift
+++ b/Sources/WasmKit/Component/CanonicalCall.swift
@@ -49,7 +49,7 @@ public struct CanonicalCallContext {
         guard case .i32(let new) = results[0] else {
             throw CanonicalABIError(description: "\"cabi_realloc\" export should return an i32 value")
         }
-        return UnsafeGuestRawPointer(memorySpace: guestMemory, offset: new)
+        return UnsafeGuestRawPointer(offset: new)
     }
 }
 
@@ -62,16 +62,5 @@ extension CanonicalCallContext {
     @available(*, deprecated, renamed: "init(options:instance:)")
     public init(options: CanonicalOptions, moduleInstance: Instance, runtime: Runtime) {
         self.init(options: options, instance: moduleInstance)
-    }
-}
-
-@available(*, deprecated, renamed: "Memory", message: "WasmKitGuestMemory has been removed; use Memory instead")
-public typealias WasmKitGuestMemory = Memory
-
-extension Memory {
-    /// Creates a new memory instance from the given store and address
-    @available(*, unavailable, message: "WasmKitGuestMemory has been removed; use Memory instead")
-    public init(store: Store, memory: Memory) {
-        fatalError()
     }
 }

--- a/Sources/WasmKit/Component/CanonicalLifting.swift
+++ b/Sources/WasmKit/Component/CanonicalLifting.swift
@@ -16,7 +16,7 @@ public enum CanonicalLifting {
     ) throws -> [Element] {
         var elements = [Element]()
         elements.reserveCapacity(Int(elementSize))
-        let guestPointer = UnsafeGuestRawPointer(memorySpace: context.guestMemory, offset: pointer)
+        let guestPointer = UnsafeGuestRawPointer(offset: pointer)
         for i in 0..<length {
             let element = try loadElement(guestPointer.advanced(by: i * elementSize))
             elements.append(element)

--- a/Sources/WasmKit/Component/CanonicalLowering.swift
+++ b/Sources/WasmKit/Component/CanonicalLowering.swift
@@ -12,7 +12,7 @@ public enum CanonicalLowering {
         let newBuffer = try context.realloc(
             old: 0, oldSize: 0, oldAlign: 1, newSize: UInt32(bytes.count)
         )
-        newBuffer.withHostPointer(count: bytes.count) { newBuffer in
+        newBuffer.withHostPointer(in: context.guestMemory, count: bytes.count) { newBuffer in
             newBuffer.copyBytes(from: bytes)
         }
         return (newBuffer.offset, UInt32(bytes.count))

--- a/Sources/WasmTypes/GuestMemory.swift
+++ b/Sources/WasmTypes/GuestMemory.swift
@@ -17,10 +17,10 @@ public protocol GuestPointee {
     static var alignInGuest: UInt32 { get }
 
     /// Reads a value of self type from the given pointer of guest memory
-    static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self
+    static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self
 
     /// Writes the given value at the given pointer of guest memory
-    static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self)
+    static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self)
 }
 
 /// A pointer-referenceable primitive type that have the same size and alignment in host and guest
@@ -48,28 +48,28 @@ extension GuestPointee where Self: RawRepresentable, Self.RawValue: GuestPointee
     }
 
     /// Reads a value of RawValue type and constructs a value of Self type
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> Self {
-        Self(rawValue: .readFromGuest(pointer))!
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> Self {
+        Self(rawValue: .readFromGuest(pointer, in: memory))!
     }
 
     /// Writes the raw value of the given value to the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: Self) {
-        Self.RawValue.writeToGuest(at: pointer, value: value.rawValue)
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: Self) {
+        Self.RawValue.writeToGuest(at: pointer, in: memory, value: value.rawValue)
     }
 }
 
 extension UInt8: GuestPrimitivePointee {
     /// Reads a value of `UInt8` type from the given pointer of guest memory
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> UInt8 {
-        pointer.withHostPointer(count: MemoryLayout<UInt8>.size) { hostPointer in
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> UInt8 {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt8>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt8.self)
             return pointer.baseAddress!.pointee
         }
     }
 
     /// Writes the given value at the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: UInt8) {
-        pointer.withHostPointer(count: MemoryLayout<UInt8>.size) { hostPointer in
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: UInt8) {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt8>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt8.self)
             pointer.baseAddress!.pointee = value
         }
@@ -78,8 +78,8 @@ extension UInt8: GuestPrimitivePointee {
 
 extension UInt16: GuestPrimitivePointee {
     /// Reads a value of `UInt16` type from the given pointer of guest memory
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> UInt16 {
-        pointer.withHostPointer(count: MemoryLayout<UInt16>.size) { hostPointer in
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> UInt16 {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt16>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt16.self)
             let value = pointer.baseAddress!.pointee
             #if _endian(little)
@@ -91,8 +91,8 @@ extension UInt16: GuestPrimitivePointee {
     }
 
     /// Writes the given value at the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: UInt16) {
-        pointer.withHostPointer(count: MemoryLayout<UInt16>.size) { hostPointer in
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: UInt16) {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt16>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt16.self)
             let writingValue: UInt16
             #if _endian(little)
@@ -107,8 +107,8 @@ extension UInt16: GuestPrimitivePointee {
 
 extension UInt32: GuestPrimitivePointee {
     /// Reads a value of `UInt32` type from the given pointer of guest memory
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> UInt32 {
-        pointer.withHostPointer(count: MemoryLayout<UInt32>.size) { hostPointer in
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> UInt32 {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt32>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt32.self)
             let value = pointer.baseAddress!.pointee
             #if _endian(little)
@@ -120,8 +120,8 @@ extension UInt32: GuestPrimitivePointee {
     }
 
     /// Writes the given value at the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: UInt32) {
-        pointer.withHostPointer(count: MemoryLayout<UInt32>.size) { hostPointer in
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: UInt32) {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt32>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt32.self)
             let writingValue: UInt32
             #if _endian(little)
@@ -136,8 +136,8 @@ extension UInt32: GuestPrimitivePointee {
 
 extension UInt64: GuestPrimitivePointee {
     /// Reads a value of `UInt64` type from the given pointer of guest memory
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> UInt64 {
-        pointer.withHostPointer(count: MemoryLayout<UInt64>.size) { hostPointer in
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> UInt64 {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt64>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt64.self)
             let value = pointer.baseAddress!.pointee
             #if _endian(little)
@@ -149,8 +149,8 @@ extension UInt64: GuestPrimitivePointee {
     }
 
     /// Writes the given value at the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: UInt64) {
-        pointer.withHostPointer(count: MemoryLayout<UInt64>.size) { hostPointer in
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: UInt64) {
+        pointer.withHostPointer(in: memory, count: MemoryLayout<UInt64>.size) { hostPointer in
             let pointer = hostPointer.assumingMemoryBound(to: UInt64.self)
             let writingValue: UInt64
             #if _endian(little)
@@ -166,34 +166,31 @@ extension UInt64: GuestPrimitivePointee {
 /// A raw pointer representation of guest memory space
 /// > Note: This type assumes pointer-size is 32-bit because WASI preview1 assumes the address space is 32-bit
 public struct UnsafeGuestRawPointer {
-    /// A guest memory space that this pointer points
-    public let memorySpace: GuestMemory
     /// An offset from the base address of the guest memory region
     public let offset: UInt32
 
-    /// Creates a new pointer from the given memory space and offset
-    public init(memorySpace: GuestMemory, offset: UInt32) {
-        self.memorySpace = memorySpace
+    /// Creates a new pointer from the given offset
+    public init(offset: UInt32) {
         self.offset = offset
     }
 
     /// Executes the given closure with a mutable raw pointer to the host memory region mapped as guest memory.
-    public func withHostPointer<R>(count: Int, _ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
-        try memorySpace.withUnsafeMutableBufferPointer(offset: UInt(offset), count: count) { buffer in
+    public func withHostPointer<M: GuestMemory, R>(in memory: M, count: Int, _ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
+        try memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: count) { buffer in
             try body(UnsafeMutableRawBufferPointer(start: buffer.baseAddress!, count: count))
         }
     }
 
     /// Returns a new pointer offset from this pointer by the specified number of bytes.
     public func advanced(by n: UInt32) -> UnsafeGuestRawPointer {
-        UnsafeGuestRawPointer(memorySpace: memorySpace, offset: offset + n)
+        UnsafeGuestRawPointer(offset: offset + n)
     }
 
     /// Obtains the next pointer that is properly aligned for the specified `alignment` value.
     public func alignedUp(toMultipleOf alignment: UInt32) -> UnsafeGuestRawPointer {
         let mask = alignment &- 1
         let aligned = (offset &+ mask) & ~mask
-        return UnsafeGuestRawPointer(memorySpace: memorySpace, offset: aligned)
+        return UnsafeGuestRawPointer(offset: aligned)
     }
 
     /// Returns a typed pointer to the same memory location.
@@ -214,13 +211,13 @@ extension UnsafeGuestRawPointer: GuestPointee {
     }
 
     /// Reads a value of self type from the given pointer of guest memory
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> UnsafeGuestRawPointer {
-        UnsafeGuestRawPointer(memorySpace: pointer.memorySpace, offset: UInt32.readFromGuest(pointer))
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> UnsafeGuestRawPointer {
+        UnsafeGuestRawPointer(offset: UInt32.readFromGuest(pointer, in: memory))
     }
 
     /// Writes the given value at the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: UnsafeGuestRawPointer) {
-        UInt32.writeToGuest(at: pointer, value: value.offset)
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: UnsafeGuestRawPointer) {
+        UInt32.writeToGuest(at: pointer, in: memory, value: value.offset)
     }
 }
 
@@ -252,22 +249,26 @@ public struct UnsafeGuestPointer<Pointee: GuestPointee> {
         self.raw = raw
     }
 
-    /// Creates a new pointer from the given memory space and offset
-    public init(memorySpace: GuestMemory, offset: UInt32) {
-        self.raw = UnsafeGuestRawPointer(memorySpace: memorySpace, offset: offset)
+    /// Creates a new pointer from the given offset
+    public init(offset: UInt32) {
+        self.raw = UnsafeGuestRawPointer(offset: offset)
     }
 
     /// Executes the given closure with a mutable pointer to the host memory region mapped as guest memory.
-    public func withHostPointer<R>(count: Int, _ body: (UnsafeMutableBufferPointer<Pointee>) throws -> R) rethrows -> R {
-        try raw.withHostPointer(count: MemoryLayout<Pointee>.stride * count) { raw in
+    public func withHostPointer<M: GuestMemory, R>(in memory: M, count: Int, _ body: (UnsafeMutableBufferPointer<Pointee>) throws -> R) rethrows -> R {
+        try raw.withHostPointer(in: memory, count: MemoryLayout<Pointee>.stride * count) { raw in
             try body(raw.assumingMemoryBound(to: Pointee.self))
         }
     }
 
-    /// Accesses the instance referenced by this pointer.
-    public var pointee: Pointee {
-        get { Pointee.readFromGuest(self.raw) }
-        nonmutating set { Pointee.writeToGuest(at: raw, value: newValue) }
+    /// Reads the instance referenced by this pointer from the given memory.
+    public func read<M: GuestMemory>(from memory: M) -> Pointee {
+        Pointee.readFromGuest(self.raw, in: memory)
+    }
+
+    /// Writes the given value at this pointer in the given memory.
+    public func write<M: GuestMemory>(_ value: Pointee, to memory: M) {
+        Pointee.writeToGuest(at: raw, in: memory, value: value)
     }
 }
 
@@ -283,13 +284,13 @@ extension UnsafeGuestPointer: GuestPointee {
     }
 
     /// Reads a value of self type from the given pointer of guest memory
-    public static func readFromGuest(_ pointer: UnsafeGuestRawPointer) -> UnsafeGuestPointer<Pointee> {
-        UnsafeGuestPointer(UnsafeGuestRawPointer.readFromGuest(pointer))
+    public static func readFromGuest<M: GuestMemory>(_ pointer: UnsafeGuestRawPointer, in memory: M) -> UnsafeGuestPointer<Pointee> {
+        UnsafeGuestPointer(UnsafeGuestRawPointer.readFromGuest(pointer, in: memory))
     }
 
     /// Writes the given value at the given pointer of guest memory
-    public static func writeToGuest(at pointer: UnsafeGuestRawPointer, value: UnsafeGuestPointer<Pointee>) {
-        UnsafeGuestRawPointer.writeToGuest(at: pointer, value: value.raw)
+    public static func writeToGuest<M: GuestMemory>(at pointer: UnsafeGuestRawPointer, in memory: M, value: UnsafeGuestPointer<Pointee>) {
+        UnsafeGuestRawPointer.writeToGuest(at: pointer, in: memory, value: value.raw)
     }
 }
 
@@ -333,54 +334,23 @@ public struct UnsafeGuestBufferPointer<Pointee: GuestPointee> {
         self.count = count
     }
 
+    /// A Boolean value indicating whether the buffer is empty.
+    public var isEmpty: Bool { count == 0 }
+
     /// Executes the given closure with a mutable buffer pointer to the host memory region mapped as guest memory.
-    public func withHostPointer<R>(_ body: (UnsafeMutableBufferPointer<Pointee>) throws -> R) rethrows -> R {
-        try baseAddress.withHostPointer(count: Int(count)) { baseAddress in
+    public func withHostPointer<M: GuestMemory, R>(in memory: M, _ body: (UnsafeMutableBufferPointer<Pointee>) throws -> R) rethrows -> R {
+        try baseAddress.withHostPointer(in: memory, count: Int(count)) { baseAddress in
             try body(baseAddress)
         }
     }
-}
 
-extension UnsafeGuestBufferPointer: Sequence {
-    /// An iterator over the elements of the buffer.
-    public struct Iterator: IteratorProtocol {
-        var position: UInt32
-        let buffer: UnsafeGuestBufferPointer
-
-        /// Accesses the next element and advances to the subsequent element, or
-        /// returns `nil` if no next element exists.
-        public mutating func next() -> Pointee? {
-            guard position != buffer.count else { return nil }
-            let pointer = buffer.baseAddress + position
-            position += 1
-            return pointer.pointee
-        }
+    /// Reads the element at the given index from the given memory.
+    public func read<M: GuestMemory>(at index: UInt32, in memory: M) -> Pointee {
+        (baseAddress + index).read(from: memory)
     }
 
-    /// Returns an iterator over the elements of this buffer.
-    public func makeIterator() -> Iterator {
-        Iterator(position: 0, buffer: self)
-    }
-}
-
-extension UnsafeGuestBufferPointer: Collection {
-    public typealias Index = UInt32
-
-    /// The index of the first element in a nonempty buffer.
-    public var startIndex: UInt32 { 0 }
-
-    /// The "past the end" position---that is, the position one greater than the
-    /// last valid subscript argument.
-    public var endIndex: UInt32 { count }
-
-    /// Accesses the pointee at the specified offset from the base address of the buffer.
-    public subscript(position: UInt32) -> Element {
-        get { (self.baseAddress + position * Element.sizeInGuest).pointee }
-        nonmutating set { Pointee.writeToGuest(at: self.baseAddress.raw.advanced(by: position * Element.sizeInGuest), value: newValue) }
-    }
-
-    /// Returns the position immediately after the given index.
-    public func index(after i: UInt32) -> UInt32 {
-        return i + 1
+    /// Writes the given value at the given index in the given memory.
+    public func write<M: GuestMemory>(at index: UInt32, _ value: Pointee, to memory: M) {
+        Pointee.writeToGuest(at: baseAddress.raw.advanced(by: index * Pointee.sizeInGuest), in: memory, value: value)
     }
 }

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -58,11 +58,12 @@ enum TestSupport {
             var dataReadOffset: UInt32 = 0
             for buffer in buffers {
                 let iovec = WASIAbi.IOVec(
-                    buffer: UnsafeGuestRawPointer(memorySpace: self, offset: dataReadOffset),
+                    buffer: UnsafeGuestRawPointer(offset: dataReadOffset),
                     length: UInt32(buffer.count)
                 )
                 WASIAbi.IOVec.writeToGuest(
-                    at: UnsafeGuestRawPointer(memorySpace: self, offset: iovecWriteOffset),
+                    at: UnsafeGuestRawPointer(offset: iovecWriteOffset),
+                    in: self,
                     value: iovec
                 )
                 dataReadOffset += UInt32(buffer.count)
@@ -70,7 +71,7 @@ enum TestSupport {
             }
 
             return UnsafeGuestBufferPointer<WASIAbi.IOVec>(
-                baseAddress: UnsafeGuestPointer(memorySpace: self, offset: iovecOffset),
+                baseAddress: UnsafeGuestPointer(offset: iovecOffset),
                 count: UInt32(buffers.count)
             )
         }
@@ -82,11 +83,12 @@ enum TestSupport {
             var iovecWriteOffset = iovecOffset
             for size in sizes {
                 let iovec = WASIAbi.IOVec(
-                    buffer: UnsafeGuestRawPointer(memorySpace: self, offset: currentDataOffset),
+                    buffer: UnsafeGuestRawPointer(offset: currentDataOffset),
                     length: UInt32(size)
                 )
                 WASIAbi.IOVec.writeToGuest(
-                    at: UnsafeGuestRawPointer(memorySpace: self, offset: iovecWriteOffset),
+                    at: UnsafeGuestRawPointer(offset: iovecWriteOffset),
+                    in: self,
                     value: iovec
                 )
                 currentDataOffset += UInt32(size)
@@ -94,7 +96,7 @@ enum TestSupport {
             }
 
             return UnsafeGuestBufferPointer<WASIAbi.IOVec>(
-                baseAddress: UnsafeGuestPointer(memorySpace: self, offset: iovecOffset),
+                baseAddress: UnsafeGuestPointer(offset: iovecOffset),
                 count: UInt32(sizes.count)
             )
         }
@@ -103,10 +105,10 @@ enum TestSupport {
             var result: [[UInt8]] = []
 
             for i in 0..<Int(iovecs.count) {
-                let iovec = (iovecs.baseAddress + UInt32(i)).pointee
+                let iovec = (iovecs.baseAddress + UInt32(i)).read(from: self)
                 var buffer = [UInt8](repeating: 0, count: Int(iovec.length))
 
-                iovec.buffer.withHostPointer(count: Int(iovec.length)) { hostBuffer in
+                iovec.buffer.withHostPointer(in: self, count: Int(iovec.length)) { hostBuffer in
                     buffer.withUnsafeMutableBytes { destBuffer in
                         destBuffer.copyMemory(from: UnsafeRawBufferPointer(hostBuffer))
                     }

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -354,7 +354,7 @@ struct WASITests {
         let memory = try Memory(store: store, type: .init(min: 1))
 
         // Test union size and alignment end-to-end
-        let start = UnsafeGuestRawPointer(memorySpace: memory, offset: 0)
+        let start = UnsafeGuestRawPointer(offset: 0)
         var pointer = start
         let read = WASIAbi.Subscription.Union.fdRead(.init(0))
         let write = WASIAbi.Subscription.Union.fdWrite(.init(0))
@@ -365,33 +365,33 @@ struct WASITests {
         let event = WASIAbi.Event(userData: 3, error: .EIO, eventType: .fdRead, fdReadWrite: .init(nBytes: 37, flags: [.hangup]))
         let eventOffset = clockOffset + WASIAbi.Subscription.sizeInGuest
         let finalOffset = eventOffset + WASIAbi.Event.sizeInGuest
-        WASIAbi.Subscription.writeToGuest(at: &pointer, value: .init(userData: 1, union: read))
+        WASIAbi.Subscription.writeToGuest(at: &pointer, in: memory, value: .init(userData: 1, union: read))
         #expect(pointer.offset == writeOffset)
-        WASIAbi.Subscription.writeToGuest(at: &pointer, value: .init(userData: 2, union: write))
+        WASIAbi.Subscription.writeToGuest(at: &pointer, in: memory, value: .init(userData: 2, union: write))
         #expect(pointer.offset == clockOffset)
-        WASIAbi.Subscription.writeToGuest(at: &pointer, value: .init(userData: 3, union: clock))
+        WASIAbi.Subscription.writeToGuest(at: &pointer, in: memory, value: .init(userData: 3, union: clock))
         #expect(pointer.offset == eventOffset)
-        WASIAbi.Event.writeToGuest(at: &pointer, value: event)
+        WASIAbi.Event.writeToGuest(at: &pointer, in: memory, value: event)
         #expect(pointer.offset == finalOffset)
 
         // Test that reading back yields same result
         pointer = start
-        #expect(WASIAbi.Subscription.readFromGuest(&pointer) == .init(userData: 1, union: read))
+        #expect(WASIAbi.Subscription.readFromGuest(&pointer, in: memory) == .init(userData: 1, union: read))
         #expect(pointer.offset == writeOffset)
-        #expect(WASIAbi.Subscription.readFromGuest(&pointer) == .init(userData: 2, union: write))
+        #expect(WASIAbi.Subscription.readFromGuest(&pointer, in: memory) == .init(userData: 2, union: write))
         #expect(pointer.offset == clockOffset)
-        #expect(WASIAbi.Subscription.readFromGuest(&pointer) == .init(userData: 3, union: clock))
+        #expect(WASIAbi.Subscription.readFromGuest(&pointer, in: memory) == .init(userData: 3, union: clock))
         #expect(pointer.offset == eventOffset)
-        #expect(WASIAbi.Event.readFromGuest(&pointer) == event)
+        #expect(WASIAbi.Event.readFromGuest(&pointer, in: memory) == event)
         #expect(pointer.offset == finalOffset)
 
         #if !os(Windows)
             let elapsed = try ContinuousClock().measure {
-                let clockPointer = UnsafeGuestBufferPointer<WASIAbi.Subscription>(baseAddress: .init(memorySpace: memory, offset: clockOffset), count: 1)
-                let result = try WASIBridgeToHost().underlying.poll_oneoff(subscriptions: clockPointer, events: .init(baseAddress: .init(memorySpace: memory, offset: finalOffset), count: 1))
+                let clockPointer = UnsafeGuestBufferPointer<WASIAbi.Subscription>(baseAddress: .init(offset: clockOffset), count: 1)
+                let result = try WASIBridgeToHost().underlying.poll_oneoff(subscriptions: clockPointer, events: .init(baseAddress: .init(offset: finalOffset), count: 1), memory: memory)
                 #expect(result == 1)
             }
-            #expect(elapsed > .nanoseconds(timeout))
+            #expect(elapsed > Duration.nanoseconds(timeout))
         #endif
     }
 
@@ -968,13 +968,13 @@ struct WASITests {
         let writeData = Array("Hello, WASI!".utf8)
         let writeVecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs)
+        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
 
         _ = try wasi.fd_seek(fd: fd, offset: 0, whence: .SET)
 
         let readVecs = memory.readIOVecs(sizes: [writeData.count])
-        let nread = try wasi.fd_read(fd: fd, iovs: readVecs)
+        let nread = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
         #expect(nread == UInt32(writeData.count))
 
         let readData = memory.loadIOVecs(readVecs)
@@ -1011,7 +1011,7 @@ struct WASITests {
             let writeData = Array("Fail".utf8)
             let iovecs = memory.writeIOVecs([writeData])
 
-            _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs)
+            _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs, memory: memory)
             #expect(Bool(false), "Should not be able to write to read-only file")
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
@@ -1047,12 +1047,12 @@ struct WASITests {
         let writeData = Array("Write only".utf8)
         let writeVecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs)
+        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
 
         do {
             let readVecs = memory.readIOVecs(sizes: [10])
-            _ = try wasi.fd_read(fd: fd, iovs: readVecs)
+            _ = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
             #expect(Bool(false), "Should not be able to read from write-only file")
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
@@ -1097,7 +1097,7 @@ struct WASITests {
             let writeData = Array("Via handle".utf8)
             let iovecs = memory.writeIOVecs([writeData])
 
-            let nwritten = try wasi.fd_write(fileDescriptor: openedFd, ioVectors: iovecs)
+            let nwritten = try wasi.fd_write(fileDescriptor: openedFd, ioVectors: iovecs, memory: memory)
             #expect(nwritten == UInt32(writeData.count))
 
             try wasi.fd_close(fd: openedFd)
@@ -1137,7 +1137,7 @@ struct WASITests {
         let writeData = Array("End".utf8)
         let iovecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs)
+        let nwritten = try wasi.fd_write(fileDescriptor: fd, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
 
         let stat = try wasi.fd_filestat_get(fd: fd)
@@ -1183,7 +1183,7 @@ struct WASITests {
         let writeData = Array("Hello, stdout!".utf8)
         let iovecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: 1, ioVectors: iovecs)
+        let nwritten = try wasi.fd_write(fileDescriptor: 1, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
     }
 
@@ -1201,7 +1201,7 @@ struct WASITests {
         let writeData = Array("Error message".utf8)
         let iovecs = memory.writeIOVecs([writeData])
 
-        let nwritten = try wasi.fd_write(fileDescriptor: 2, ioVectors: iovecs)
+        let nwritten = try wasi.fd_write(fileDescriptor: 2, ioVectors: iovecs, memory: memory)
         #expect(nwritten == UInt32(writeData.count))
     }
 
@@ -1220,7 +1220,7 @@ struct WASITests {
         let iovecs = memory.writeIOVecs([writeData])
 
         do {
-            _ = try wasi.fd_write(fileDescriptor: 0, ioVectors: iovecs)
+            _ = try wasi.fd_write(fileDescriptor: 0, ioVectors: iovecs, memory: memory)
             #expect(Bool(false), "Should not be able to write to stdin")
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
@@ -1241,7 +1241,7 @@ struct WASITests {
         let iovecs = memory.readIOVecs(sizes: [10])
 
         do {
-            _ = try wasi.fd_read(fd: 1, iovs: iovecs)
+            _ = try wasi.fd_read(fd: 1, iovs: iovecs, memory: memory)
             #expect(Bool(false), "Should not be able to read from stdout")
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
@@ -1262,7 +1262,7 @@ struct WASITests {
         let iovecs = memory.readIOVecs(sizes: [10])
 
         do {
-            _ = try wasi.fd_read(fd: 2, iovs: iovecs)
+            _ = try wasi.fd_read(fd: 2, iovs: iovecs, memory: memory)
             #expect(Bool(false), "Should not be able to read from stderr")
         } catch let error as WASIAbi.Errno {
             #expect(error == .EBADF)
@@ -1299,14 +1299,14 @@ struct WASITests {
 
         let memory = TestSupport.TestGuestMemory()
         let readVecs = memory.readIOVecs(sizes: [4])
-        _ = try wasi.fd_read(fd: fd, iovs: readVecs)
+        _ = try wasi.fd_read(fd: fd, iovs: readVecs, memory: memory)
 
         let stat2 = try wasi.fd_filestat_get(fd: fd)
         #expect(stat2.atim >= stat1.atim)
 
         let writeData = Array("more".utf8)
         let writeVecs = memory.writeIOVecs([writeData])
-        _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs)
+        _ = try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory)
 
         let stat3 = try wasi.fd_filestat_get(fd: fd)
         #expect(stat3.mtim >= stat2.mtim)
@@ -1386,12 +1386,12 @@ struct WASITests {
 
             let memory = TestSupport.TestGuestMemory()
             let buffer = UnsafeGuestBufferPointer<UInt8>(
-                baseAddress: UnsafeGuestPointer<UInt8>(memorySpace: memory, offset: 0),
+                baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
                 count: 4096
             )
 
             // Without the noFollow fix, this throws ELOOP due to the cyclic symlink
-            let nwritten = try wasi.fd_readdir(fd: preopenFd, buffer: buffer, cookie: 0)
+            let nwritten = try wasi.fd_readdir(fd: preopenFd, buffer: buffer, cookie: 0, memory: memory)
             #expect(nwritten > 0)
         }
     #endif
@@ -1418,7 +1418,7 @@ struct WASITests {
 
             let memory = TestSupport.TestGuestMemory()
             let buffer = UnsafeGuestBufferPointer<UInt8>(
-                baseAddress: UnsafeGuestPointer<UInt8>(memorySpace: memory, offset: 0),
+                baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
                 count: 4096
             )
             let writeData = Array("hello".utf8)
@@ -1434,7 +1434,7 @@ struct WASITests {
                     fsRightsInheriting: [],
                     fdflags: []
                 )
-                #expect(try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs) > 0)
+                #expect(try wasi.fd_write(fileDescriptor: fd, ioVectors: writeVecs, memory: memory) > 0)
                 try wasi.fd_close(fd: fd)
 
                 try wasi.path_rename(oldFd: dir1Fd, oldPath: "foo/bar", newFd: dir2Fd, newPath: "foo/baz")
@@ -1442,8 +1442,8 @@ struct WASITests {
                 try wasi.path_symlink(oldPath: "baz", dirFd: dir2Fd, newPath: "foo/quux")
                 let stat = try wasi.path_filestat_get(dirFd: dir2Fd, flags: .SYMLINK_FOLLOW, path: "foo/quux")
                 #expect(stat.size == 5)  // hello
-                let count = try Int(wasi.path_readlink(fd: dir2Fd, path: "foo/quux", buffer: buffer))
-                buffer.withHostPointer { ptr in
+                let count = try Int(wasi.path_readlink(fd: dir2Fd, path: "foo/quux", buffer: buffer, memory: memory))
+                buffer.withHostPointer(in: memory) { ptr in
                     #expect(String(decoding: ptr[..<count], as: UTF8.self) == "baz")
                 }
                 try wasi.path_unlink_file(dirFd: dir2Fd, path: "foo/baz")


### PR DESCRIPTION
This should improve WASI performance and make adoption easier for Embedded Swift.