### PR TITLE
Add `ThrowingDefer` helper to unify `defer` error handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let DarwinPlatforms: [Platform] = [.macOS, .iOS, .watchOS, .tvOS, .visionOS]
 let cliCommandsTarget = Target.target(
     name: "CLICommands",
     dependencies: [
+        "SystemExtras",
         "WAT",
         "WasmKit",
         "WasmKitWASI",
@@ -99,6 +100,7 @@ let package = Package(
         .target(
             name: "WasmParser",
             dependencies: [
+                "SystemExtras",
                 "WasmTypes",
                 .product(name: "SystemPackage", package: "swift-system"),
                 .target(

--- a/Sources/CLICommands/CMakeLists.txt
+++ b/Sources/CLICommands/CMakeLists.txt
@@ -5,7 +5,7 @@ add_wasmkit_library(CLICommands
 )
 
 target_link_wasmkit_libraries(CLICommands PUBLIC
-  WAT WasmKitWASI)
+  SystemExtras WAT WasmKitWASI)
 
 add_dependencies(
   CLICommands

--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import SystemExtras
 import SystemPackage
 import WAT
 import WasmKit
@@ -353,14 +354,16 @@ package struct Run: AsyncParsableCommand {
 func parseWasm(filePath: FilePath) throws -> Module {
     if filePath.extension == "wat", #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, visionOS 1.0, watchOS 7.0, *) {
         let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-        defer { try? fileHandle.close() }
+        return try withThrowing {
+            let size = try fileHandle.seek(offset: 0, from: .end)
 
-        let size = try fileHandle.seek(offset: 0, from: .end)
-
-        let wat = try String(unsafeUninitializedCapacity: Int(size)) {
-            try fileHandle.read(fromAbsoluteOffset: 0, into: .init($0))
+            let wat = try String(unsafeUninitializedCapacity: Int(size)) {
+                try fileHandle.read(fromAbsoluteOffset: 0, into: .init($0))
+            }
+            return try WasmKit.parseWasm(bytes: wat2wasm(wat))
+        } defer: {
+            try fileHandle.close()
         }
-        return try WasmKit.parseWasm(bytes: wat2wasm(wat))
     } else {
         return try WasmKit.parseWasm(filePath: filePath)
     }

--- a/Sources/CLICommands/Wat2wasm.swift
+++ b/Sources/CLICommands/Wat2wasm.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import SystemExtras
 import SystemPackage
 import WAT
 
@@ -81,45 +82,49 @@ package struct Wat2wasm: ParsableCommand {
         let filePath = FilePath(path)
         guard filePath.extension == "wat" else { throw Error.unknownFileExtension(filePath.extension) }
         let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-        defer { try? fileHandle.close() }
+        try withThrowing {
+            let size = try fileHandle.seek(offset: 0, from: .end)
 
-        let size = try fileHandle.seek(offset: 0, from: .end)
+            let wat: String
+            if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, visionOS 1.0, watchOS 7.0, *) {
+                wat = try String(unsafeUninitializedCapacity: Int(size)) {
+                    try fileHandle.read(fromAbsoluteOffset: 0, into: .init($0))
+                }
+            } else {
+                let watBuffer = try [UInt8](unsafeUninitializedCapacity: Int(size)) { buffer, count in
+                    count = try fileHandle.read(fromAbsoluteOffset: 0, into: .init(buffer))
+                }
+                wat = String(decoding: watBuffer, as: UTF8.self)
+            }
 
-        let wat: String
-        if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, visionOS 1.0, watchOS 7.0, *) {
-            wat = try String(unsafeUninitializedCapacity: Int(size)) {
-                try fileHandle.read(fromAbsoluteOffset: 0, into: .init($0))
+            let wasm = try wat2wasm(wat, options: EncodeOptions(nameSection: nameSection))
+
+            var outputPath: FilePath
+
+            if let output {
+                outputPath = FilePath(output)
+            } else {
+                outputPath = filePath
+                outputPath.extension = "wasm"
+
+                guard (try? FileDescriptor.open(outputPath, .readOnly)) == nil else {
+                    throw Error.fileAlreadyExists(outputPath.string)
+                }
             }
-        } else {
-            let watBuffer = try [UInt8](unsafeUninitializedCapacity: Int(size)) { buffer, count in
-                count = try fileHandle.read(fromAbsoluteOffset: 0, into: .init(buffer))
+
+            let outputHandle = try FileDescriptor.open(
+                outputPath,
+                .writeOnly,
+                options: [.create],
+                permissions: [.ownerReadWrite, .groupRead, .otherRead]
+            )
+            try withThrowing {
+                try outputHandle.writeAll(wasm)
+            } defer: {
+                try outputHandle.close()
             }
-            wat = String(decoding: watBuffer, as: UTF8.self)
+        } defer: {
+            try fileHandle.close()
         }
-
-        let wasm = try wat2wasm(wat, options: EncodeOptions(nameSection: nameSection))
-
-        var outputPath: FilePath
-
-        if let output {
-            outputPath = FilePath(output)
-        } else {
-            outputPath = filePath
-            outputPath.extension = "wasm"
-
-            guard (try? FileDescriptor.open(outputPath, .readOnly)) == nil else {
-                throw Error.fileAlreadyExists(outputPath.string)
-            }
-        }
-
-        let outputHandle = try FileDescriptor.open(
-            outputPath,
-            .writeOnly,
-            options: [.create],
-            permissions: [.ownerReadWrite, .groupRead, .otherRead]
-        )
-        defer { try? outputHandle.close() }
-
-        try outputHandle.writeAll(wasm)
     }
 }

--- a/Sources/SystemExtras/CMakeLists.txt
+++ b/Sources/SystemExtras/CMakeLists.txt
@@ -7,6 +7,7 @@ add_wasmkit_library(SystemExtras
   FileAtOperations.swift
   FileOperations.swift
   Syscalls.swift
+  ThrowingDefer.swift
 )
 
 set(SWIFT_SYSTEM_APPLE_PLATFORMS "Darwin" "iOS" "watchOS" "tvOS" "visionOS")

--- a/Sources/SystemExtras/ThrowingDefer.swift
+++ b/Sources/SystemExtras/ThrowingDefer.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Runs a cleanup closure (`deferred`) after a given `work` closure,
+/// making sure `deferred` is run also when `work` throws an error.
+/// - Parameters:
+///   - work: The work that should be performed. Will always be executed.
+///   - deferred: The cleanup that needs to be done in any case.
+/// - Throws: Any error thrown by `deferred` or `work` (in that order).
+/// - Returns: The result of `work`.
+/// - Note: If `work` **and** `deferred` throw an error,
+///         the one thrown by `deferred` is thrown from this function.
+/// - SeeAlso: ``withAsyncThrowing(do:defer:)``
+@discardableResult
+package func withThrowing<T>(
+    do work: () throws -> T,
+    defer deferred: () throws -> Void
+) throws -> T {
+    do {
+        let result = try work()
+        try deferred()
+        return result
+    } catch {
+        try deferred()
+        throw error
+    }
+}
+
+/// Runs an async cleanup closure (`deferred`) after a given async `work` closure,
+/// making sure `deferred` is run also when `work` throws an error.
+/// - Parameters:
+///   - work: The work that should be performed. Will always be executed.
+///   - deferred: The cleanup that needs to be done in any case.
+/// - Throws: Any error thrown by `deferred` or `work` (in that order).
+/// - Returns: The result of `work`.
+/// - Note: If `work` **and** `deferred` throw an error,
+///         the one thrown by `deferred` is thrown from this function.
+/// - SeeAlso: ``withThrowing(do:defer:)``
+@discardableResult
+package func withAsyncThrowing<T: Sendable>(
+    do work: @Sendable () async throws -> T,
+    defer deferred: @Sendable () async throws -> Void
+) async throws -> T {
+    do {
+        let result = try await work()
+        try await deferred()
+        return result
+    } catch {
+        try await deferred()
+        throw error
+    }
+}

--- a/Sources/WASI/Platform/Directory.swift
+++ b/Sources/WASI/Platform/Directory.swift
@@ -1,3 +1,4 @@
+import SystemExtras
 import SystemPackage
 
 struct DirEntry {
@@ -90,12 +91,15 @@ extension DirEntry: WASIDir, FdWASIEntry {
             symlinkFollow: symlinkFollow, path: path,
             oflags: [], accessMode: .write, fdflags: []
         )
-        defer { try? fd.close() }
-        let (access, modification) = try WASIAbi.Timestamp.platformTimeSpec(
-            atim: atim, mtim: mtim, fstFlags: fstFlags
-        )
-        try WASIAbi.Errno.translatingPlatformErrno {
-            try fd.setTimes(access: access, modification: modification)
+        try withThrowing {
+            let (access, modification) = try WASIAbi.Timestamp.platformTimeSpec(
+                atim: atim, mtim: mtim, fstFlags: fstFlags
+            )
+            try WASIAbi.Errno.translatingPlatformErrno {
+                try fd.setTimes(access: access, modification: modification)
+            }
+        } defer: {
+            try fd.close()
         }
     }
 

--- a/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
+++ b/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
@@ -1,5 +1,6 @@
 #if ComponentModel
     import ComponentModel
+    import SystemExtras
     import SystemPackage
     import WasmParser
 
@@ -19,9 +20,12 @@
         features: WasmFeatureSet = .default
     ) throws -> ParsedComponent {
         let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-        defer { try? fileHandle.close() }
-        let stream = try FileHandleStream(fileHandle: fileHandle)
-        return try parseComponent(stream: stream, features: features)
+        return try withThrowing {
+            let stream = try FileHandleStream(fileHandle: fileHandle)
+            return try parseComponent(stream: stream, features: features)
+        } defer: {
+            try fileHandle.close()
+        }
     }
 
     /// Parse a component binary into a `ParsedComponent` ready for instantiation.

--- a/Sources/WasmKit/ModuleParser.swift
+++ b/Sources/WasmKit/ModuleParser.swift
@@ -1,3 +1,4 @@
+import SystemExtras
 import SystemPackage
 import WasmParser
 
@@ -17,10 +18,13 @@ public func parseWasm(filePath: FilePath, features: WasmFeatureSet = .default) t
         let accessMode: FileDescriptor.AccessMode = .readOnly
     #endif
     let fileHandle = try FileDescriptor.open(filePath, accessMode)
-    defer { try? fileHandle.close() }
-    let stream = try FileHandleStream(fileHandle: fileHandle)
-    let module = try parseModule(stream: stream, features: features)
-    return module
+    return try withThrowing {
+        let stream = try FileHandleStream(fileHandle: fileHandle)
+        let module = try parseModule(stream: stream, features: features)
+        return module
+    } defer: {
+        try fileHandle.close()
+    }
 }
 
 /// Parse a given byte array as a WebAssembly binary format file

--- a/Sources/WasmParser/CMakeLists.txt
+++ b/Sources/WasmParser/CMakeLists.txt
@@ -11,4 +11,4 @@ add_wasmkit_library(WasmParser
 )
 
 target_link_wasmkit_libraries(WasmParser PUBLIC
-  WasmTypes SystemPackage)
+  SystemExtras WasmTypes SystemPackage)

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -1,3 +1,4 @@
+import SystemExtras
 import WasmTypes
 
 import struct SystemPackage.FileDescriptor
@@ -1284,37 +1285,39 @@ public enum WasmFileType: Equatable, Sendable {
 /// - Throws: If the file cannot be opened or read
 public func detectWasmFileType(filePath: FilePath) throws -> WasmFileType {
     let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-    defer { try? fileHandle.close() }
+    return try withThrowing {
+        // Use a tuple to avoid heap allocation - 8 bytes on stack
+        // TODO: needs a `SmallArray` abstraction until `InlineArray` becomes available after dropping support for macOS 15.
+        var header: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (0, 0, 0, 0, 0, 0, 0, 0)
+        let bytesRead = try withUnsafeMutableBytes(of: &header) { buffer in
+            try fileHandle.read(into: buffer)
+        }
 
-    // Use a tuple to avoid heap allocation - 8 bytes on stack
-    // TODO: needs a `SmallArray` abstraction until `InlineArray` becomes available after dropping support for macOS 15.
-    var header: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (0, 0, 0, 0, 0, 0, 0, 0)
-    let bytesRead = try withUnsafeMutableBytes(of: &header) { buffer in
-        try fileHandle.read(into: buffer)
-    }
+        // Need at least 8 bytes for a valid header
+        guard bytesRead >= 8 else {
+            return .unknown
+        }
 
-    // Need at least 8 bytes for a valid header
-    guard bytesRead >= 8 else {
-        return .unknown
-    }
+        // Check magic number: \0asm (uses WASM_MAGIC as source of truth)
+        guard
+            header.0 == WASM_MAGIC[0] && header.1 == WASM_MAGIC[1]
+                && header.2 == WASM_MAGIC[2] && header.3 == WASM_MAGIC[3]
+        else {
+            return .unknown
+        }
 
-    // Check magic number: \0asm (uses WASM_MAGIC as source of truth)
-    guard
-        header.0 == WASM_MAGIC[0] && header.1 == WASM_MAGIC[1]
-            && header.2 == WASM_MAGIC[2] && header.3 == WASM_MAGIC[3]
-    else {
-        return .unknown
-    }
-
-    // Check version and layer bytes:
-    // - Core module: version=0x01, 0x00 and layer=0x00, 0x00
-    // - Component:   version=0x0d, 0x00 and layer=0x01, 0x00
-    switch (header.4, header.5, header.6, header.7) {
-    case (0x01, 0x00, 0x00, 0x00):
-        return .coreModule
-    case (0x0d, 0x00, 0x01, 0x00):
-        return .component
-    default:
-        return .unknown
+        // Check version and layer bytes:
+        // - Core module: version=0x01, 0x00 and layer=0x00, 0x00
+        // - Component:   version=0x0d, 0x00 and layer=0x01, 0x00
+        switch (header.4, header.5, header.6, header.7) {
+        case (0x01, 0x00, 0x00, 0x00):
+            return .coreModule
+        case (0x0d, 0x00, 0x01, 0x00):
+            return .component
+        default:
+            return .unknown
+        }
+    } defer: {
+        try fileHandle.close()
     }
 }


### PR DESCRIPTION
Vendored from https://github.com/swiftlang/swift-sdk-generator/blob/main/Sources/Helpers/ThrowingDefer.swift