### PR TITLE
Fix subscript visibility

### DIFF
--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -51,7 +51,7 @@ package struct EntityHandle<T>: Equatable, Hashable {
         self.pointer = pointer
     }
 
-    subscript<R>(dynamicMember keyPath: KeyPath<T, R>) -> R {
+    package subscript<R>(dynamicMember keyPath: KeyPath<T, R>) -> R {
         pointer.pointee[keyPath: keyPath]
     }
 


### PR DESCRIPTION
The nominal type has package visibility, so the dynamicMember subscript must also have package visibility.

This is now diagnosed with https://github.com/swiftlang/swift/pull/88480.