### PR TITLE
Make `WASIBridgeToHost` thread-safe

### DIFF
--- a/Sources/WASI/Clock.swift
+++ b/Sources/WASI/Clock.swift
@@ -3,7 +3,7 @@ import SystemExtras
 /// WASI wall clock interface based on WASI Preview 2 `wall-clock` interface.
 ///
 /// See also https://github.com/WebAssembly/wasi-clocks/blob/v0.2.0/wit/wall-clock.wit
-public protocol WallClock {
+public protocol WallClock: Sendable {
     /// An instant in time, in seconds and nanoseconds.
     typealias Duration = (
         seconds: UInt64,
@@ -22,7 +22,7 @@ public protocol WallClock {
 /// WASI monotonic clock interface based on WASI Preview 2 `monotonic-clock` interface.
 ///
 /// See also https://github.com/WebAssembly/wasi-clocks/blob/v0.2.0/wit/monotonic-clock.wit
-public protocol MonotonicClock {
+public protocol MonotonicClock: Sendable {
     /// An instant in time, in nanoseconds.
     typealias Instant = UInt64
     /// A duration of time, in nanoseconds.

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -163,7 +163,7 @@ public enum FileContent {
 /// Protocol for file system implementations used by WASI.
 ///
 /// This protocol contains WASI-specific implementation details.
-protocol FileSystemImplementation: ~Copyable {
+protocol FileSystemImplementation: ~Copyable, Sendable {
     /// Preopens a directory and returns a WASIDir implementation.
     func preopenDirectory(guestPath: String, hostPath: String) throws -> any WASIDir
 

--- a/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
@@ -14,7 +14,7 @@ struct MemoryDirEntry: WASIDir {
     }
 
     func attributes() throws -> WASIAbi.Filestat {
-        let timestamps = dirNode.timestamps
+        let timestamps = fileSystem.withTreeLock { dirNode.timestamps }
         return WASIAbi.Filestat(
             dev: 0, ino: 0, filetype: .DIRECTORY,
             nlink: 1, size: 0,
@@ -55,7 +55,9 @@ struct MemoryDirEntry: WASIDir {
             newMtim = nil
         }
 
-        dirNode.setTimes(atim: newAtim, mtim: newMtim)
+        fileSystem.withTreeLock {
+            dirNode.setTimes(atim: newAtim, mtim: newMtim)
+        }
     }
 
     func advise(
@@ -86,11 +88,11 @@ struct MemoryDirEntry: WASIDir {
     }
 
     func removeDirectory(atPath path: String) throws {
-        try fileSystem.removeNode(in: dirNode, at: path, mustBeDirectory: true)
+        try fileSystem.removeNode(at: self.path, relativePath: path, mustBeDirectory: true)
     }
 
     func removeFile(atPath path: String) throws {
-        try fileSystem.removeNode(in: dirNode, at: path, mustBeDirectory: false)
+        try fileSystem.removeNode(at: self.path, relativePath: path, mustBeDirectory: false)
     }
 
     func symlink(from sourcePath: String, to destPath: String) throws {
@@ -104,13 +106,13 @@ struct MemoryDirEntry: WASIDir {
         }
 
         try fileSystem.rename(
-            from: sourcePath, in: dirNode,
-            to: destPath, in: newMemoryDir.dirNode
+            from: sourcePath, at: self.path,
+            to: destPath, at: newMemoryDir.path
         )
     }
 
     func readEntries(cookie: WASIAbi.DirCookie) throws -> AnyIterator<Result<ReaddirElement, any Error>> {
-        let children = dirNode.listChildren()
+        let children = fileSystem.withTreeLock { dirNode.listChildren() }
 
         let iterator = children.enumerated()
             .dropFirst(Int(cookie))
@@ -214,7 +216,7 @@ struct MemoryDirEntry: WASIDir {
         }
 
         if let dirNode = node as? MemoryDirectoryNode {
-            dirNode.setTimes(atim: newAtim, mtim: newMtim)
+            fileSystem.withTreeLock { dirNode.setTimes(atim: newAtim, mtim: newMtim) }
             return
         }
 
@@ -224,7 +226,7 @@ struct MemoryDirEntry: WASIDir {
 
         switch fileNode.content {
         case .bytes:
-            fileNode.setTimes(atim: newAtim, mtim: newMtim)
+            fileSystem.withTreeLock { fileNode.setTimes(atim: newAtim, mtim: newMtim) }
 
         case .handle(let handle):
             let accessTime: FileTime

--- a/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
@@ -5,11 +5,13 @@ import WasmTypes
 /// A WASIFile implementation for regular files in the memory file system.
 final class MemoryFileEntry: WASIFile {
     let fileNode: MemoryFileNode
+    let fileSystem: MemoryFileSystem
     let accessMode: FileAccessMode
     var position: Int
 
-    init(fileNode: MemoryFileNode, accessMode: FileAccessMode, position: Int = 0) {
+    init(fileNode: MemoryFileNode, fileSystem: MemoryFileSystem, accessMode: FileAccessMode, position: Int = 0) {
         self.fileNode = fileNode
+        self.fileSystem = fileSystem
         self.accessMode = accessMode
         self.position = position
     }
@@ -17,10 +19,12 @@ final class MemoryFileEntry: WASIFile {
     // MARK: - WASIEntry
 
     func attributes() throws -> WASIAbi.Filestat {
-        let timestamps = fileNode.timestamps
+        let (timestamps, size) = fileSystem.withTreeLock {
+            (fileNode.timestamps, fileNode.size)
+        }
         return WASIAbi.Filestat(
             dev: 0, ino: 0, filetype: .REGULAR_FILE,
-            nlink: 1, size: WASIAbi.FileSize(fileNode.size),
+            nlink: 1, size: WASIAbi.FileSize(size),
             atim: timestamps.atim,
             mtim: timestamps.mtim,
             ctim: timestamps.ctim
@@ -60,7 +64,9 @@ final class MemoryFileEntry: WASIFile {
                 newMtim = nil
             }
 
-            fileNode.setTimes(atim: newAtim, mtim: newMtim)
+            fileSystem.withTreeLock {
+                fileNode.setTimes(atim: newAtim, mtim: newMtim)
+            }
 
         case .handle(let handle):
             let accessTime: FileTime
@@ -128,15 +134,18 @@ final class MemoryFileEntry: WASIFile {
 
     func setFilestatSize(_ size: WASIAbi.FileSize) throws {
         switch fileNode.content {
-        case .bytes(var bytes):
-            let newSize = Int(size)
-            if newSize < bytes.count {
-                bytes = Array(bytes.prefix(newSize))
-            } else if newSize > bytes.count {
-                bytes.append(contentsOf: Array(repeating: 0, count: newSize - bytes.count))
+        case .bytes:
+            fileSystem.withTreeLock {
+                guard case .bytes(var bytes) = fileNode.content else { return }
+                let newSize = Int(size)
+                if newSize < bytes.count {
+                    bytes = Array(bytes.prefix(newSize))
+                } else if newSize > bytes.count {
+                    bytes.append(contentsOf: Array(repeating: 0, count: newSize - bytes.count))
+                }
+                fileNode.content = .bytes(bytes)
+                fileNode.touchModificationTime()
             }
-            fileNode.content = .bytes(bytes)
-            fileNode.touchModificationTime()
 
         case .handle(let handle):
             try handle.truncate(size: Int64(size))
@@ -163,14 +172,18 @@ final class MemoryFileEntry: WASIFile {
         let newPosition: Int
 
         switch fileNode.content {
-        case .bytes(let bytes):
+        case .bytes:
+            let byteCount = fileSystem.withTreeLock {
+                guard case .bytes(let bytes) = fileNode.content else { return 0 }
+                return bytes.count
+            }
             switch whence {
             case .SET:
                 newPosition = Int(offset)
             case .CUR:
                 newPosition = position + Int(offset)
             case .END:
-                newPosition = bytes.count + Int(offset)
+                newPosition = byteCount + Int(offset)
             }
 
         case .handle(let handle):
@@ -204,25 +217,28 @@ final class MemoryFileEntry: WASIFile {
         var totalWritten: UInt32 = 0
 
         switch fileNode.content {
-        case .bytes(var bytes):
-            var currentPosition = position
-            for iovec in buffer {
-                iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    let bytesToWrite = bufferPtr.count
-                    let requiredSize = currentPosition + bytesToWrite
+        case .bytes:
+            fileSystem.withTreeLock {
+                guard case .bytes(var bytes) = fileNode.content else { return }
+                var currentPosition = position
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let bytesToWrite = bufferPtr.count
+                        let requiredSize = currentPosition + bytesToWrite
 
-                    if requiredSize > bytes.count {
-                        bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
+                        if requiredSize > bytes.count {
+                            bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
+                        }
+
+                        bytes.replaceSubrange(currentPosition..<(currentPosition + bytesToWrite), with: bufferPtr)
+                        currentPosition += bytesToWrite
+                        totalWritten += UInt32(bytesToWrite)
                     }
-
-                    bytes.replaceSubrange(currentPosition..<(currentPosition + bytesToWrite), with: bufferPtr)
-                    currentPosition += bytesToWrite
-                    totalWritten += UInt32(bytesToWrite)
                 }
+                fileNode.content = .bytes(bytes)
+                position = currentPosition
+                fileNode.touchModificationTime()
             }
-            fileNode.content = .bytes(bytes)
-            position = currentPosition
-            fileNode.touchModificationTime()
 
         case .handle(let handle):
             var currentOffset = Int64(position)
@@ -247,24 +263,27 @@ final class MemoryFileEntry: WASIFile {
         var totalWritten: UInt32 = 0
 
         switch fileNode.content {
-        case .bytes(var bytes):
-            var currentOffset = Int(offset)
-            for iovec in buffer {
-                iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    let bytesToWrite = bufferPtr.count
-                    let requiredSize = currentOffset + bytesToWrite
+        case .bytes:
+            fileSystem.withTreeLock {
+                guard case .bytes(var bytes) = fileNode.content else { return }
+                var currentOffset = Int(offset)
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let bytesToWrite = bufferPtr.count
+                        let requiredSize = currentOffset + bytesToWrite
 
-                    if requiredSize > bytes.count {
-                        bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
+                        if requiredSize > bytes.count {
+                            bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
+                        }
+
+                        bytes.replaceSubrange(currentOffset..<(currentOffset + bytesToWrite), with: bufferPtr)
+                        currentOffset += bytesToWrite
+                        totalWritten += UInt32(bytesToWrite)
                     }
-
-                    bytes.replaceSubrange(currentOffset..<(currentOffset + bytesToWrite), with: bufferPtr)
-                    currentOffset += bytesToWrite
-                    totalWritten += UInt32(bytesToWrite)
                 }
+                fileNode.content = .bytes(bytes)
+                fileNode.touchModificationTime()
             }
-            fileNode.content = .bytes(bytes)
-            fileNode.touchModificationTime()
 
         case .handle(let handle):
             var currentOffset = Int64(offset)
@@ -288,26 +307,29 @@ final class MemoryFileEntry: WASIFile {
         var totalRead: UInt32 = 0
 
         switch fileNode.content {
-        case .bytes(let bytes):
-            var currentPosition = position
-            for iovec in buffer {
-                iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    let available = max(0, bytes.count - currentPosition)
-                    let toRead = min(bufferPtr.count, available)
+        case .bytes:
+            fileSystem.withTreeLock {
+                guard case .bytes(let bytes) = fileNode.content else { return }
+                var currentPosition = position
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let available = max(0, bytes.count - currentPosition)
+                        let toRead = min(bufferPtr.count, available)
 
-                    guard toRead > 0 else { return }
+                        guard toRead > 0 else { return }
 
-                    bytes.withUnsafeBytes { contentBytes in
-                        let sourcePtr = contentBytes.baseAddress!.advanced(by: currentPosition)
-                        bufferPtr.baseAddress!.copyMemory(from: sourcePtr, byteCount: toRead)
+                        bytes.withUnsafeBytes { contentBytes in
+                            let sourcePtr = contentBytes.baseAddress!.advanced(by: currentPosition)
+                            bufferPtr.baseAddress!.copyMemory(from: sourcePtr, byteCount: toRead)
+                        }
+
+                        currentPosition += toRead
+                        totalRead += UInt32(toRead)
                     }
-
-                    currentPosition += toRead
-                    totalRead += UInt32(toRead)
                 }
+                position = currentPosition
+                fileNode.touchAccessTime()
             }
-            position = currentPosition
-            fileNode.touchAccessTime()
 
         case .handle(let handle):
             var currentOffset = Int64(position)
@@ -332,25 +354,28 @@ final class MemoryFileEntry: WASIFile {
         var totalRead: UInt32 = 0
 
         switch fileNode.content {
-        case .bytes(let bytes):
-            var currentOffset = Int(offset)
-            for iovec in buffer {
-                iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    let available = max(0, bytes.count - currentOffset)
-                    let toRead = min(bufferPtr.count, available)
+        case .bytes:
+            fileSystem.withTreeLock {
+                guard case .bytes(let bytes) = fileNode.content else { return }
+                var currentOffset = Int(offset)
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let available = max(0, bytes.count - currentOffset)
+                        let toRead = min(bufferPtr.count, available)
 
-                    guard toRead > 0 else { return }
+                        guard toRead > 0 else { return }
 
-                    bytes.withUnsafeBytes { contentBytes in
-                        let sourcePtr = contentBytes.baseAddress!.advanced(by: currentOffset)
-                        bufferPtr.baseAddress!.copyMemory(from: sourcePtr, byteCount: toRead)
+                        bytes.withUnsafeBytes { contentBytes in
+                            let sourcePtr = contentBytes.baseAddress!.advanced(by: currentOffset)
+                            bufferPtr.baseAddress!.copyMemory(from: sourcePtr, byteCount: toRead)
+                        }
+
+                        currentOffset += toRead
+                        totalRead += UInt32(toRead)
                     }
-
-                    currentOffset += toRead
-                    totalRead += UInt32(toRead)
                 }
+                fileNode.touchAccessTime()
             }
-            fileNode.touchAccessTime()
 
         case .handle(let handle):
             var currentOffset = Int64(offset)

--- a/Sources/WASI/MemoryFileSystem/MemoryFileSystem.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileSystem.swift
@@ -1,3 +1,4 @@
+import Synchronization
 import SystemPackage
 
 /// An in-memory file system implementation for WASI environments.
@@ -17,14 +18,163 @@ import SystemPackage
 /// let fd = try FileDescriptor.open("/path/to/file", .readOnly)
 /// try fs.addFile(at: "/mounted.txt", handle: fd)
 /// ```
-public final class MemoryFileSystem: FileSystemImplementation {
+public final class MemoryFileSystem: FileSystemImplementation, Sendable {
     private static let rootPath = "/"
 
-    private var root: MemoryDirectoryNode
+    private let root: Mutex<MemoryDirectoryNode>
 
     /// Creates a new in-memory file system.
     public init() throws {
-        self.root = MemoryDirectoryNode()
+        self.root = Mutex(MemoryDirectoryNode())
+    }
+
+    // MARK: - Tree Lock
+
+    /// Acquires the tree-wide lock for use by MemoryDirEntry / MemoryFileEntry.
+    /// All node mutations must be performed under this lock.
+    func withTreeLock<R>(_ body: () throws -> R) rethrows -> R {
+        try root.withLock { _ in try body() }
+    }
+
+    // MARK: - Static Unlocked Helpers (must be called under root lock)
+    //
+    // These are static to avoid capturing `self` inside Mutex.withLock closures,
+    // which would connect the `inout sending` lock parameter to the task-isolated
+    // `self` region and violate region isolation constraints.
+
+    /// Traverses the tree from `root` to `path`. Must be called under root lock.
+    private static func lookupNode(from root: MemoryDirectoryNode, at path: String) -> MemFSNode? {
+        let normalized = normalizePath(path)
+        if normalized == Self.rootPath {
+            return root
+        }
+
+        let components = normalized.split(separator: "/").map(String.init)
+        var current: MemFSNode = root
+
+        for component in components {
+            guard let dir = current as? MemoryDirectoryNode else {
+                return nil
+            }
+            guard let next = dir.getChild(name: component) else {
+                return nil
+            }
+            current = next
+        }
+
+        return current
+    }
+
+    /// Resolves a relative path from a directory node. Must be called under root lock.
+    private static func resolveNode(root: MemoryDirectoryNode, from directory: MemoryDirectoryNode, at directoryPath: String, path relativePath: String) -> MemFSNode? {
+        if relativePath.isEmpty {
+            return directory
+        }
+
+        if relativePath.hasPrefix("/") {
+            return lookupNode(from: root, at: relativePath)
+        }
+
+        let fullPath: String
+        if directoryPath == Self.rootPath {
+            fullPath = Self.rootPath + relativePath
+        } else {
+            fullPath = directoryPath + "/" + relativePath
+        }
+
+        let components = fullPath.split(separator: "/").map(String.init)
+        var stack: [String] = []
+
+        for component in components {
+            if component == "." {
+                continue
+            } else if component == ".." {
+                if !stack.isEmpty {
+                    stack.removeLast()
+                }
+            } else {
+                stack.append(component)
+            }
+        }
+
+        let resolvedPath = stack.isEmpty ? Self.rootPath : Self.rootPath + stack.joined(separator: "/")
+        return lookupNode(from: root, at: resolvedPath)
+    }
+
+    /// Ensures all directory components exist. Must be called under root lock.
+    private static func ensureDirectoryNode(from root: MemoryDirectoryNode, at path: String) throws -> MemoryDirectoryNode {
+        let normalized = normalizePath(path)
+        if normalized == Self.rootPath {
+            return root
+        }
+
+        let components = normalized.split(separator: "/").map(String.init)
+        var current = root
+
+        for component in components {
+            if let existing = current.getChild(name: component) {
+                guard let dir = existing as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOTDIR
+                }
+                current = dir
+            } else {
+                let newDir = MemoryDirectoryNode()
+                current.setChild(name: component, node: newDir)
+                current = newDir
+            }
+        }
+
+        return current
+    }
+
+    /// Must be called under root lock.
+    @discardableResult
+    private static func createFileNode(in directory: MemoryDirectoryNode, at relativePath: String, oflags: WASIAbi.Oflags) throws -> MemoryFileNode {
+        try validateRelativePath(relativePath)
+
+        let components = relativePath.split(separator: "/").map(String.init)
+        guard let fileName = components.last else {
+            throw WASIAbi.Errno.EINVAL
+        }
+
+        let parentDir = try traverseToParent(from: directory, components: Array(components.dropLast()))
+
+        if let existing = parentDir.getChild(name: fileName) {
+            guard let fileNode = existing as? MemoryFileNode else {
+                throw WASIAbi.Errno.EISDIR
+            }
+            if oflags.contains(.TRUNC) {
+                fileNode.content = .bytes([])
+            }
+            return fileNode
+        } else {
+            let fileNode = MemoryFileNode(bytes: [])
+            parentDir.setChild(name: fileName, node: fileNode)
+            return fileNode
+        }
+    }
+
+    private static func validateRelativePath(_ path: String) throws {
+        guard !path.isEmpty && !path.hasPrefix("/") else {
+            throw WASIAbi.Errno.EINVAL
+        }
+    }
+
+    private static func traverseToParent(from directory: MemoryDirectoryNode, components: [String]) throws -> MemoryDirectoryNode {
+        var current = directory
+        for component in components {
+            if let existing = current.getChild(name: component) {
+                guard let dir = existing as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOTDIR
+                }
+                current = dir
+            } else {
+                let newDir = MemoryDirectoryNode()
+                current.setChild(name: component, node: newDir)
+                current = newDir
+            }
+        }
+        return current
     }
 
     // MARK: - Public API
@@ -35,11 +185,14 @@ public final class MemoryFileSystem: FileSystemImplementation {
     ///   - path: The path where the file should be created
     ///   - content: The file content as a sequence of bytes
     public func addFile(at path: String, content: some Sequence<UInt8>) throws {
-        let normalized = normalizePath(path)
-        let (parentPath, fileName) = try splitPath(normalized)
+        let normalized = Self.normalizePath(path)
+        let (parentPath, fileName) = try Self.splitPath(normalized)
+        let bytes = Array(content)
 
-        let parent = try ensureDirectory(at: parentPath)
-        parent.setChild(name: fileName, node: MemoryFileNode(bytes: content))
+        try root.withLock { root in
+            let parent = try Self.ensureDirectoryNode(from: root, at: parentPath)
+            parent.setChild(name: fileName, node: MemoryFileNode(content: .bytes(bytes)))
+        }
     }
 
     /// Adds a file to the file system with the given string content.
@@ -57,11 +210,13 @@ public final class MemoryFileSystem: FileSystemImplementation {
     ///   - path: The path where the file should be created
     ///   - handle: The file descriptor handle
     public func addFile(at path: String, handle: FileDescriptor) throws {
-        let normalized = normalizePath(path)
-        let (parentPath, fileName) = try splitPath(normalized)
+        let normalized = Self.normalizePath(path)
+        let (parentPath, fileName) = try Self.splitPath(normalized)
 
-        let parent = try ensureDirectory(at: parentPath)
-        parent.setChild(name: fileName, node: MemoryFileNode(handle: handle))
+        try root.withLock { root in
+            let parent = try Self.ensureDirectoryNode(from: root, at: parentPath)
+            parent.setChild(name: fileName, node: MemoryFileNode(handle: handle))
+        }
     }
 
     /// Gets the content of a file at the specified path.
@@ -69,30 +224,31 @@ public final class MemoryFileSystem: FileSystemImplementation {
     /// - Parameter path: The path of the file to retrieve
     /// - Returns: The file content
     public func getFile(at path: String) throws -> FileContent {
-        guard let node = lookup(at: path) else {
-            throw WASIAbi.Errno.ENOENT
+        try root.withLock { root in
+            guard let node = Self.lookupNode(from: root, at: path) else {
+                throw WASIAbi.Errno.ENOENT
+            }
+            guard let fileNode = node as? MemoryFileNode else {
+                throw WASIAbi.Errno.EISDIR
+            }
+            return fileNode.content
         }
-
-        guard let fileNode = node as? MemoryFileNode else {
-            throw WASIAbi.Errno.EISDIR
-        }
-
-        return fileNode.content
     }
 
     /// Removes a file from the file system.
     ///
     /// - Parameter path: The path of the file to remove
     public func removeFile(at path: String) throws {
-        let normalized = normalizePath(path)
-        let (parentPath, fileName) = try splitPath(normalized)
+        let normalized = Self.normalizePath(path)
+        let (parentPath, fileName) = try Self.splitPath(normalized)
 
-        guard let parent = lookup(at: parentPath) as? MemoryDirectoryNode else {
-            throw WASIAbi.Errno.ENOENT
-        }
-
-        guard parent.removeChild(name: fileName) else {
-            throw WASIAbi.Errno.ENOENT
+        try root.withLock { root in
+            guard let parent = Self.lookupNode(from: root, at: parentPath) as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOENT
+            }
+            guard parent.removeChild(name: fileName) else {
+                throw WASIAbi.Errno.ENOENT
+            }
         }
     }
 
@@ -122,286 +278,206 @@ public final class MemoryFileSystem: FileSystemImplementation {
             throw WASIAbi.Errno.EBADF
         }
 
-        let fullPath = memoryDir.path.hasSuffix("/") ? memoryDir.path + path : memoryDir.path + "/" + path
+        // Extract Sendable values before the lock closure to avoid capturing
+        // non-Sendable MemoryDirEntry in the lock's region.
+        let dirPath = memoryDir.path
+        let fullPath = dirPath.hasSuffix("/") ? dirPath + path : dirPath + "/" + path
 
-        var node = resolve(from: memoryDir.dirNode, at: memoryDir.path, path: path)
-
-        if node != nil {
-            if oflags.contains(.EXCL) && oflags.contains(.CREAT) {
-                throw WASIAbi.Errno.EEXIST
+        return try root.withLock { root in
+            // Re-resolve the directory from root using the path
+            guard let dirNode = Self.lookupNode(from: root, at: dirPath) as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.EBADF
             }
-        } else {
-            if oflags.contains(.CREAT) {
-                node = try createFile(in: memoryDir.dirNode, at: path, oflags: oflags)
+
+            var node = Self.resolveNode(root: root, from: dirNode, at: dirPath, path: path)
+
+            if node != nil {
+                if oflags.contains(.EXCL) && oflags.contains(.CREAT) {
+                    throw WASIAbi.Errno.EEXIST
+                }
             } else {
+                if oflags.contains(.CREAT) {
+                    node = try Self.createFileNode(in: dirNode, at: path, oflags: oflags)
+                } else {
+                    throw WASIAbi.Errno.ENOENT
+                }
+            }
+
+            guard let resolvedNode = node else {
                 throw WASIAbi.Errno.ENOENT
             }
+
+            if oflags.contains(.DIRECTORY) {
+                guard resolvedNode.type == .directory else {
+                    throw WASIAbi.Errno.ENOTDIR
+                }
+            }
+
+            if resolvedNode.type == .directory {
+                guard let dirNode = resolvedNode as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOTDIR
+                }
+                return .directory(
+                    MemoryDirEntry(
+                        preopenPath: nil,
+                        dirNode: dirNode,
+                        path: fullPath,
+                        fileSystem: self
+                    ))
+            }
+
+            if resolvedNode.type == .file {
+                guard let fileNode = resolvedNode as? MemoryFileNode else {
+                    throw WASIAbi.Errno.EBADF
+                }
+
+                if oflags.contains(.TRUNC) && fsRightsBase.contains(.FD_WRITE) {
+                    fileNode.content = .bytes([])
+                }
+
+                var accessMode: FileAccessMode = []
+                if fsRightsBase.contains(.FD_READ) {
+                    accessMode.insert(.read)
+                }
+                if fsRightsBase.contains(.FD_WRITE) {
+                    accessMode.insert(.write)
+                }
+
+                return .file(MemoryFileEntry(fileNode: fileNode, fileSystem: self, accessMode: accessMode, position: 0))
+            }
+
+            if resolvedNode.type == .characterDevice {
+                guard let deviceNode = resolvedNode as? MemoryCharacterDeviceNode else {
+                    throw WASIAbi.Errno.EBADF
+                }
+
+                var accessMode: FileAccessMode = []
+                if fsRightsBase.contains(.FD_READ) {
+                    accessMode.insert(.read)
+                }
+                if fsRightsBase.contains(.FD_WRITE) {
+                    accessMode.insert(.write)
+                }
+
+                return .file(MemoryCharacterDeviceEntry(deviceNode: deviceNode, accessMode: accessMode))
+            }
+
+            throw WASIAbi.Errno.ENOTSUP
         }
-
-        guard let resolvedNode = node else {
-            throw WASIAbi.Errno.ENOENT
-        }
-
-        if oflags.contains(.DIRECTORY) {
-            guard resolvedNode.type == .directory else {
-                throw WASIAbi.Errno.ENOTDIR
-            }
-        }
-
-        // Handle directory nodes
-        if resolvedNode.type == .directory {
-            guard let dirNode = resolvedNode as? MemoryDirectoryNode else {
-                throw WASIAbi.Errno.ENOTDIR
-            }
-            return .directory(
-                MemoryDirEntry(
-                    preopenPath: nil,
-                    dirNode: dirNode,
-                    path: fullPath,
-                    fileSystem: self
-                ))
-        }
-
-        // Handle regular file nodes
-        if resolvedNode.type == .file {
-            guard let fileNode = resolvedNode as? MemoryFileNode else {
-                throw WASIAbi.Errno.EBADF
-            }
-
-            if oflags.contains(.TRUNC) && fsRightsBase.contains(.FD_WRITE) {
-                fileNode.content = .bytes([])
-            }
-
-            var accessMode: FileAccessMode = []
-            if fsRightsBase.contains(.FD_READ) {
-                accessMode.insert(.read)
-            }
-            if fsRightsBase.contains(.FD_WRITE) {
-                accessMode.insert(.write)
-            }
-
-            return .file(MemoryFileEntry(fileNode: fileNode, accessMode: accessMode, position: 0))
-        }
-        if resolvedNode.type == .characterDevice {
-            guard let deviceNode = resolvedNode as? MemoryCharacterDeviceNode else {
-                throw WASIAbi.Errno.EBADF
-            }
-
-            var accessMode: FileAccessMode = []
-            if fsRightsBase.contains(.FD_READ) {
-                accessMode.insert(.read)
-            }
-            if fsRightsBase.contains(.FD_WRITE) {
-                accessMode.insert(.write)
-            }
-
-            return .file(MemoryCharacterDeviceEntry(deviceNode: deviceNode, accessMode: accessMode))
-        }
-        throw WASIAbi.Errno.ENOTSUP
     }
 
     // MARK: - File Operations
 
     func lookup(at path: String) -> MemFSNode? {
-        let normalized = normalizePath(path)
-
-        if normalized == Self.rootPath {
-            return root
+        root.withLock { root in
+            Self.lookupNode(from: root, at: path)
         }
-
-        let components = normalized.split(separator: "/").map(String.init)
-        var current: MemFSNode = root
-
-        for component in components {
-            guard let dir = current as? MemoryDirectoryNode else {
-                return nil
-            }
-            guard let next = dir.getChild(name: component) else {
-                return nil
-            }
-            current = next
-        }
-
-        return current
     }
 
-    func resolve(from directory: MemoryDirectoryNode, at directoryPath: String, path relativePath: String) -> MemFSNode? {
-        if relativePath.isEmpty {
-            return directory
-        }
-
-        if relativePath.hasPrefix("/") {
-            return lookup(at: relativePath)
-        }
-
-        let fullPath: String
-        if directoryPath == Self.rootPath {
-            fullPath = Self.rootPath + relativePath
-        } else {
-            fullPath = directoryPath + "/" + relativePath
-        }
-
-        let components = fullPath.split(separator: "/").map(String.init)
-        var stack: [String] = []
-
-        for component in components {
-            if component == "." {
-                continue
-            } else if component == ".." {
-                if !stack.isEmpty {
-                    stack.removeLast()
-                }
-            } else {
-                stack.append(component)
+    func resolve(at directoryPath: String, path relativePath: String) -> MemFSNode? {
+        root.withLock { root in
+            guard let directory = Self.lookupNode(from: root, at: directoryPath) as? MemoryDirectoryNode else {
+                return nil
             }
+            return Self.resolveNode(root: root, from: directory, at: directoryPath, path: relativePath)
         }
-
-        let resolvedPath = stack.isEmpty ? Self.rootPath : Self.rootPath + stack.joined(separator: "/")
-        return lookup(at: resolvedPath)
     }
 
     @discardableResult
     package func ensureDirectory(at path: String) throws -> MemoryDirectoryNode {
-        let normalized = normalizePath(path)
-
-        if normalized == Self.rootPath {
-            return root
-        }
-
-        let components = normalized.split(separator: "/").map(String.init)
-        var current = root
-
-        for component in components {
-            if let existing = current.getChild(name: component) {
-                guard let dir = existing as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-                current = dir
-            } else {
-                let newDir = MemoryDirectoryNode()
-                current.setChild(name: component, node: newDir)
-                current = newDir
-            }
-        }
-
-        return current
-    }
-
-    private func validateRelativePath(_ path: String) throws {
-        guard !path.isEmpty && !path.hasPrefix("/") else {
-            throw WASIAbi.Errno.EINVAL
+        try root.withLock { root in
+            try Self.ensureDirectoryNode(from: root, at: path)
         }
     }
 
-    private func traverseToParent(from directory: MemoryDirectoryNode, components: [String]) throws -> MemoryDirectoryNode {
-        var current = directory
-        for component in components {
-            if let existing = current.getChild(name: component) {
-                guard let dir = existing as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-                current = dir
-            } else {
-                let newDir = MemoryDirectoryNode()
-                current.setChild(name: component, node: newDir)
-                current = newDir
-            }
-        }
-        return current
-    }
-
-    @discardableResult
-    func createFile(in directory: MemoryDirectoryNode, at relativePath: String, oflags: WASIAbi.Oflags) throws -> MemoryFileNode {
-        try validateRelativePath(relativePath)
-
-        let components = relativePath.split(separator: "/").map(String.init)
-        guard let fileName = components.last else {
-            throw WASIAbi.Errno.EINVAL
-        }
-
-        let parentDir = try traverseToParent(from: directory, components: Array(components.dropLast()))
-
-        if let existing = parentDir.getChild(name: fileName) {
-            guard let fileNode = existing as? MemoryFileNode else {
-                throw WASIAbi.Errno.EISDIR
-            }
-            if oflags.contains(.TRUNC) {
-                fileNode.content = .bytes([])
-            }
-            return fileNode
-        } else {
-            let fileNode = MemoryFileNode(bytes: [])
-            parentDir.setChild(name: fileName, node: fileNode)
-            return fileNode
-        }
-    }
-
-    func removeNode(in directory: MemoryDirectoryNode, at relativePath: String, mustBeDirectory: Bool) throws {
-        try validateRelativePath(relativePath)
-
-        let components = relativePath.split(separator: "/").map(String.init)
-        guard let fileName = components.last else {
-            throw WASIAbi.Errno.EINVAL
-        }
-
-        var current = directory
-        for component in components.dropLast() {
-            guard let next = current.getChild(name: component) as? MemoryDirectoryNode else {
+    /// Remove a node relative to the directory at `directoryPath`.
+    /// Accepts paths (Sendable) rather than node references to satisfy
+    /// Mutex.withLock's `inout sending` constraint.
+    func removeNode(at directoryPath: String, relativePath: String, mustBeDirectory: Bool) throws {
+        try root.withLock { root in
+            guard let directory = Self.lookupNode(from: root, at: directoryPath) as? MemoryDirectoryNode else {
                 throw WASIAbi.Errno.ENOENT
             }
-            current = next
-        }
 
-        guard let node = current.getChild(name: fileName) else {
-            throw WASIAbi.Errno.ENOENT
-        }
+            try Self.validateRelativePath(relativePath)
 
-        if mustBeDirectory {
-            guard let dirNode = node as? MemoryDirectoryNode else {
-                throw WASIAbi.Errno.ENOTDIR
+            let components = relativePath.split(separator: "/").map(String.init)
+            guard let fileName = components.last else {
+                throw WASIAbi.Errno.EINVAL
             }
-            if dirNode.childCount() > 0 {
-                throw WASIAbi.Errno.ENOTEMPTY
+
+            var current = directory
+            for component in components.dropLast() {
+                guard let next = current.getChild(name: component) as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOENT
+                }
+                current = next
             }
-        } else {
-            if node.type == .directory {
-                throw WASIAbi.Errno.EISDIR
-            }
-        }
 
-        current.removeChild(name: fileName)
-    }
-
-    func rename(from sourcePath: String, in sourceDir: MemoryDirectoryNode, to destPath: String, in destDir: MemoryDirectoryNode) throws {
-        guard let sourceNode = resolve(from: sourceDir, at: "", path: sourcePath) else {
-            throw WASIAbi.Errno.ENOENT
-        }
-
-        let destComponents = destPath.split(separator: "/").map(String.init)
-        guard let destFileName = destComponents.last else {
-            throw WASIAbi.Errno.EINVAL
-        }
-
-        let destParentDir = try traverseToParent(from: destDir, components: Array(destComponents.dropLast()))
-
-        let sourceComponents = sourcePath.split(separator: "/").map(String.init)
-        guard let sourceFileName = sourceComponents.last else {
-            throw WASIAbi.Errno.EINVAL
-        }
-
-        var sourceParentDir = sourceDir
-        for component in sourceComponents.dropLast() {
-            guard let next = sourceParentDir.getChild(name: component) as? MemoryDirectoryNode else {
+            guard let node = current.getChild(name: fileName) else {
                 throw WASIAbi.Errno.ENOENT
             }
-            sourceParentDir = next
-        }
 
-        sourceParentDir.removeChild(name: sourceFileName)
-        destParentDir.setChild(name: destFileName, node: sourceNode)
+            if mustBeDirectory {
+                guard let dirNode = node as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOTDIR
+                }
+                if dirNode.childCount() > 0 {
+                    throw WASIAbi.Errno.ENOTEMPTY
+                }
+            } else {
+                if node.type == .directory {
+                    throw WASIAbi.Errno.EISDIR
+                }
+            }
+
+            current.removeChild(name: fileName)
+        }
     }
 
-    private func normalizePath(_ path: String) -> String {
+    /// Rename a node from `sourcePath` (relative to `sourceDirectoryPath`) to
+    /// `destPath` (relative to `destDirectoryPath`).
+    func rename(from sourcePath: String, at sourceDirectoryPath: String, to destPath: String, at destDirectoryPath: String) throws {
+        try root.withLock { root in
+            guard let sourceDir = Self.lookupNode(from: root, at: sourceDirectoryPath) as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOENT
+            }
+            guard let destDir = Self.lookupNode(from: root, at: destDirectoryPath) as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOENT
+            }
+
+            guard let sourceNode = Self.resolveNode(root: root, from: sourceDir, at: sourceDirectoryPath, path: sourcePath) else {
+                throw WASIAbi.Errno.ENOENT
+            }
+
+            let destComponents = destPath.split(separator: "/").map(String.init)
+            guard let destFileName = destComponents.last else {
+                throw WASIAbi.Errno.EINVAL
+            }
+
+            let destParentDir = try Self.traverseToParent(from: destDir, components: Array(destComponents.dropLast()))
+
+            let sourceComponents = sourcePath.split(separator: "/").map(String.init)
+            guard let sourceFileName = sourceComponents.last else {
+                throw WASIAbi.Errno.EINVAL
+            }
+
+            var sourceParentDir = sourceDir
+            for component in sourceComponents.dropLast() {
+                guard let next = sourceParentDir.getChild(name: component) as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOENT
+                }
+                sourceParentDir = next
+            }
+
+            sourceParentDir.removeChild(name: sourceFileName)
+            destParentDir.setChild(name: destFileName, node: sourceNode)
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private static func normalizePath(_ path: String) -> String {
         if path.isEmpty {
             return Self.rootPath
         }
@@ -431,7 +507,7 @@ public final class MemoryFileSystem: FileSystemImplementation {
         return cleaned
     }
 
-    private func splitPath(_ path: String) throws -> (parent: String, name: String) {
+    private static func splitPath(_ path: String) throws -> (parent: String, name: String) {
         let normalized = normalizePath(path)
 
         guard normalized != Self.rootPath else {

--- a/Sources/WASI/Platform/HostFileSystem.swift
+++ b/Sources/WASI/Platform/HostFileSystem.swift
@@ -19,7 +19,7 @@ import SystemPackage
 /// A file system implementation that directly accesses the host operating system's file system.
 ///
 /// This implementation provides access to actual files and directories on the host system.
-final class HostFileSystem: FileSystemImplementation {
+final class HostFileSystem: FileSystemImplementation, Sendable {
 
     /// Creates a new host file system.
     init() {

--- a/Sources/WASI/RandomBufferGenerator.swift
+++ b/Sources/WASI/RandomBufferGenerator.swift
@@ -5,7 +5,7 @@ import SwiftShims  // For swift_stdlib_random
 /// This type is similar to `RandomNumberGenerator` in Swift standard library,
 /// but it provides a way to fill a buffer with random bytes instead of a single
 /// random number.
-public protocol RandomBufferGenerator {
+public protocol RandomBufferGenerator: Sendable {
 
     /// Fills the buffer with random bytes.
     ///

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1,3 +1,4 @@
+import Synchronization
 import SystemExtras
 import SystemPackage
 import WasmTypes
@@ -767,12 +768,12 @@ public struct WASIExitCode: Error {
     public let code: UInt32
 }
 
-public struct WASIHostFunction {
+public struct WASIHostFunction: Sendable {
     public let type: FunctionType
-    public let implementation: (GuestMemory, [Value]) throws -> [Value]
+    public let implementation: @Sendable (GuestMemory, [Value]) throws -> [Value]
 }
 
-public struct WASIHostModule {
+public struct WASIHostModule: Sendable {
     public let functions: [String: WASIHostFunction]
 }
 
@@ -793,14 +794,14 @@ extension WASIImplementation {
             }
         }
 
-        func withMemoryBuffer<T>(
+        @Sendable func withMemoryBuffer<T>(
             caller: GuestMemory,
             body: (GuestMemory) throws -> T
         ) throws -> T {
             return try body(caller)
         }
 
-        func readString(pointer: UInt32, length: UInt32, buffer: GuestMemory) throws -> String {
+        @Sendable func readString(pointer: UInt32, length: UInt32, buffer: GuestMemory) throws -> String {
             let pointer = UnsafeGuestBufferPointer<UInt8>(
                 baseAddress: UnsafeGuestPointer(offset: pointer),
                 count: length
@@ -817,7 +818,7 @@ extension WASIImplementation {
             }
         }
 
-        func wasiFunction(type: FunctionType, implementation: @escaping (GuestMemory, [Value]) throws -> [Value]) -> WASIHostFunction {
+        func wasiFunction(type: FunctionType, implementation: @Sendable @escaping (GuestMemory, [Value]) throws -> [Value]) -> WASIHostFunction {
             return WASIHostFunction(type: type) { caller, arguments in
                 do {
                     return try implementation(caller, arguments)
@@ -1361,13 +1362,13 @@ extension WASIImplementation {
     }
 }
 
-final class WASIImplementation {
+final class WASIImplementation: Sendable {
     private let args: [String]
     private let environment: [String: String]
     private let wallClock: WallClock
     private let monotonicClock: MonotonicClock
-    private var randomGenerator: RandomBufferGenerator
-    internal var fdTable: FdTable
+    private let randomGenerator: Mutex<any RandomBufferGenerator>
+    internal let fdTable: Mutex<FdTable>
     internal let fileSystem: FileSystemImplementation
 
     init(
@@ -1382,21 +1383,21 @@ final class WASIImplementation {
         self.environment = environment
         self.fileSystem = fileSystem
 
-        self.fdTable = FdTable()
+        self.fdTable = Mutex(FdTable())
         self.wallClock = wallClock
         self.monotonicClock = monotonicClock
-        self.randomGenerator = randomGenerator
+        self.randomGenerator = Mutex(randomGenerator)
     }
 
     /// Closes all owned file descriptors (skipping borrowed ones like stdio).
     func close() throws {
-        try fdTable.closeAll()
+        try fdTable.withLock { try $0.closeAll() }
     }
 
     /// Look up a directory entry by WASI fd, throwing EBADF if the fd doesn't
     /// exist or ENOTDIR if it exists but isn't a directory.
     private func directoryEntry(fd: WASIAbi.Fd) throws -> any WASIDir {
-        guard let entry = fdTable[fd] else {
+        guard let entry = fdTable.withLock({ $0[fd] }) else {
             throw WASIAbi.Errno.EBADF
         }
         guard case .directory(let dirEntry) = entry else {
@@ -1496,16 +1497,21 @@ final class WASIImplementation {
 
     /// Provide file advisory information on a file descriptor.
     func fd_advise(fd: WASIAbi.Fd, offset: WASIAbi.FileSize, length: WASIAbi.FileSize, advice: WASIAbi.Advice) throws {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         try fileEntry.advise(offset: offset, length: length, advice: advice)
     }
 
     /// Force the allocation of space in a file.
     func fd_allocate(fd: WASIAbi.Fd, offset: WASIAbi.FileSize, length: WASIAbi.FileSize) throws {
-        guard fdTable[fd] != nil else {
-            throw WASIAbi.Errno.EBADF
+        try fdTable.withLock { table in
+            guard table[fd] != nil else {
+                throw WASIAbi.Errno.EBADF
+            }
         }
         // This operation has been removed in preview 2 and is not supported across all linux
         // filesystems, and has no support on macos or windows, so just return ENOTSUP now.
@@ -1514,17 +1520,23 @@ final class WASIImplementation {
 
     /// Close a file descriptor.
     func fd_close(fd: WASIAbi.Fd) throws {
-        guard let entry = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let entry = try fdTable.withLock { table -> FdEntry in
+            guard let entry = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            table[fd] = nil
+            return entry
         }
-        fdTable[fd] = nil
         try entry.asEntry().close()
     }
 
     /// Synchronize the data of a file to disk.
     func fd_datasync(fd: WASIAbi.Fd) throws {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.datasync()
     }
@@ -1532,7 +1544,7 @@ final class WASIImplementation {
     /// Get the attributes of a file descriptor.
     /// - Parameter fileDescriptor: File descriptor to get attribute.
     func fd_fdstat_get(fileDescriptor: UInt32) throws -> WASIAbi.FdStat {
-        let entry = self.fdTable[fileDescriptor]
+        let entry = fdTable.withLock { table in table[fileDescriptor] }
         switch entry {
         case .file(let entry):
             return try entry.fdStat()
@@ -1550,8 +1562,11 @@ final class WASIImplementation {
 
     /// Adjust the flags associated with a file descriptor.
     func fd_fdstat_set_flags(fd: WASIAbi.Fd, flags: WASIAbi.Fdflags) throws {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         try fileEntry.setFdStatFlags(flags)
     }
@@ -1567,16 +1582,22 @@ final class WASIImplementation {
 
     /// Return the attributes of an open file.
     func fd_filestat_get(fd: WASIAbi.Fd) throws -> WASIAbi.Filestat {
-        guard let entry = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let entry = try fdTable.withLock { table -> FdEntry in
+            guard let entry = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return entry
         }
         return try entry.asEntry().attributes()
     }
 
     /// Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
     func fd_filestat_set_size(fd: WASIAbi.Fd, size: WASIAbi.FileSize) throws {
-        guard case .file(let entry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let entry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let entry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return entry
         }
         return try entry.setFilestatSize(size)
     }
@@ -1586,8 +1607,11 @@ final class WASIImplementation {
         fd: WASIAbi.Fd, atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags
     ) throws {
-        guard let entry = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let entry = try fdTable.withLock { table -> FdEntry in
+            guard let entry = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return entry
         }
         try entry.asEntry().setTimes(atim: atim, mtim: mtim, fstFlags: fstFlags)
     }
@@ -1598,28 +1622,37 @@ final class WASIImplementation {
         offset: WASIAbi.FileSize,
         memory: M
     ) throws -> WASIAbi.Size {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.pread(into: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory, offset: offset)
     }
 
     /// Return a description of the given preopened file descriptor.
     func fd_prestat_get(fd: WASIAbi.Fd) throws -> WASIAbi.Prestat {
-        guard case .directory(let entry) = fdTable[fd],
-            let preopenPath = entry.preopenPath
-        else {
-            throw WASIAbi.Errno.EBADF
+        let preopenPath = try fdTable.withLock { table -> String in
+            guard case .directory(let entry) = table[fd],
+                let preopenPath = entry.preopenPath
+            else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return preopenPath
         }
         return .dir(WASIAbi.PrestatDir(preopenPath.utf8.count))
     }
 
     /// Return a directory name of the given preopened file descriptor
     func fd_prestat_dir_name<M: GuestMemory>(fd: WASIAbi.Fd, path: UnsafeGuestPointer<UInt8>, maxPathLength: WASIAbi.Size, memory: M) throws {
-        guard case .directory(let entry) = fdTable[fd],
-            var preopenPath = entry.preopenPath
-        else {
-            throw WASIAbi.Errno.EBADF
+        var preopenPath = try fdTable.withLock { table -> String in
+            guard case .directory(let entry) = table[fd],
+                let preopenPath = entry.preopenPath
+            else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return preopenPath
         }
 
         try preopenPath.withUTF8 { bytes in
@@ -1638,8 +1671,11 @@ final class WASIImplementation {
         offset: WASIAbi.FileSize,
         memory: M
     ) throws -> WASIAbi.Size {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.pwrite(vectored: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory, offset: offset)
     }
@@ -1650,8 +1686,11 @@ final class WASIImplementation {
         iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>,
         memory: M
     ) throws -> WASIAbi.Size {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.read(into: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory)
     }
@@ -1663,8 +1702,11 @@ final class WASIImplementation {
         cookie: WASIAbi.DirCookie,
         memory: M
     ) throws -> WASIAbi.Size {
-        guard case .directory(let dirEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let dirEntry = try fdTable.withLock { table -> any WASIDir in
+            guard case .directory(let dirEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return dirEntry
         }
 
         let entries = try dirEntry.readEntries(cookie: cookie)
@@ -1712,37 +1754,49 @@ final class WASIImplementation {
 
     /// Atomically replace a file descriptor by renumbering another file descriptor.
     func fd_renumber(fd: WASIAbi.Fd, to toFd: WASIAbi.Fd) throws {
-        guard let entry = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let toClose = try fdTable.withLock { table -> FdEntry in
+            guard let entry = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            guard let toEntry = table[toFd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            table[toFd] = entry
+            table[fd] = nil
+            return toEntry
         }
-        guard fdTable[toFd] != nil else {
-            throw WASIAbi.Errno.EBADF
-        }
-        try fdTable[toFd]!.asEntry().close()
-        fdTable[toFd] = entry
-        fdTable[fd] = nil
+        try toClose.asEntry().close()
     }
 
     /// Move the offset of a file descriptor.
     func fd_seek(fd: WASIAbi.Fd, offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.seek(offset: offset, whence: whence)
     }
 
     /// Synchronize the data and metadata of a file to disk.
     func fd_sync(fd: WASIAbi.Fd) throws {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.sync()
     }
 
     /// Return the current offset of a file descriptor.
     func fd_tell(fd: WASIAbi.Fd) throws -> WASIAbi.FileSize {
-        guard case .file(let fileEntry) = fdTable[fd] else {
-            throw WASIAbi.Errno.EBADF
+        let fileEntry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let fileEntry) = table[fd] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return fileEntry
         }
         return try fileEntry.tell()
     }
@@ -1757,8 +1811,11 @@ final class WASIImplementation {
         ioVectors: UnsafeGuestBufferPointer<WASIAbi.IOVec>,
         memory: M
     ) throws -> UInt32 {
-        guard case .file(let entry) = self.fdTable[fileDescriptor] else {
-            throw WASIAbi.Errno.EBADF
+        let entry = try fdTable.withLock { table -> any WASIFile in
+            guard case .file(let entry) = table[fileDescriptor] else {
+                throw WASIAbi.Errno.EBADF
+            }
+            return entry
         }
         return try entry.write(vectored: (0..<ioVectors.count).map { ioVectors.read(at: $0, in: memory) }, memory: memory)
     }
@@ -1802,6 +1859,19 @@ final class WASIImplementation {
     }
 
     /// Open a file or directory.
+    ///
+    /// The lookup, open, and push are done in a single lock scope so that the
+    /// new entry (which contains non-Sendable existentials) is created inside
+    /// the closure, satisfying Mutex's `sending` contract. The openAt call is
+    /// non-blocking (opens a host fd or traverses an in-memory tree).
+    ///
+    /// - Note: This holds the fdTable lock during `fileSystem.openAt()`, which
+    ///   performs `openat(2)` + `fstat(2)` for `HostFileSystem`. These are
+    ///   normally sub-millisecond on local filesystems but can block on network
+    ///   mounts (NFS, FUSE). In a multi-threaded WASI context, this means all
+    ///   fd operations on all threads stall during any single `path_open`. A
+    ///   two-phase approach (reserve fd slot under lock, fill entry separately)
+    ///   would reduce contention but requires FdTable to support reserved slots.
     func path_open(
         dirFd: WASIAbi.Fd,
         dirFlags: WASIAbi.LookupFlags,
@@ -1811,20 +1881,21 @@ final class WASIImplementation {
         fsRightsInheriting: WASIAbi.Rights,
         fdflags: WASIAbi.Fdflags
     ) throws -> WASIAbi.Fd {
-        let dirEntry = try directoryEntry(fd: dirFd)
-
-        let newEntry = try fileSystem.openAt(
-            dirFd: dirEntry,
-            path: path,
-            oflags: oflags,
-            fsRightsBase: fsRightsBase,
-            fsRightsInheriting: fsRightsInheriting,
-            fdflags: fdflags,
-            symlinkFollow: dirFlags.contains(.SYMLINK_FOLLOW)
-        )
-
-        let guestFd = try fdTable.push(newEntry)
-        return guestFd
+        try fdTable.withLock { table in
+            guard case .directory(let dirEntry) = table[dirFd] else {
+                throw WASIAbi.Errno.ENOTDIR
+            }
+            let newEntry = try fileSystem.openAt(
+                dirFd: dirEntry,
+                path: path,
+                oflags: oflags,
+                fsRightsBase: fsRightsBase,
+                fsRightsInheriting: fsRightsInheriting,
+                fdflags: fdflags,
+                symlinkFollow: dirFlags.contains(.SYMLINK_FOLLOW)
+            )
+            return try table.push(newEntry)
+        }
     }
 
     /// Read the contents of a symbolic link.
@@ -1880,14 +1951,17 @@ final class WASIImplementation {
     ) throws -> WASIAbi.Size {
         guard !subscriptions.isEmpty else { throw WASIAbi.Errno.EINVAL }
         let materializedSubscriptions = (0..<subscriptions.count).map { subscriptions.read(at: $0, in: memory) }
-        return try poll(subscriptions: materializedSubscriptions, events: events, self.fdTable, memory: memory)
+        let table = fdTable.withLock { $0 }
+        return try poll(subscriptions: materializedSubscriptions, events: events, table, memory: memory)
     }
 
     /// Shut down socket send and receive channels.
     /// Since WasmKit has no socket support, any valid fd is not a socket.
     func sock_shutdown(fd: WASIAbi.Fd) throws {
-        guard fdTable[fd] != nil else {
-            throw WASIAbi.Errno.EBADF
+        try fdTable.withLock { table in
+            guard table[fd] != nil else {
+                throw WASIAbi.Errno.EBADF
+            }
         }
         throw WASIAbi.Errno.ENOTSOCK
     }
@@ -1907,8 +1981,10 @@ final class WASIImplementation {
     /// Write high-quality random data into a buffer.
     func random_get<M: GuestMemory>(buffer: UnsafeGuestPointer<UInt8>, length: WASIAbi.Size, memory: M) {
         guard length > 0 else { return }
-        buffer.withHostPointer(in: memory, count: Int(length)) {
-            self.randomGenerator.fill(buffer: $0)
+        buffer.withHostPointer(in: memory, count: Int(length)) { hostBuffer in
+            self.randomGenerator.withLock { rng in
+                rng.fill(buffer: hostBuffer)
+            }
         }
     }
 }

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -1,3 +1,4 @@
+import Synchronization
 import SystemPackage
 
 /// A bridge that connects WebAssembly System Interface (WASI) calls to the host system.
@@ -18,9 +19,9 @@ import SystemPackage
 ///     // ... use wasi ...
 /// }
 /// ```
-public final class WASIBridgeToHost {
+public final class WASIBridgeToHost: Sendable {
     internal let underlying: WASIImplementation
-    private var isClosed = false
+    private let isClosed = Mutex(false)
 
     /// A preopened directory mapping from a guest path to a host path.
     ///
@@ -110,8 +111,12 @@ public final class WASIBridgeToHost {
     /// guest-opened files that were not closed by the WASI program).
     /// Borrowed descriptors (e.g. process stdio) are left open.
     public func close() throws {
-        guard !isClosed else { return }
-        isClosed = true
+        let shouldClose = isClosed.withLock { closed -> Bool in
+            if closed { return false }
+            closed = true
+            return true
+        }
+        guard shouldClose else { return }
         try underlying.close()
     }
 
@@ -132,7 +137,7 @@ public final class WASIBridgeToHost {
     }
 
     deinit {
-        precondition(isClosed, "WASIBridgeToHost.close() must be called before the bridge is deallocated")
+        precondition(isClosed.withLock { $0 }, "WASIBridgeToHost.close() must be called before the bridge is deallocated")
     }
 
     /// Creates a new WASI bridge with host file system access.
@@ -235,8 +240,10 @@ public final class WASIBridgeToHost {
             monotonicClock: monotonicClock,
             randomGenerator: randomGenerator
         )
-        try fileSystemOptions.initializeStdio?(&underlying.fdTable)
-        try fileSystemOptions.initializePreopens?(fileSystem, &underlying.fdTable)
+        try underlying.fdTable.withLock { table in
+            try fileSystemOptions.initializeStdio?(&table)
+            try fileSystemOptions.initializePreopens?(fileSystem, &table)
+        }
     }
 
     /// Creates a new WASI bridge with custom file system options.

--- a/Sources/WasmKit/ResourceLimiter.swift
+++ b/Sources/WasmKit/ResourceLimiter.swift
@@ -1,5 +1,5 @@
 /// A protocol for limiting resource allocation.
-public protocol ResourceLimiter {
+public protocol ResourceLimiter: Sendable {
     /// Limit the memory growth of the process to the specified number of bytes.
     ///
     /// - Parameter desired: The desired size of the memory in bytes.

--- a/Sources/WasmParser/InstructionVisitor.swift
+++ b/Sources/WasmParser/InstructionVisitor.swift
@@ -4,8 +4,8 @@
 
 import WasmTypes
 
-public enum Instruction: Equatable {
-    public enum Load: Equatable {
+public enum Instruction: Equatable, Sendable {
+    public enum Load: Equatable, Sendable {
         case i32Load
         case i64Load
         case f32Load
@@ -41,7 +41,7 @@ public enum Instruction: Equatable {
         case v128Load32Zero
         case v128Load64Zero
     }
-    public enum Store: Equatable {
+    public enum Store: Equatable, Sendable {
         case i32Store
         case i64Store
         case f32Store
@@ -60,7 +60,7 @@ public enum Instruction: Equatable {
         case i64AtomicStore32
         case v128Store
     }
-    public enum Cmp: Equatable {
+    public enum Cmp: Equatable, Sendable {
         case i32Eq
         case i32Ne
         case i32LtS
@@ -94,7 +94,7 @@ public enum Instruction: Equatable {
         case f64Le
         case f64Ge
     }
-    public enum Unary: Equatable {
+    public enum Unary: Equatable, Sendable {
         case i32Clz
         case i32Ctz
         case i32Popcnt
@@ -121,7 +121,7 @@ public enum Instruction: Equatable {
         case i64Extend16S
         case i64Extend32S
     }
-    public enum Binary: Equatable {
+    public enum Binary: Equatable, Sendable {
         case i32Add
         case i32Sub
         case i32Mul
@@ -167,7 +167,7 @@ public enum Instruction: Equatable {
         case f64Max
         case f64Copysign
     }
-    public enum Conversion: Equatable {
+    public enum Conversion: Equatable, Sendable {
         case i32WrapI64
         case i32TruncF32S
         case i32TruncF32U
@@ -202,7 +202,7 @@ public enum Instruction: Equatable {
         case i64TruncSatF64S
         case i64TruncSatF64U
     }
-    public enum Simd: Equatable {
+    public enum Simd: Equatable, Sendable {
         case i8x16Swizzle
         case i8x16Splat
         case i16x8Splat
@@ -402,7 +402,7 @@ public enum Instruction: Equatable {
         case i32x4ExtaddPairwiseI16X8S
         case i32x4ExtaddPairwiseI16X8U
     }
-    public enum SimdLane: Equatable {
+    public enum SimdLane: Equatable, Sendable {
         case i8x16ExtractLaneS
         case i8x16ExtractLaneU
         case i8x16ReplaceLane
@@ -418,7 +418,7 @@ public enum Instruction: Equatable {
         case f64x2ExtractLane
         case f64x2ReplaceLane
     }
-    public enum SimdMemLane: Equatable {
+    public enum SimdMemLane: Equatable, Sendable {
         case v128Load8Lane
         case v128Load16Lane
         case v128Load32Lane

--- a/Sources/WasmParser/WasmTypes.swift
+++ b/Sources/WasmParser/WasmTypes.swift
@@ -3,7 +3,7 @@ import WasmTypes
 /// Function code in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-code>
-public struct Code {
+public struct Code: Sendable {
     /// Local variables in the function
     public let locals: [ValueType]
     /// Expression body of the function
@@ -34,7 +34,7 @@ extension Code: Equatable {
     }
 }
 
-public struct MemArg: Equatable {
+public struct MemArg: Equatable, Sendable {
     public let offset: UInt64
     public let align: UInt32
 
@@ -44,7 +44,7 @@ public struct MemArg: Equatable {
     }
 }
 
-public enum BlockType: Equatable {
+public enum BlockType: Equatable, Sendable {
     case empty
     case type(ValueType)
     case funcType(UInt32)
@@ -52,7 +52,7 @@ public enum BlockType: Equatable {
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/types.html#limits>
-public struct Limits: Equatable {
+public struct Limits: Equatable, Sendable {
     public var min: UInt64
     public var max: UInt64?
     public var isMemory64: Bool
@@ -72,7 +72,7 @@ public typealias MemoryType = Limits
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/types.html#table-types>
-public struct TableType: Equatable {
+public struct TableType: Equatable, Sendable {
     public var elementType: ReferenceType
     public var limits: Limits
 
@@ -84,14 +84,14 @@ public struct TableType: Equatable {
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/types.html#global-types>
-public enum Mutability: Equatable {
+public enum Mutability: Equatable, Sendable {
     case constant
     case variable
 }
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/types.html#global-types>
-public struct GlobalType: Equatable {
+public struct GlobalType: Equatable, Sendable {
     public let mutability: Mutability
     public let valueType: ValueType
 
@@ -103,7 +103,7 @@ public struct GlobalType: Equatable {
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/types.html#external-types>
-public enum ExternalType {
+public enum ExternalType: Sendable {
     case function(FunctionType)
     case table(TableType)
     case memory(MemoryType)
@@ -111,14 +111,14 @@ public enum ExternalType {
 }
 
 public enum IEEE754 {
-    public struct Float32: Equatable {
+    public struct Float32: Equatable, Sendable {
         public let bitPattern: UInt32
 
         public init(bitPattern: UInt32) {
             self.bitPattern = bitPattern
         }
     }
-    public struct Float64: Equatable {
+    public struct Float64: Equatable, Sendable {
         public let bitPattern: UInt64
 
         public init(bitPattern: UInt64) {
@@ -127,7 +127,7 @@ public enum IEEE754 {
     }
 }
 
-public struct BrTable: Equatable {
+public struct BrTable: Equatable, Sendable {
     public let labelIndices: [UInt32]
     public let defaultIndex: UInt32
 
@@ -138,7 +138,7 @@ public struct BrTable: Equatable {
 }
 
 /// A custom section in a module
-public struct CustomSection: Equatable {
+public struct CustomSection: Equatable, Sendable {
     public let name: String
     public let bytes: ArraySlice<UInt8>
 }
@@ -166,7 +166,7 @@ public typealias ConstExpression = [Instruction]
 /// Table entry in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#tables>
-public struct Table: Equatable {
+public struct Table: Equatable, Sendable {
     public let type: TableType
 
     public init(type: TableType) {
@@ -176,14 +176,14 @@ public struct Table: Equatable {
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#memories>
-public struct Memory: Equatable {
+public struct Memory: Equatable, Sendable {
     public let type: MemoryType
 }
 
 /// Global entry in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#globals>
-public struct Global: Equatable {
+public struct Global: Equatable, Sendable {
     public let type: GlobalType
     public let initializer: ConstExpression
 }
@@ -191,7 +191,7 @@ public struct Global: Equatable {
 /// Segment of elements that are initialized in a table
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#element-segments>
-public struct ElementSegment: Equatable {
+public struct ElementSegment: Equatable, Sendable {
     @usableFromInline
     struct Flag: OptionSet, Sendable {
         @usableFromInline let rawValue: UInt32
@@ -215,7 +215,7 @@ public struct ElementSegment: Equatable {
         @usableFromInline static let usesExpressions = Flag(rawValue: 1 << 2)
     }
 
-    public enum Mode: Equatable {
+    public enum Mode: Equatable, Sendable {
         case active(table: UInt32, offset: ConstExpression)
         case declarative
         case passive
@@ -235,8 +235,8 @@ public struct ElementSegment: Equatable {
 /// Data segment in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#data-segments>
-public enum DataSegment: Equatable {
-    public struct Active: Equatable {
+public enum DataSegment: Equatable, Sendable {
+    public struct Active: Equatable, Sendable {
         public let index: UInt32
         public let offset: ConstExpression
         public let initializer: ArraySlice<UInt8>
@@ -255,7 +255,7 @@ public enum DataSegment: Equatable {
 /// Exported entity in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#exports>
-public struct Export: Equatable {
+public struct Export: Equatable, Sendable {
     /// Name of the export
     public let name: String
     /// Descriptor of the export
@@ -268,7 +268,7 @@ public struct Export: Equatable {
 }
 
 /// Export descriptor
-public enum ExportDescriptor: Equatable {
+public enum ExportDescriptor: Equatable, Sendable {
     /// Function export
     case function(FunctionIndex)
     /// Table export
@@ -282,7 +282,7 @@ public enum ExportDescriptor: Equatable {
 /// Import entity in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#imports>
-public struct Import: Equatable {
+public struct Import: Equatable, Sendable {
     /// Module name imported from
     public let module: String
     /// Name of the import
@@ -298,7 +298,7 @@ public struct Import: Equatable {
 }
 
 /// Import descriptor
-public enum ImportDescriptor: Equatable {
+public enum ImportDescriptor: Equatable, Sendable {
     /// Function import
     case function(TypeIndex)
     /// Table import

--- a/Tests/WASITests/WASIFdRenumberTests.swift
+++ b/Tests/WASITests/WASIFdRenumberTests.swift
@@ -1,0 +1,124 @@
+import Testing
+
+@testable import WASI
+
+@Suite struct WASIFdRenumberTests {
+    /// Helper: run `body` with a WASI implementation backed by a MemoryFileSystem
+    /// containing two files. The owning bridge is closed once `body` returns.
+    private func withWASI(_ body: (WASIImplementation) throws -> Void) throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/")
+        try fs.addFile(at: "/a.txt", content: Array("file-a".utf8))
+        try fs.addFile(at: "/b.txt", content: Array("file-b".utf8))
+        let bridge = try WASIBridgeToHost(
+            fileSystem: .memory(fs).withPreopens([
+                .init(guestPath: "/", hostPath: "/")
+            ])
+        )
+        try bridge.runAndClose { bridge in
+            try body(bridge.underlying)
+        }
+    }
+
+    @Test func renumber_sourceBecomesInvalid() throws {
+        try withWASI { wasi in
+            let rootFd: WASIAbi.Fd = 3
+
+            let fdA = try wasi.path_open(
+                dirFd: rootFd, dirFlags: [], path: "a.txt", oflags: [],
+                fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+            )
+            let fdB = try wasi.path_open(
+                dirFd: rootFd, dirFlags: [], path: "b.txt", oflags: [],
+                fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+            )
+
+            // Both fds valid before renumber
+            #expect(try wasi.fd_filestat_get(fd: fdA).filetype == .REGULAR_FILE)
+            #expect(try wasi.fd_filestat_get(fd: fdB).filetype == .REGULAR_FILE)
+
+            try wasi.fd_renumber(fd: fdA, to: fdB)
+
+            // Source fd is now invalid
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                _ = try wasi.fd_filestat_get(fd: fdA)
+            }
+
+            // Target fd is valid (now points to what was fdA)
+            #expect(try wasi.fd_filestat_get(fd: fdB).filetype == .REGULAR_FILE)
+
+            try wasi.fd_close(fd: fdB)
+        }
+    }
+
+    @Test func renumber_targetEntryIsClosed() throws {
+        try withWASI { wasi in
+            let rootFd: WASIAbi.Fd = 3
+
+            let fdA = try wasi.path_open(
+                dirFd: rootFd, dirFlags: [], path: "a.txt", oflags: [],
+                fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+            )
+            let fdB = try wasi.path_open(
+                dirFd: rootFd, dirFlags: [], path: "b.txt", oflags: [],
+                fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+            )
+
+            // Renumber fdA -> fdB; the old fdB entry gets closed
+            try wasi.fd_renumber(fd: fdA, to: fdB)
+
+            // After renumber, closing fdB again should succeed (it's the moved fdA)
+            try wasi.fd_close(fd: fdB)
+
+            // Both fds now invalid
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                _ = try wasi.fd_filestat_get(fd: fdA)
+            }
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                _ = try wasi.fd_filestat_get(fd: fdB)
+            }
+        }
+    }
+
+    @Test func renumber_invalidSourceReturnsEBADF() throws {
+        try withWASI { wasi in
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                try wasi.fd_renumber(fd: 99, to: 3)
+            }
+
+            // fd 3 (root preopen) is unaffected — accessing it should not throw
+            _ = try wasi.fd_prestat_get(fd: 3)
+        }
+    }
+
+    @Test func renumber_invalidTargetReturnsEBADF() throws {
+        try withWASI { wasi in
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                try wasi.fd_renumber(fd: 3, to: 99)
+            }
+
+            // fd 3 is unaffected — accessing it should not throw
+            _ = try wasi.fd_prestat_get(fd: 3)
+        }
+    }
+
+    @Test func renumber_selfIsNoop() throws {
+        try withWASI { wasi in
+            let rootFd: WASIAbi.Fd = 3
+
+            let fd = try wasi.path_open(
+                dirFd: rootFd, dirFlags: [], path: "a.txt", oflags: [],
+                fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+            )
+
+            // Renumber fd to itself — fd_renumber sets source to nil after
+            // overwriting target with the same entry, so the slot is cleared
+            try wasi.fd_renumber(fd: fd, to: fd)
+
+            // The fd should be gone
+            #expect(throws: WASIAbi.Errno.EBADF) {
+                _ = try wasi.fd_filestat_get(fd: fd)
+            }
+        }
+    }
+}

--- a/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
+++ b/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
@@ -1,0 +1,119 @@
+import Testing
+
+@testable import WASI
+
+@Suite struct MemoryFileSystemConcurrencyTests {
+    @Test func concurrentAddAndRead() async throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/data")
+
+        let iterations = 50
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for t in 0..<4 {
+                group.addTask {
+                    for i in 0..<iterations {
+                        let path = "/data/t\(t)_f\(i).txt"
+                        let body = Array("content-\(t)-\(i)".utf8)
+                        try fs.addFile(at: path, content: body)
+                        let content = try fs.getFile(at: path)
+                        guard case .bytes(let bytes) = content else {
+                            Issue.record("Expected .bytes content at \(path)")
+                            return
+                        }
+                        #expect(bytes == body)
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    @Test func concurrentCreateAndRemove() async throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/")
+
+        let iterations = 50
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            // Writer: create files
+            group.addTask {
+                for i in 0..<iterations {
+                    try fs.addFile(at: "/file\(i).txt", content: Array("data\(i)".utf8))
+                }
+            }
+            // Reader/remover: try to read and remove files
+            group.addTask {
+                for i in 0..<iterations {
+                    let path = "/file\(i).txt"
+                    // File may or may not exist yet — both outcomes are fine
+                    if fs.lookup(at: path) != nil {
+                        do {
+                            try fs.removeFile(at: path)
+                        } catch {
+                            // ENOENT is acceptable — writer hasn't created it yet
+                            // or another iteration already removed it
+                        }
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+        // No crash, no corruption — success
+    }
+
+    @Test func concurrentWASIPathOpen() async throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/")
+        for i in 0..<20 {
+            try fs.addFile(at: "/f\(i).txt", content: Array("data".utf8))
+        }
+
+        let bridge = try WASIBridgeToHost(
+            fileSystem: .memory(fs).withPreopens([
+                .init(guestPath: "/", hostPath: "/")
+            ])
+        )
+        let wasi = bridge.underlying
+
+        let rootFd: WASIAbi.Fd = 3
+
+        do {
+            // Each task returns its own open count; summing the returned values
+            // avoids sharing mutable state across the `sending` task boundary.
+            let openCount = try await withThrowingTaskGroup(of: Int.self) { group in
+                for t in 0..<4 {
+                    group.addTask {
+                        var localCount = 0
+                        for i in 0..<20 {
+                            let idx = (t * 5 + i) % 20
+                            let fd = try wasi.path_open(
+                                dirFd: rootFd,
+                                dirFlags: [],
+                                path: "f\(idx).txt",
+                                oflags: [],
+                                fsRightsBase: [.FD_READ],
+                                fsRightsInheriting: [],
+                                fdflags: []
+                            )
+                            localCount += 1
+                            try wasi.fd_close(fd: fd)
+                        }
+                        return localCount
+                    }
+                }
+                var total = 0
+                for try await count in group {
+                    total += count
+                }
+                return total
+            }
+
+            #expect(openCount == 80)
+            try bridge.close()
+        } catch {
+            try bridge.close()
+            throw error
+        }
+    }
+}

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -446,11 +446,11 @@ struct WASITests {
         try bridge.runAndClose { _ in
             let wasi = bridge.underlying
 
-            guard case .directory(let fd3Dir) = wasi.fdTable[3] else {
+            guard case .directory(let fd3Dir) = wasi.fdTable.withLock({ $0[3] }) else {
                 #expect(Bool(false), "Expected fd=3 to be a preopened directory")
                 return
             }
-            guard case .directory(let fd4Dir) = wasi.fdTable[4] else {
+            guard case .directory(let fd4Dir) = wasi.fdTable.withLock({ $0[4] }) else {
                 #expect(Bool(false), "Expected fd=4 to be a preopened directory")
                 return
             }
@@ -505,18 +505,14 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.ensureDirectory(at: "/dir")
         try fs.addFile(at: "/dir/file.txt", content: [])
-        guard let dirNode = fs.lookup(at: "/dir") as? MemoryDirectoryNode else {
-            #expect(Bool(false), "Expected DirectoryNode")
-            return
-        }
-        let resolved = fs.resolve(from: dirNode, at: "/dir", path: "file.txt")
+        let resolved = fs.resolve(at: "/dir", path: "file.txt")
         #expect(resolved != nil)
         #expect(resolved?.type == .file)
 
-        let dotResolved = fs.resolve(from: dirNode, at: "/dir", path: ".")
+        let dotResolved = fs.resolve(at: "/dir", path: ".")
         #expect(dotResolved != nil)
 
-        let parentResolved = fs.resolve(from: dirNode, at: "/dir", path: "..")
+        let parentResolved = fs.resolve(at: "/dir", path: "..")
         #expect(parentResolved != nil)
         #expect(parentResolved?.type == .directory)
     }

--- a/Utilities/Sources/WasmGen.swift
+++ b/Utilities/Sources/WasmGen.swift
@@ -182,7 +182,7 @@ enum WasmGen {
         var code = """
             import WasmTypes
 
-            public enum Instruction: Equatable {
+            public enum Instruction: Equatable, Sendable {
 
             """
 
@@ -190,7 +190,7 @@ enum WasmGen {
 
         for instruction in categorized {
             guard let categoryTypeName = instruction.categoryTypeName else { continue }
-            code += "    public enum \(categoryTypeName): Equatable {\n"
+            code += "    public enum \(categoryTypeName): Equatable, Sendable {\n"
             for sourceInstruction in instruction.sourceInstructions {
                 code += "        case \(sourceInstruction.name.enumCase)\n"
             }


### PR DESCRIPTION
Make the WASI host layer `Sendable` and safe for concurrent use, as the foundation for future wasi-threads work. Guard the file descriptor table with a `Mutex<FdTable>` and rework the in-memory file system (`MemoryFileSystem`, `MemoryFileEntry`, and `MemoryDirEntry`) for concurrent access, replacing `resolve`'s caller-supplied directory node with path-based lookup. Conform required types to `Sendable`: the `Instruction` enums, the `WasmParser` value types (`Code`, `MemArg`, `Limits`, `TableType`, `GlobalType`, and related), `WallClock`, `MonotonicClock`, `RandomBufferGenerator`, `ResourceLimiter`, and the file system protocols (`FileSystemImplementation` and `HostFileSystem`). Add fd-renumber and `MemoryFileSystem` concurrency regression tests.