### PR TITLE
Bump MSSV to Swift 6.3

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: swift:6.0-noble
+      image: swift:6.3-noble
     steps:
       - uses: actions/checkout@v6
       - run: apt-get update && apt-get install -y python3 && ./Utilities/format.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,9 +140,6 @@ jobs:
           - swift: "swiftlang/swift:nightly-main-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport"
             build-benchmarks: true
-          - swift: "swiftlang/swift:nightly-main-noble"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport --build-system swiftbuild"
-            label: " --build-system swiftbuild"
 
     runs-on: ubuntu-24.04
     name: "build-linux (${{ matrix.swift }}${{ matrix.label }})"
@@ -259,18 +256,17 @@ jobs:
       - uses: compnerd/gha-setup-swift@main
         with:
           swift-version: swift-6.3-release
-          swift-build: 6.3-RELEASE
+          swift-build: 6.3.2-RELEASE
       - uses: actions/checkout@v6
       - run: python3 ./Vendor/checkout-dependency --category default
-      # FIXME: CMake build is failing on CI due to "link: extra operand '/OUT:lib\\libXXXX.a'" error
-      # # Check Windows build with CMake
-      # - uses: Cyberboss/install-winget@v1
-      # - run: winget install Ninja-build.Ninja Kitware.CMake --disable-interactivity --accept-source-agreements
-      # - run: |
-      #     echo "$env:LOCALAPPDATA\Microsoft\WinGet\Links" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      #     echo "$env:ProgramFiles\CMake\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      # - run: cmake -G Ninja -B .build/cmake
-      # - run: cmake --build .build/cmake
+      # Check Windows build with CMake
+      - uses: Cyberboss/install-winget@v1
+      - run: winget install Ninja-build.Ninja Kitware.CMake --disable-interactivity --accept-source-agreements
+      - run: |
+          echo "$env:LOCALAPPDATA\Microsoft\WinGet\Links" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$env:ProgramFiles\CMake\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - run: cmake -G Ninja -B .build/cmake
+      - run: cmake --build .build/cmake
       # Run tests with SwiftPM
       - name: Run tests with SwiftPM
         run: swift test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,12 +259,6 @@ jobs:
           swift-build: 6.3.2-RELEASE
       - uses: actions/checkout@v6
       - run: python3 ./Vendor/checkout-dependency --category default
-      - run: winget install Ninja-build.Ninja Kitware.CMake --disable-interactivity --accept-source-agreements
-      - run: |
-          echo "$env:LOCALAPPDATA\Microsoft\WinGet\Links" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "$env:ProgramFiles\CMake\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - run: cmake -G Ninja -B .build/cmake
-      - run: cmake --build .build/cmake
       # Run tests with SwiftPM
       - name: Run tests with SwiftPM
         run: swift test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,7 +224,7 @@ jobs:
       matrix:
         include:
           - swift: 6.3-noble
-            musl-swift-sdk-download: "https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"
+            musl-swift-sdk-download: "https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz"
             musl-swift-sdk-checksum: "3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,7 +255,7 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          swift-version: swift-6.3-release
+          swift-version: swift-6.3.2-release
           swift-build: 6.3.2-RELEASE
       - uses: actions/checkout@v6
       - run: python3 ./Vendor/checkout-dependency --category default

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   check-autogen-diff:
     runs-on: ubuntu-latest
     container:
-      image: swift:6.2-noble
+      image: swift:6.3-noble
     steps:
       - uses: actions/checkout@v6
       - name: Re-generate auto-generated code checks
@@ -32,10 +32,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - toolchain: 6.3-snapshot
+          - toolchain: 6.4.x-snapshot
             test-args: ""
           - toolchain: main-snapshot
-            test-args: "-Xswiftc -DWASMKIT_CI_TOOLCHAIN_MAIN_NIGHTLY"
+            test-args: ""
     steps:
       - uses: actions/checkout@v6
       - id: setup-development
@@ -62,37 +62,13 @@ jobs:
     strategy:
       matrix:
         include:
-          # Swift 6.1
-          - os: macos-15
-            xcode: Xcode_16.4
-            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--sanitize address --traits ComponentModel,WasmDebuggingSupport"
-          # Swift 6.2
-          - os: macos-15
-            xcode: Xcode_26.1
-            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--sanitize address --traits ComponentModel,WasmDebuggingSupport"
-          # Swift 6.2.4 (Disabled due to hanging build).
-          # - os: macos-26
-          #   xcode: Xcode_26.3
-          #   development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a
-          #   wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-          #   wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-          #   wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-          #   test-args: "--sanitize address --traits ComponentModel,WasmDebuggingSupport"
           # Swift 6.3.2
           - os: macos-26
             xcode: Xcode_26.5
-            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
+            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a
+            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
+            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
+            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
             test-args: "--sanitize address --traits ComponentModel,WasmDebuggingSupport"
 
     runs-on: ${{ matrix.os }}
@@ -133,7 +109,7 @@ jobs:
       - name: Prepare Xcode platforms
         run: |
           set -euxo pipefail
-          sudo xcode-select -s /Applications/Xcode_26.3.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
           sudo xcodebuild -runFirstLaunch || true
           for PLAT in iOS tvOS watchOS visionOS; do
             if ! xcodebuild -showsdks | grep -q "$PLAT"; then
@@ -153,47 +129,27 @@ jobs:
     strategy:
       matrix:
         include:
-          - swift: "swift:6.1-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport"
-            build-benchmarks: true
-          - swift: "swift:6.2-amazonlinux2"
-            development-toolchain-download: "https://download.swift.org/development/amazonlinux2/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a-amazonlinux2.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport"
-          - swift: "swift:6.2-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
+          - swift: "swift:6.3-noble"
+            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a-ubuntu24.04.tar.gz"
+            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
+            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
+            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
             test-args: "--traits ComponentModel,WasmDebuggingSupport --enable-code-coverage"
             build-benchmarks: true
             build-dev-dashboard: true
-          - swift: "swiftlang/swift:nightly-6.3-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport -Xswiftc -DWASMKIT_CI_TOOLCHAIN_NIGHTLY"
+          - swift: "swiftlang/swift:nightly-main-noble"
+            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a-ubuntu24.04.tar.gz"
+            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
+            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
+            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
+            test-args: "--traits ComponentModel,WasmDebuggingSupport"
             build-benchmarks: true
           - swift: "swiftlang/swift:nightly-main-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport -Xswiftc -DWASMKIT_CI_TOOLCHAIN_NIGHTLY -Xswiftc -DWASMKIT_CI_TOOLCHAIN_MAIN_NIGHTLY"
-            build-benchmarks: true
-          - swift: "swiftlang/swift:nightly-main-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a/swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2025-10-02-a_wasm
-            wasi-swift-sdk-checksum: "b64dfad9e1c9ccdf06f35cf9b1a00317e000df0c0de0b3eb9f49d6db0fcba4d9"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport -Xswiftc -DWASMKIT_CI_TOOLCHAIN_NIGHTLY -Xswiftc -DWASMKIT_CI_TOOLCHAIN_MAIN_NIGHTLY --build-system swiftbuild"
+            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a-ubuntu24.04.tar.gz"
+            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
+            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
+            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
+            test-args: "--traits ComponentModel,WasmDebuggingSupport --build-system swiftbuild"
             label: " --build-system swiftbuild"
 
     runs-on: ubuntu-24.04
@@ -267,9 +223,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - swift: 6.2-noble
-            musl-swift-sdk-download: "https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"
-            musl-swift-sdk-checksum: "f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c"
+          - swift: 6.3-noble
+            musl-swift-sdk-download: "https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"
+            musl-swift-sdk-checksum: "3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407"
     steps:
       - uses: actions/checkout@v6
       - name: Configure container
@@ -292,10 +248,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - swift-version: "6.2"
-          - swift-version: "nightly-6.3"
-          # Regressed since `swift-DEVELOPMENT-SNAPSHOT-2026-04-01-a`
-          # - swift-version: nightly-main
+          - swift-version: "6.3"
+          - swift-version: "nightly-main"
 
     steps:
       - uses: actions/checkout@v6
@@ -312,8 +266,8 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          swift-version: swift-6.2-release
-          swift-build: 6.2-RELEASE
+          swift-version: swift-6.3-release
+          swift-build: 6.3-RELEASE
       - uses: actions/checkout@v6
       - run: python3 ./Vendor/checkout-dependency --category default
       # FIXME: CMake build is failing on CI due to "link: extra operand '/OUT:lib\\libXXXX.a'" error
@@ -332,7 +286,7 @@ jobs:
   build-cmake:
     runs-on: ubuntu-24.04
     container:
-      image: swift:6.2-noble
+      image: swift:6.3-noble
     steps:
       - uses: actions/checkout@v6
       - name: Install Ninja
@@ -348,12 +302,12 @@ jobs:
   build-wasi:
     runs-on: ubuntu-24.04
     container:
-      image: swift:6.2-noble
+      image: swift:6.3-noble
     steps:
       - uses: actions/checkout@v6
       - name: Install jq
         run: apt-get update && apt-get install -y jq
       - name: Install Swift SDK
-        run: swift sdk install https://download.swift.org/swift-6.2.4-release/wasm-sdk/swift-6.2.4-RELEASE/swift-6.2.4-RELEASE_wasm.artifactbundle.tar.gz --checksum 32fdb8772d73bb174f77b5c59bc88a0d55003d75712832129394d3465158fb43
+        run: swift sdk install https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz --checksum a61f0584c93283589f8b2f42db05c1f9a182b506c2957271402992655591dd7c
       - name: Build with the Swift SDK
         run: swift build --swift-sdk "$(swiftc -print-target-info | jq -r '.swiftCompilerTag')_wasm" --traits ComponentModel --explicit-target-dependency-import-check error --product wasmkit-cli

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,8 +259,6 @@ jobs:
           swift-build: 6.3.2-RELEASE
       - uses: actions/checkout@v6
       - run: python3 ./Vendor/checkout-dependency --category default
-      # Check Windows build with CMake
-      - uses: Cyberboss/install-winget@v1
       - run: winget install Ninja-build.Ninja Kitware.CMake --disable-interactivity --accept-source-agreements
       - run: |
           echo "$env:LOCALAPPDATA\Microsoft\WinGet\Links" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Shared dev snapshot; bump these two to refresh every dev-snapshot download below.
+  DEV_SNAPSHOT: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a
+  WASI_SDK_CHECKSUM: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
+
 jobs:
   check-autogen-diff:
     runs-on: ubuntu-latest
@@ -65,10 +70,6 @@ jobs:
           # Swift 6.3.2
           - os: macos-26
             xcode: Xcode_26.5
-            development-toolchain-tag: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
-            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
             test-args: "--sanitize address --traits ComponentModel,WasmDebuggingSupport"
 
     runs-on: ${{ matrix.os }}
@@ -77,14 +78,14 @@ jobs:
       - uses: actions/checkout@v6
       - id: setup-development
         run: |
-          toolchain_path="/Library/Developer/Toolchains/${{ matrix.development-toolchain-tag }}.xctoolchain"
+          toolchain_path="/Library/Developer/Toolchains/$DEV_SNAPSHOT.xctoolchain"
           pkg="$(mktemp -d)/InstallMe.pkg"
-          development_toolchain_download="https://download.swift.org/development/xcode/${{ matrix.development-toolchain-tag }}/${{ matrix.development-toolchain-tag }}-osx.pkg"
+          development_toolchain_download="https://download.swift.org/development/xcode/$DEV_SNAPSHOT/$DEV_SNAPSHOT-osx.pkg"
           curl -L "$development_toolchain_download" -o $pkg
           sudo installer -pkg $pkg -target /
           echo "toolchain-path=$toolchain_path" >> $GITHUB_OUTPUT
-          "$toolchain_path/usr/bin/swift" sdk install "${{ matrix.wasi-swift-sdk-download }}" --checksum "${{ matrix.wasi-swift-sdk-checksum }}"
-          wasi_sdk_path=$("$toolchain_path/usr/bin/swift" sdk configure --show-configuration "${{ matrix.wasi-swift-sdk-id }}" wasm32-unknown-wasi | grep sdkRootPath: | cut -d: -f2)
+          "$toolchain_path/usr/bin/swift" sdk install "https://download.swift.org/development/wasm-sdk/$DEV_SNAPSHOT/${DEV_SNAPSHOT}_wasm.artifactbundle.tar.gz" --checksum "$WASI_SDK_CHECKSUM"
+          wasi_sdk_path=$("$toolchain_path/usr/bin/swift" sdk configure --show-configuration "${DEV_SNAPSHOT}_wasm" wasm32-unknown-wasi | grep sdkRootPath: | cut -d: -f2)
           echo "wasi-swift-sdk-path=$(dirname $wasi_sdk_path)" >> $GITHUB_OUTPUT
 
       - name: Select Xcode version
@@ -130,25 +131,16 @@ jobs:
       matrix:
         include:
           - swift: "swift:6.3-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
-            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
             test-args: "--traits ComponentModel,WasmDebuggingSupport --enable-code-coverage"
             build-benchmarks: true
             build-dev-dashboard: true
-          - swift: "swiftlang/swift:nightly-main-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
-            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
+          - swift: "swiftlang/swift:nightly-6.4.x-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport"
             build-benchmarks: true
           - swift: "swiftlang/swift:nightly-main-noble"
-            development-toolchain-download: "https://download.swift.org/development/ubuntu2404/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a-ubuntu24.04.tar.gz"
-            wasi-swift-sdk-download: "https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm.artifactbundle.tar.gz"
-            wasi-swift-sdk-id: swift-DEVELOPMENT-SNAPSHOT-2026-06-12-a_wasm
-            wasi-swift-sdk-checksum: "72eeab944b2ac44536aaaea2c5dc75fb30a0aa469f9ce59f831e08d2a8e60c48"
+            test-args: "--traits ComponentModel,WasmDebuggingSupport"
+            build-benchmarks: true
+          - swift: "swiftlang/swift:nightly-main-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport --build-system swiftbuild"
             label: " --build-system swiftbuild"
 
@@ -168,10 +160,10 @@ jobs:
         run: |
           toolchain_path="/opt/swiftwasm"
           ./build-exec mkdir -p "$toolchain_path"
-          curl -L ${{ matrix.development-toolchain-download }} | ./build-exec tar xz --strip-component 1 -C "$toolchain_path"
+          curl -L "https://download.swift.org/development/ubuntu2404/$DEV_SNAPSHOT/$DEV_SNAPSHOT-ubuntu24.04.tar.gz" | ./build-exec tar xz --strip-component 1 -C "$toolchain_path"
           echo "toolchain-path=$toolchain_path" >> $GITHUB_OUTPUT
-          ./build-exec "$toolchain_path/usr/bin/swift" sdk install "${{ matrix.wasi-swift-sdk-download }}" --checksum "${{ matrix.wasi-swift-sdk-checksum }}"
-          wasi_sdk_path=$(./build-exec "$toolchain_path/usr/bin/swift" sdk configure --show-configuration "${{ matrix.wasi-swift-sdk-id }}" wasm32-unknown-wasi | grep sdkRootPath: | cut -d: -f2)
+          ./build-exec "$toolchain_path/usr/bin/swift" sdk install "https://download.swift.org/development/wasm-sdk/$DEV_SNAPSHOT/${DEV_SNAPSHOT}_wasm.artifactbundle.tar.gz" --checksum "$WASI_SDK_CHECKSUM"
+          wasi_sdk_path=$(./build-exec "$toolchain_path/usr/bin/swift" sdk configure --show-configuration "${DEV_SNAPSHOT}_wasm" wasm32-unknown-wasi | grep sdkRootPath: | cut -d: -f2)
           echo "wasi-swift-sdk-path=$(dirname $wasi_sdk_path)" >> $GITHUB_OUTPUT
 
       - name: Configure Tests/default.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure container
         run: |
-          docker run -dit --name build-container -v $PWD:/workspace -w /workspace swift:6.0.1-jammy
+          docker run -dit --name build-container -v $PWD:/workspace -w /workspace swift:6.3.2-jammy
           echo 'docker exec -i build-container "$@"' > ./build-exec
           chmod +x ./build-exec
       - name: Install Static Linux SDK
-        run: ./build-exec swift sdk install "https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz" --checksum "d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481"
+        run: ./build-exec swift sdk install "https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz" --checksum "3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407"
       - name: Install LLVM tools
         run: |
           ./build-exec apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo 'docker exec -i build-container "$@"' > ./build-exec
           chmod +x ./build-exec
       - name: Install Static Linux SDK
-        run: ./build-exec swift sdk install "https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz" --checksum "3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407"
+        run: ./build-exec swift sdk install "https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz" --checksum "3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407"
       - name: Install LLVM tools
         run: |
           ./build-exec apt-get update

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.3
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Proposals are grouped by their [phase](https://github.com/WebAssembly/meetings/b
 
 ## Minimum Supported Swift Version (MSSV)
 
-Currently, the minimum supported version is Swift 6.1. The general strategy is to support last two minor versions of the Swift toolchain available at the time of WasmKit's release. At the same time, development branches of WasmKit tend to adopt newer development versions of the Swift toolchain.
+Currently, the minimum supported version is Swift 6.3. When possible, our goal is to support the last two minor versions of the Swift toolchain available at the time of WasmKit's release. At the same time, development branches of WasmKit tend to adopt newer development versions of the Swift toolchain.
 
 ## Testing
 


### PR DESCRIPTION
As uncovered by https://github.com/swiftwasm/WasmKit/pull/209 in fuzzing CI jobs, Swift 6.2 and earlier versions miscompile certain uses of `~Copyable`. The miscompile is fixed in 6.3, but we should not be supporting versions where miscompiles can't be fixed. With 6.3 already released and 6.4 branched, bumping to 6.3 lands roughly within the existing declared WasmKit's MSSV policy, depending on when next WasmKit is going to be tagged. If at the time of WasmKit's release Swift 6.4 is not available, temporarily shorter MSSV window is still worth it for avoiding miscompiles.