### PR TITLE
Represent CM valtypes as type index or inline primitive

### DIFF
--- a/Sources/ComponentModel/ComponentRepresentation.swift
+++ b/Sources/ComponentModel/ComponentRepresentation.swift
@@ -133,7 +133,7 @@ public enum ComponentExternDesc {
 /// A bound on a value type.
 public enum ComponentValueBound {
     case eq(valueIndex: UInt32)
-    case type(ComponentValueType)
+    case type(ComponentDefValType)
 }
 
 /// A bound on a type.
@@ -222,10 +222,10 @@ public struct ComponentExportDef {
 
 /// A value definition (from binary section 12).
 public struct ComponentValueDef {
-    public let type: ComponentValueType
+    public let type: ComponentDefValType
     public let value: [UInt8]  // Raw bytes, interpretation depends on type
 
-    public init(type: ComponentValueType, value: [UInt8]) {
+    public init(type: ComponentDefValType, value: [UInt8]) {
         self.type = type
         self.value = value
     }

--- a/Sources/ComponentModel/ComponentType.swift
+++ b/Sources/ComponentModel/ComponentType.swift
@@ -65,29 +65,54 @@ public enum ComponentDefSort {
     case instance
 }
 
-public enum ComponentValueType: Hashable {
+/// Primitive value types that can be encoded inline in valtypes.
+/// Corresponds to `primvaltype` in the Component Model binary spec.
+public enum ComponentPrimValType: Hashable {
     case bool
-    case u8
-    case u16
-    case u32
-    case u64
     case s8
     case s16
     case s32
     case s64
+    case u8
+    case u16
+    case u32
+    case u64
     case float32
     case float64
     case char
     case string
     case errorContext
-    case list(ComponentTypeIndex)
-    //    case handleOwn(ResourceSyntax)
-    //    case handleBorrow(ResourceSyntax)
-    case tuple([ComponentTypeIndex])
-    case option(ComponentTypeIndex)
-    case result(ok: ComponentTypeIndex?, error: ComponentTypeIndex?)
-    case future(ComponentTypeIndex?)
-    case stream(element: ComponentTypeIndex?, end: ComponentTypeIndex?)
+}
+
+/// A value type reference: either a type index or an inline primitive.
+/// Corresponds to `valtype` in the Component Model binary spec:
+/// `valtype ::= i:<typeidx> | pvt:<primvaltype>`
+public enum ComponentValType: Hashable {
+    case index(ComponentTypeIndex)
+    case primitive(ComponentPrimValType)
+
+    /// Resolve this value-type reference to a definition type: inline primitives
+    /// become `.inlined(.primitive(...))`; type indices are looked up via `resolveType`.
+    package func resolve(
+        _ resolveType: (ComponentTypeIndex) throws -> ComponentDefValType
+    ) rethrows -> ComponentDefValType {
+        switch self {
+        case .primitive(let prim): return .inlined(.primitive(prim))
+        case .index(let idx): return try resolveType(idx)
+        }
+    }
+}
+
+public enum ComponentDefValType: Hashable {
+    /// A value type: a type index or an inline primitive.
+    case inlined(ComponentValType)
+
+    case list(ComponentValType)
+    case tuple([ComponentValType])
+    case option(ComponentValType)
+    case result(ok: ComponentValType?, error: ComponentValType?)
+    case future(ComponentValType?)
+    case stream(element: ComponentValType?, end: ComponentValType?)
 
     // Named type declarations
 
@@ -97,43 +122,43 @@ public enum ComponentValueType: Hashable {
     case variant([ComponentCaseField])
     case resource(destructor: ComponentFuncIndex)
 
-    case indexed(ComponentTypeIndex)
+    /// Construct an inline-primitive value type.
+    public static func primitive(_ type: ComponentPrimValType) -> Self { .inlined(.primitive(type)) }
 
-    /// Returns `true` if this is a primitive type that can be inlined in valtypes during binary encoding
+    /// Construct a type-index value type.
+    public static func indexed(_ index: ComponentTypeIndex) -> Self { .inlined(.index(index)) }
+
+    /// `true` if this is an inline-primitive value type.
     package var isPrimitive: Bool {
-        switch self {
-        case .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .float32, .float64, .char, .string, .errorContext:
-            return true
-        case .list, .tuple, .option, .result, .future, .stream, .record, .flags, .enum, .variant, .resource, .indexed:
-            return false
-        }
+        guard case .inlined(.primitive) = self else { return false }
+        return true
     }
 }
 
 public struct ComponentFuncType: Hashable {
-    public init(params: [ComponentFuncType.Param], result: ComponentValueType?) {
+    public init(params: [ComponentFuncType.Param], result: ComponentDefValType?) {
         self.params = params
         self.result = result
     }
 
     public struct Param: Hashable {
-        public init(name: String, type: ComponentValueType) {
+        public init(name: String, type: ComponentDefValType) {
             self.name = name
             self.type = type
         }
 
         public let name: String
-        public let type: ComponentValueType
+        public let type: ComponentDefValType
     }
     public let params: [Param]
-    public let result: ComponentValueType?
+    public let result: ComponentDefValType?
 }
 
 public struct ComponentRecordField: Hashable {
     public let name: String
-    public let type: ComponentTypeIndex
+    public let type: ComponentValType
 
-    public init(name: String, type: ComponentTypeIndex) {
+    public init(name: String, type: ComponentValType) {
         self.name = name
         self.type = type
     }
@@ -141,9 +166,9 @@ public struct ComponentRecordField: Hashable {
 
 public struct ComponentCaseField: Hashable {
     public let name: String
-    public let type: ComponentTypeIndex?
+    public let type: ComponentValType?
 
-    public init(name: String, type: ComponentTypeIndex?) {
+    public init(name: String, type: ComponentValType?) {
         self.name = name
         self.type = type
     }

--- a/Sources/WAT/BinaryEncoding/ComponentEncoder.swift
+++ b/Sources/WAT/BinaryEncoding/ComponentEncoder.swift
@@ -356,24 +356,28 @@
         }
 
         // Collect all type indices that a value type depends on
-        private func collectDependentTypeIndices(from valueType: ComponentValueType) -> [Int] {
+        private func collectDependentTypeIndices(from valueType: ComponentDefValType) -> [Int] {
+            func indexOf(_ ref: ComponentValType) -> Int? {
+                if case .index(let idx) = ref { return Int(idx.rawValue) }
+                return nil
+            }
             switch valueType {
-            case .indexed(let typeIndex):
+            case .inlined(.index(let typeIndex)):
                 return [Int(typeIndex.rawValue)]
-            case .list(let typeIndex), .option(let typeIndex):
-                return [Int(typeIndex.rawValue)]
-            case .tuple(let typeIndices):
-                return typeIndices.map { Int($0.rawValue) }
-            case .result(let okType, let errorType):
+            case .list(let ref), .option(let ref):
+                return indexOf(ref).map { [$0] } ?? []
+            case .tuple(let refs):
+                return refs.compactMap(indexOf)
+            case .result(let okRef, let errorRef):
                 var indices: [Int] = []
-                if let okType { indices.append(Int(okType.rawValue)) }
-                if let errorType { indices.append(Int(errorType.rawValue)) }
+                if let okRef, let i = indexOf(okRef) { indices.append(i) }
+                if let errorRef, let i = indexOf(errorRef) { indices.append(i) }
                 return indices
             case .record(let fields):
-                return fields.map { Int($0.type.rawValue) }
+                return fields.compactMap { indexOf($0.type) }
             case .variant(let cases):
-                return cases.compactMap { $0.type.map { Int($0.rawValue) } }
-            case .bool, .u8, .u16, .u32, .u64, .s8, .s16, .s32, .s64, .float32, .float64, .char, .string, .errorContext, .flags, .enum:
+                return cases.compactMap { $0.type.flatMap(indexOf) }
+            case .inlined(.primitive), .flags, .enum:
                 return []
             case .future, .stream, .resource:
                 return []
@@ -451,7 +455,7 @@
                 encoder.writeUnsignedLEB128(UInt32(funcType.params.count))
                 for param in funcType.params {
                     encoder.encode(param.name)
-                    try Self.encodeComponentValueType(
+                    try Self.encodeComponentDefValType(
                         param.type,
                         types: types,
                         indexMapping: typeIndexMapping,
@@ -461,7 +465,7 @@
 
                 if let result = funcType.result {
                     encoder.output.append(0x00)  // has result
-                    try Self.encodeComponentValueType(
+                    try Self.encodeComponentDefValType(
                         result,
                         types: types,
                         indexMapping: typeIndexMapping,
@@ -473,7 +477,7 @@
                 }
 
             case .value(let valueType):
-                try Self.encodeComponentValueType(
+                try Self.encodeComponentDefValType(
                     valueType,
                     types: types,
                     indexMapping: typeIndexMapping,
@@ -487,7 +491,7 @@
 
                 for typeDecl in instanceType.typeDecls {
                     encoder.output.append(0x01)  // type declaration tag
-                    try Self.encodeComponentValueType(
+                    try Self.encodeComponentDefValType(
                         typeDecl.valueType,
                         types: types,
                         indexMapping: typeIndexMapping,
@@ -512,7 +516,7 @@
 
                 for typeDecl in componentType.typeDecls {
                     encoder.output.append(0x01)  // type declaration tag
-                    try Self.encodeComponentValueType(
+                    try Self.encodeComponentDefValType(
                         typeDecl.valueType,
                         types: types,
                         indexMapping: typeIndexMapping,
@@ -1387,11 +1391,19 @@
 
         /// Encode a component value type as valtype (either index or inline primitive)
         private static func encodeValType(
-            _ typeIndex: ComponentTypeIndex,
+            _ ref: ComponentValType,
             types: NameMapping<ComponentWatParser.ComponentTypeDef>,
             indexMapping: [Int: Int],
             encoder: inout Encoder
         ) throws(WatParserError) {
+            let typeIndex: ComponentTypeIndex
+            switch ref {
+            case .primitive(let prim):
+                try encodeComponentDefValType(.inlined(.primitive(prim)), types: types, indexMapping: indexMapping, encoder: &encoder)
+                return
+            case .index(let idx):
+                typeIndex = idx
+            }
             // Look up the type to see if it's a primitive
             let typeDef = types[Int(typeIndex.rawValue)]
             // Only inline primitives if the type is anonymous (no ID)
@@ -1399,9 +1411,9 @@
             if typeDef.id == nil, case .value(let valueType) = typeDef.kind {
                 // Check if it's a primitive that can be inlined
                 switch valueType {
-                case .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .float32, .float64, .char, .string, .errorContext:
+                case .inlined(.primitive):
                     // Inline the primitive
-                    try encodeComponentValueType(valueType, types: types, indexMapping: indexMapping, encoder: &encoder)
+                    try encodeComponentDefValType(valueType, types: types, indexMapping: indexMapping, encoder: &encoder)
                     return
                 default:
                     break
@@ -1415,28 +1427,28 @@
         }
 
         /// Encode a component value type
-        private static func encodeComponentValueType(
-            _ valueType: ComponentValueType,
+        private static func encodeComponentDefValType(
+            _ valueType: ComponentDefValType,
             types: NameMapping<ComponentWatParser.ComponentTypeDef>,
             indexMapping: [Int: Int],
             encoder: inout Encoder
         ) throws(WatParserError) {
             switch valueType {
             // Primitive types
-            case .bool: encoder.output.append(0x7F)
-            case .s8: encoder.output.append(0x7E)
-            case .u8: encoder.output.append(0x7D)
-            case .s16: encoder.output.append(0x7C)
-            case .u16: encoder.output.append(0x7B)
-            case .s32: encoder.output.append(0x7A)
-            case .u32: encoder.output.append(0x79)
-            case .s64: encoder.output.append(0x78)
-            case .u64: encoder.output.append(0x77)
-            case .float32: encoder.output.append(0x76)
-            case .float64: encoder.output.append(0x75)
-            case .char: encoder.output.append(0x74)
-            case .string: encoder.output.append(0x73)
-            case .errorContext: encoder.output.append(0x64)
+            case .inlined(.primitive(.bool)): encoder.output.append(0x7F)
+            case .inlined(.primitive(.s8)): encoder.output.append(0x7E)
+            case .inlined(.primitive(.u8)): encoder.output.append(0x7D)
+            case .inlined(.primitive(.s16)): encoder.output.append(0x7C)
+            case .inlined(.primitive(.u16)): encoder.output.append(0x7B)
+            case .inlined(.primitive(.s32)): encoder.output.append(0x7A)
+            case .inlined(.primitive(.u32)): encoder.output.append(0x79)
+            case .inlined(.primitive(.s64)): encoder.output.append(0x78)
+            case .inlined(.primitive(.u64)): encoder.output.append(0x77)
+            case .inlined(.primitive(.float32)): encoder.output.append(0x76)
+            case .inlined(.primitive(.float64)): encoder.output.append(0x75)
+            case .inlined(.primitive(.char)): encoder.output.append(0x74)
+            case .inlined(.primitive(.string)): encoder.output.append(0x73)
+            case .inlined(.primitive(.errorContext)): encoder.output.append(0x64)
 
             // Composite types
             case .list(let typeIndex):
@@ -1508,7 +1520,7 @@
             case .future, .stream, .resource:
                 throw WatParserError("Component value type not yet supported: \(valueType)", location: nil)
 
-            case .indexed(let typeIndex):
+            case .inlined(.index(let typeIndex)):
                 // This is already a type reference, encode as index with remapping
                 guard let mappedIndex = indexMapping[Int(typeIndex.rawValue)] else {
                     throw WatParserError("Type index \(typeIndex.rawValue) not found in index mapping", location: nil)

--- a/Sources/WAT/Parser/ComponentDef.swift
+++ b/Sources/WAT/Parser/ComponentDef.swift
@@ -242,7 +242,7 @@
         struct ComponentTypeDef: NamedFieldDecl {
             enum Kind: Hashable {
                 case function(ComponentFuncType)
-                case value(ComponentValueType)
+                case value(ComponentDefValType)
                 case instance(InstanceTypeDef)
                 case component(ComponentInnerTypeDef)
             }
@@ -253,7 +253,7 @@
         struct InstanceTypeDef: Hashable {
             struct TypeDecl: Hashable {
                 let id: Name?
-                let valueType: ComponentValueType
+                let valueType: ComponentDefValType
             }
             struct ExportDecl: Hashable {
                 let name: String
@@ -266,7 +266,7 @@
         struct ComponentInnerTypeDef: Hashable {
             struct TypeDecl: Hashable {
                 let id: Name?
-                let valueType: ComponentValueType
+                let valueType: ComponentDefValType
             }
             struct ImportDecl: Hashable {
                 let name: String

--- a/Sources/WAT/Parser/ComponentWatParser.swift
+++ b/Sources/WAT/Parser/ComponentWatParser.swift
@@ -392,9 +392,9 @@
                 switch typeKeyword {
                 case "func":
                     let params = try parseFuncParams(&parser)
-                    var resultType: ComponentValueType?
+                    var resultType: ComponentDefValType?
                     if try parser.takeParenBlockStart("result") {
-                        resultType = try parseComponentValueType(&parser)
+                        resultType = try parseComponentDefValType(&parser)
                         try parser.expect(.rightParen)
                     }
                     kind = .function(ComponentFuncType(params: params, result: resultType))
@@ -414,18 +414,18 @@
                     var fields: [ComponentRecordField] = []
                     while try parser.takeParenBlockStart("field") {
                         let fieldName = try parser.expectString()
-                        let fieldType = try parseComponentValueType(&parser)
+                        let fieldType = try parseComponentDefValType(&parser)
                         let fieldTypeIndex: ComponentTypeIndex
-                        if case .indexed(let idx) = fieldType {
+                        if case .inlined(.index(let idx)) = fieldType {
                             fieldTypeIndex = idx
                         } else {
                             let idx = try addAnonymousComponentType(fieldType)
                             fieldTypeIndex = ComponentTypeIndex(rawValue: idx)
                         }
-                        fields.append(ComponentRecordField(name: fieldName, type: fieldTypeIndex))
+                        fields.append(ComponentRecordField(name: fieldName, type: .index(fieldTypeIndex)))
                         try parser.expect(.rightParen)
                     }
-                    let recordType = ComponentValueType.record(fields)
+                    let recordType = ComponentDefValType.record(fields)
                     kind = .value(recordType)
                     try parser.expect(.rightParen)
 
@@ -436,8 +436,8 @@
                         let caseName = try parser.expectString()
                         var caseType: ComponentTypeIndex? = nil
                         if try !parser.take(.rightParen) {
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 caseType = idx
                             } else {
                                 let idx = try addAnonymousComponentType(valueType)
@@ -445,9 +445,9 @@
                             }
                             try parser.expect(.rightParen)
                         }
-                        cases.append(ComponentCaseField(name: caseName, type: caseType))
+                        cases.append(ComponentCaseField(name: caseName, type: caseType.map { .index($0) }))
                     }
-                    let variantType = ComponentValueType.variant(cases)
+                    let variantType = ComponentDefValType.variant(cases)
                     kind = .value(variantType)
                     try parser.expect(.rightParen)
 
@@ -456,7 +456,7 @@
                     while let flagName = try parser.takeString() {
                         flagNames.append(flagName)
                     }
-                    let flagsType = ComponentValueType.flags(flagNames)
+                    let flagsType = ComponentDefValType.flags(flagNames)
                     kind = .value(flagsType)
                     try parser.expect(.rightParen)
 
@@ -465,47 +465,47 @@
                     while let caseName = try parser.takeString() {
                         enumCases.append(caseName)
                     }
-                    let enumType = ComponentValueType.enum(enumCases)
+                    let enumType = ComponentDefValType.enum(enumCases)
                     kind = .value(enumType)
                     try parser.expect(.rightParen)
 
                 case "list":
-                    let elementType = try parseComponentValueType(&parser)
+                    let elementType = try parseComponentDefValType(&parser)
                     let elementIndex: ComponentTypeIndex
-                    if case .indexed(let idx) = elementType {
+                    if case .inlined(.index(let idx)) = elementType {
                         elementIndex = idx
                     } else {
                         let elemIdx = try addAnonymousComponentType(elementType)
                         elementIndex = ComponentTypeIndex(rawValue: elemIdx)
                     }
-                    let listType = ComponentValueType.list(elementIndex)
+                    let listType = ComponentDefValType.list(.index(elementIndex))
                     kind = .value(listType)
                     try parser.expect(.rightParen)
 
                 case "tuple":
                     var typeIndices: [ComponentTypeIndex] = []
                     while try !parser.take(.rightParen) {
-                        let valueType = try parseComponentValueType(&parser)
-                        if case .indexed(let idx) = valueType {
+                        let valueType = try parseComponentDefValType(&parser)
+                        if case .inlined(.index(let idx)) = valueType {
                             typeIndices.append(idx)
                         } else {
                             let elemIdx = try addAnonymousComponentType(valueType)
                             typeIndices.append(ComponentTypeIndex(rawValue: elemIdx))
                         }
                     }
-                    let tupleType = ComponentValueType.tuple(typeIndices)
+                    let tupleType = ComponentDefValType.tuple(typeIndices.map { .index($0) })
                     kind = .value(tupleType)
 
                 case "option":
-                    let someType = try parseComponentValueType(&parser)
+                    let someType = try parseComponentDefValType(&parser)
                     let elementIndex: ComponentTypeIndex
-                    if case .indexed(let idx) = someType {
+                    if case .inlined(.index(let idx)) = someType {
                         elementIndex = idx
                     } else {
                         let elemIdx = try addAnonymousComponentType(someType)
                         elementIndex = ComponentTypeIndex(rawValue: elemIdx)
                     }
-                    let optionType = ComponentValueType.option(elementIndex)
+                    let optionType = ComponentDefValType.option(.index(elementIndex))
                     kind = .value(optionType)
                     try parser.expect(.rightParen)
 
@@ -517,8 +517,8 @@
                     if try !parser.take(.rightParen) {
                         // Check for (error ...) first (error-only result)
                         if try parser.takeParenBlockStart("error") {
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 errorType = idx
                             } else {
                                 errorType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(valueType))
@@ -527,8 +527,8 @@
                             try parser.expect(.rightParen)
                         } else if try parser.takeParenBlockStart("ok") {
                             // Explicit (ok TYPE)
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 okType = idx
                             } else {
                                 okType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(valueType))
@@ -536,8 +536,8 @@
                             try parser.expect(.rightParen)
                             // Check for optional (error TYPE)
                             if try parser.takeParenBlockStart("error") {
-                                let errType = try parseComponentValueType(&parser)
-                                if case .indexed(let idx) = errType {
+                                let errType = try parseComponentDefValType(&parser)
+                                if case .inlined(.index(let idx)) = errType {
                                     errorType = idx
                                 } else {
                                     errorType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(errType))
@@ -547,16 +547,16 @@
                             try parser.expect(.rightParen)
                         } else {
                             // Shorthand: TYPE is the ok type
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 okType = idx
                             } else {
                                 okType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(valueType))
                             }
                             // Check for optional (error TYPE)
                             if try parser.takeParenBlockStart("error") {
-                                let errType = try parseComponentValueType(&parser)
-                                if case .indexed(let idx) = errType {
+                                let errType = try parseComponentDefValType(&parser)
+                                if case .inlined(.index(let idx)) = errType {
                                     errorType = idx
                                 } else {
                                     errorType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(errType))
@@ -566,7 +566,7 @@
                             try parser.expect(.rightParen)
                         }
                     }
-                    let resultType = ComponentValueType.result(ok: okType, error: errorType)
+                    let resultType = ComponentDefValType.result(ok: okType.map { .index($0) }, error: errorType.map { .index($0) })
                     kind = .value(resultType)
 
                 default:
@@ -577,7 +577,7 @@
                 }
             } else {
                 // Shorthand: primitive value type keyword directly (e.g., `bool`, `u8`, etc.)
-                let primitiveType = try parseComponentValueType(&parser)
+                let primitiveType = try parseComponentDefValType(&parser)
                 kind = .value(primitiveType)
             }
 
@@ -887,7 +887,7 @@
                 switch declKeyword {
                 case "type":
                     let typeId = try parser.takeId()
-                    let valueType = try parseComponentValueType(&parser)
+                    let valueType = try parseComponentDefValType(&parser)
                     typeDecls.append(InstanceTypeDef.TypeDecl(id: typeId, valueType: valueType))
                 case "export":
                     let exportName = try parser.expectString()
@@ -924,7 +924,7 @@
                 switch declKeyword {
                 case "type":
                     let typeId = try parser.takeId()
-                    let valueType = try parseComponentValueType(&parser)
+                    let valueType = try parseComponentDefValType(&parser)
                     typeDecls.append(ComponentInnerTypeDef.TypeDecl(id: typeId, valueType: valueType))
                 case "import":
                     let importName = try parser.expectString()
@@ -966,7 +966,7 @@
             return ComponentInnerTypeDef(typeDecls: typeDecls, imports: imports, exports: exports)
         }
 
-        private mutating func parseComponentValueType(_ parser: inout Parser) throws(WatParserError) -> ComponentValueType {
+        private mutating func parseComponentDefValType(_ parser: inout Parser) throws(WatParserError) -> ComponentDefValType {
             // First check for type reference (identifier like $A1)
             if let typeRef = try parser.takeId() {
                 // Resolve the type reference to an index
@@ -979,22 +979,22 @@
             let primitiveTypeKeyword = try parser.peekKeyword()
 
             if let primitiveTypeKeyword {
-                let primitiveType: ComponentValueType
+                let primitiveType: ComponentDefValType
                 switch primitiveTypeKeyword {
-                case "bool": primitiveType = .bool
-                case "u8": primitiveType = .u8
-                case "u16": primitiveType = .u16
-                case "u32": primitiveType = .u32
-                case "u64": primitiveType = .u64
-                case "s8": primitiveType = .s8
-                case "s16": primitiveType = .s16
-                case "s32": primitiveType = .s32
-                case "s64": primitiveType = .s64
-                case "float32", "f32": primitiveType = .float32
-                case "float64", "f64": primitiveType = .float64
-                case "char": primitiveType = .char
-                case "string": primitiveType = .string
-                case "error-context": primitiveType = .errorContext
+                case "bool": primitiveType = .primitive(.bool)
+                case "u8": primitiveType = .primitive(.u8)
+                case "u16": primitiveType = .primitive(.u16)
+                case "u32": primitiveType = .primitive(.u32)
+                case "u64": primitiveType = .primitive(.u64)
+                case "s8": primitiveType = .primitive(.s8)
+                case "s16": primitiveType = .primitive(.s16)
+                case "s32": primitiveType = .primitive(.s32)
+                case "s64": primitiveType = .primitive(.s64)
+                case "float32", "f32": primitiveType = .primitive(.float32)
+                case "float64", "f64": primitiveType = .primitive(.float64)
+                case "char": primitiveType = .primitive(.char)
+                case "string": primitiveType = .primitive(.string)
+                case "error-context": primitiveType = .primitive(.errorContext)
                 default:
                     throw WatParserError(
                         "Unexpected primitive component type keyword `\(primitiveTypeKeyword)`",
@@ -1008,26 +1008,26 @@
                 let compositeTypeKeyword = try parser.expectKeyword()
                 switch compositeTypeKeyword {
                 case "list":
-                    let elementType = try parseComponentValueType(&parser)
+                    let elementType = try parseComponentDefValType(&parser)
                     try parser.expect(.rightParen)
                     // Get or create type index for element
                     let elementIndex: ComponentTypeIndex
-                    if case .indexed(let idx) = elementType {
+                    if case .inlined(.index(let idx)) = elementType {
                         elementIndex = idx
                     } else {
                         // Primitive - create a "pseudo-type" entry that encoder will inline
                         let elemIdx = try addAnonymousComponentType(elementType)
                         elementIndex = ComponentTypeIndex(rawValue: elemIdx)
                     }
-                    let listValueType: ComponentValueType = .list(elementIndex)
+                    let listValueType: ComponentDefValType = .list(.index(elementIndex))
                     let typeIndex = try addAnonymousComponentType(listValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
                 case "tuple":
                     var typeIndices: [ComponentTypeIndex] = []
                     while try !parser.take(.rightParen) {
-                        let valueType = try parseComponentValueType(&parser)
-                        if case .indexed(let idx) = valueType {
+                        let valueType = try parseComponentDefValType(&parser)
+                        if case .inlined(.index(let idx)) = valueType {
                             typeIndices.append(idx)
                         } else {
                             // Primitive - create pseudo-type entry
@@ -1035,21 +1035,21 @@
                             typeIndices.append(ComponentTypeIndex(rawValue: elemIdx))
                         }
                     }
-                    let tupleValueType: ComponentValueType = .tuple(typeIndices)
+                    let tupleValueType: ComponentDefValType = .tuple(typeIndices.map { .index($0) })
                     let typeIndex = try addAnonymousComponentType(tupleValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
                 case "option":
-                    let someType = try parseComponentValueType(&parser)
+                    let someType = try parseComponentDefValType(&parser)
                     try parser.expect(.rightParen)
                     let elementIndex: ComponentTypeIndex
-                    if case .indexed(let idx) = someType {
+                    if case .inlined(.index(let idx)) = someType {
                         elementIndex = idx
                     } else {
                         let elemIdx = try addAnonymousComponentType(someType)
                         elementIndex = ComponentTypeIndex(rawValue: elemIdx)
                     }
-                    let optionValueType: ComponentValueType = .option(elementIndex)
+                    let optionValueType: ComponentDefValType = .option(.index(elementIndex))
                     let typeIndex = try addAnonymousComponentType(optionValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
@@ -1061,8 +1061,8 @@
                     if try !parser.take(.rightParen) {
                         // Check for (error ...) first (error-only result)
                         if try parser.takeParenBlockStart("error") {
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 errorType = idx
                             } else {
                                 errorType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(valueType))
@@ -1071,8 +1071,8 @@
                             try parser.expect(.rightParen)
                         } else if try parser.takeParenBlockStart("ok") {
                             // Explicit (ok TYPE)
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 okType = idx
                             } else {
                                 okType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(valueType))
@@ -1080,8 +1080,8 @@
                             try parser.expect(.rightParen)
                             // Check for optional (error TYPE)
                             if try parser.takeParenBlockStart("error") {
-                                let errType = try parseComponentValueType(&parser)
-                                if case .indexed(let idx) = errType {
+                                let errType = try parseComponentDefValType(&parser)
+                                if case .inlined(.index(let idx)) = errType {
                                     errorType = idx
                                 } else {
                                     errorType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(errType))
@@ -1091,16 +1091,16 @@
                             try parser.expect(.rightParen)
                         } else {
                             // Shorthand: TYPE is the ok type
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 okType = idx
                             } else {
                                 okType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(valueType))
                             }
                             // Check for optional (error TYPE)
                             if try parser.takeParenBlockStart("error") {
-                                let errType = try parseComponentValueType(&parser)
-                                if case .indexed(let idx) = errType {
+                                let errType = try parseComponentDefValType(&parser)
+                                if case .inlined(.index(let idx)) = errType {
                                     errorType = idx
                                 } else {
                                     errorType = ComponentTypeIndex(rawValue: try addAnonymousComponentType(errType))
@@ -1110,24 +1110,24 @@
                             try parser.expect(.rightParen)
                         }
                     }
-                    return .result(ok: okType, error: errorType)
+                    return .result(ok: okType.map { .index($0) }, error: errorType.map { .index($0) })
 
                 case "record":
                     var fields: [ComponentRecordField] = []
                     while try parser.takeParenBlockStart("field") {
                         let fieldName = try parser.expectString()
-                        let fieldType = try parseComponentValueType(&parser)
+                        let fieldType = try parseComponentDefValType(&parser)
                         let fieldTypeIndex: ComponentTypeIndex
-                        if case .indexed(let idx) = fieldType {
+                        if case .inlined(.index(let idx)) = fieldType {
                             fieldTypeIndex = idx
                         } else {
                             let idx = try addAnonymousComponentType(fieldType)
                             fieldTypeIndex = ComponentTypeIndex(rawValue: idx)
                         }
-                        fields.append(ComponentRecordField(name: fieldName, type: fieldTypeIndex))
+                        fields.append(ComponentRecordField(name: fieldName, type: .index(fieldTypeIndex)))
                         try parser.expect(.rightParen)
                     }
-                    let recordValueType: ComponentValueType = .record(fields)
+                    let recordValueType: ComponentDefValType = .record(fields)
                     let typeIndex = try addAnonymousComponentType(recordValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
@@ -1138,8 +1138,8 @@
                         var caseType: ComponentTypeIndex? = nil
                         // Check if there's a type after the case name
                         if try !parser.take(.rightParen) {
-                            let valueType = try parseComponentValueType(&parser)
-                            if case .indexed(let idx) = valueType {
+                            let valueType = try parseComponentDefValType(&parser)
+                            if case .inlined(.index(let idx)) = valueType {
                                 caseType = idx
                             } else {
                                 let idx = try addAnonymousComponentType(valueType)
@@ -1147,9 +1147,9 @@
                             }
                             try parser.expect(.rightParen)
                         }
-                        cases.append(ComponentCaseField(name: caseName, type: caseType))
+                        cases.append(ComponentCaseField(name: caseName, type: caseType.map { .index($0) }))
                     }
-                    let variantValueType: ComponentValueType = .variant(cases)
+                    let variantValueType: ComponentDefValType = .variant(cases)
                     let typeIndex = try addAnonymousComponentType(variantValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
@@ -1158,7 +1158,7 @@
                     while let flagName = try parser.takeString() {
                         flagNames.append(flagName)
                     }
-                    let flagsValueType: ComponentValueType = .flags(flagNames)
+                    let flagsValueType: ComponentDefValType = .flags(flagNames)
                     let typeIndex = try addAnonymousComponentType(flagsValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
@@ -1167,7 +1167,7 @@
                     while let caseName = try parser.takeString() {
                         enumCases.append(caseName)
                     }
-                    let enumValueType: ComponentValueType = .enum(enumCases)
+                    let enumValueType: ComponentDefValType = .enum(enumCases)
                     let typeIndex = try addAnonymousComponentType(enumValueType)
                     return .indexed(ComponentTypeIndex(rawValue: typeIndex))
 
@@ -1186,7 +1186,7 @@
         }
 
         /// Add an anonymous component type for inline type references
-        private mutating func addAnonymousComponentType(_ valueType: ComponentValueType) throws(WatParserError) -> Int {
+        private mutating func addAnonymousComponentType(_ valueType: ComponentDefValType) throws(WatParserError) -> Int {
             let typeDef = ComponentTypeDef(id: nil, kind: .value(valueType))
 
             // Check if this type already exists as an anonymous type (deduplication)
@@ -1207,7 +1207,7 @@
         }
 
         private mutating func parseComponentFuncParam(_ parser: inout Parser) throws(WatParserError) -> ComponentFuncType.Param {
-            try .init(name: parser.expectString(), type: try parseComponentValueType(&parser))
+            try .init(name: parser.expectString(), type: try parseComponentDefValType(&parser))
         }
 
         /// Parse function parameters for component function types
@@ -1215,7 +1215,7 @@
             var params: [ComponentFuncType.Param] = []
             while try parser.takeParenBlockStart("param") {
                 let name = try parser.expectString()
-                let type = try parseComponentValueType(&parser)
+                let type = try parseComponentDefValType(&parser)
                 params.append(ComponentFuncType.Param(name: name, type: type))
                 try parser.expect(.rightParen)
             }
@@ -1226,7 +1226,7 @@
             _ = parser.lexer.location()
             _ = try parser.takeId()
             var parameters = [ComponentFuncType.Param]()
-            var resultType: ComponentValueType?
+            var resultType: ComponentDefValType?
             var exportDef: (location: Location, exportName: String)?
             var importDef: (location: Location, importModule: String, importName: String)?
 
@@ -1249,7 +1249,7 @@
                     parameters.append(try self.parseComponentFuncParam(&parser))
 
                 case "result":
-                    resultType = try parseComponentValueType(&parser)
+                    resultType = try parseComponentDefValType(&parser)
 
                 case "export":
                     exportDef = (parser.lexer.location(), try parser.expectString())

--- a/Sources/WAVE/WAVEParser.swift
+++ b/Sources/WAVE/WAVEParser.swift
@@ -26,22 +26,10 @@
         }
 
         /// Parse a value given its expected type
-        public mutating func parse(type: ComponentValueType) throws(WAVEParserError) -> ComponentValue {
+        public mutating func parse(type: ComponentDefValType) throws(WAVEParserError) -> ComponentValue {
             switch type {
-            case .bool:
-                return try parseBool()
-            case .u8, .u16, .u32, .u64:
-                return try parseUnsignedInt(type: type)
-            case .s8, .s16, .s32, .s64:
-                return try parseSignedInt(type: type)
-            case .float32:
-                return try parseFloat32()
-            case .float64:
-                return try parseFloat64()
-            case .char:
-                return try parseChar()
-            case .string:
-                return try parseString()
+            case .inlined(.primitive(let prim)):
+                return try parsePrimitive(prim)
             case .list(_):
                 // For now, we need a type context to resolve the element type
                 // This will be provided by the caller
@@ -67,31 +55,19 @@
 
         /// Parse a value with a type resolver for composite types
         public mutating func parse(
-            type: ComponentValueType,
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            type: ComponentDefValType,
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             switch type {
-            case .bool:
-                return try parseBool()
-            case .u8, .u16, .u32, .u64:
-                return try parseUnsignedInt(type: type)
-            case .s8, .s16, .s32, .s64:
-                return try parseSignedInt(type: type)
-            case .float32:
-                return try parseFloat32()
-            case .float64:
-                return try parseFloat64()
-            case .char:
-                return try parseChar()
-            case .string:
-                return try parseString()
-            case .list(let elementTypeIdx):
-                let elementType = try resolver(elementTypeIdx)
+            case .inlined(.primitive(let prim)):
+                return try parsePrimitive(prim)
+            case .list(let element):
+                let elementType = try element.resolve(resolver)
                 return try parseList(elementType: elementType, resolver: resolver)
-            case .tuple(let typeIndices):
-                var types: [ComponentValueType] = []
-                for idx in typeIndices {
-                    types.append(try resolver(idx))
+            case .tuple(let elements):
+                var types: [ComponentDefValType] = []
+                for elem in elements {
+                    types.append(try elem.resolve(resolver))
                 }
                 return try parseTuple(types: types, resolver: resolver)
             case .record(let fields):
@@ -102,23 +78,39 @@
                 return try parseEnum(cases: cases)
             case .flags(let flagNames):
                 return try parseFlags(flagNames: flagNames)
-            case .option(let innerTypeIdx):
-                let innerType = try resolver(innerTypeIdx)
+            case .option(let inner):
+                let innerType = try inner.resolve(resolver)
                 return try parseOption(innerType: innerType, resolver: resolver)
-            case .result(let okTypeIdx, let errTypeIdx):
-                var okType: ComponentValueType?
-                var errType: ComponentValueType?
-                if let idx = okTypeIdx {
-                    okType = try resolver(idx)
-                }
-                if let idx = errTypeIdx {
-                    errType = try resolver(idx)
-                }
+            case .result(let okTypeRef, let errTypeRef):
+                let okType = try okTypeRef.map { try $0.resolve(resolver) }
+                let errType = try errTypeRef.map { try $0.resolve(resolver) }
                 return try parseResult(okType: okType, errType: errType, resolver: resolver)
-            case .indexed(let idx):
+            case .inlined(.index(let idx)):
                 return try parse(type: try resolver(idx), resolver: resolver)
             default:
                 throw WAVEParserError("unsupported type", span: try lexer.peek().span)
+            }
+        }
+
+        /// Parse a primitive value given its primitive type.
+        private mutating func parsePrimitive(_ prim: ComponentPrimValType) throws(WAVEParserError) -> ComponentValue {
+            switch prim {
+            case .bool:
+                return try parseBool()
+            case .u8, .u16, .u32, .u64:
+                return try parseUnsignedInt(prim)
+            case .s8, .s16, .s32, .s64:
+                return try parseSignedInt(prim)
+            case .float32:
+                return try parseFloat32()
+            case .float64:
+                return try parseFloat64()
+            case .char:
+                return try parseChar()
+            case .string:
+                return try parseString()
+            case .errorContext:
+                throw WAVEParserError("error-context values are not supported in WAVE", span: try lexer.peek().span)
             }
         }
 
@@ -136,7 +128,7 @@
             }
         }
 
-        private mutating func parseUnsignedInt(type: ComponentValueType) throws(WAVEParserError) -> ComponentValue {
+        private mutating func parseUnsignedInt(_ prim: ComponentPrimValType) throws(WAVEParserError) -> ComponentValue {
             let token = try lexer.next()
             guard case .number(let str, let span) = token else {
                 throw WAVEParserError("expected number", span: token.span)
@@ -146,7 +138,7 @@
                 throw WAVEParserError("invalid integer", span: span)
             }
 
-            switch type {
+            switch prim {
             case .u8:
                 guard value <= UInt64(UInt8.max) else {
                     throw WAVEParserError("value out of range for u8", span: span)
@@ -169,7 +161,7 @@
             }
         }
 
-        private mutating func parseSignedInt(type: ComponentValueType) throws(WAVEParserError) -> ComponentValue {
+        private mutating func parseSignedInt(_ prim: ComponentPrimValType) throws(WAVEParserError) -> ComponentValue {
             let token = try lexer.next()
             guard case .number(let str, let span) = token else {
                 throw WAVEParserError("expected number", span: token.span)
@@ -179,7 +171,7 @@
                 throw WAVEParserError("invalid integer", span: span)
             }
 
-            switch type {
+            switch prim {
             case .s8:
                 guard value >= Int64(Int8.min) && value <= Int64(Int8.max) else {
                     throw WAVEParserError("value out of range for s8", span: span)
@@ -259,8 +251,8 @@
         // MARK: - Composite Parsing
 
         private mutating func parseList(
-            elementType: ComponentValueType,
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            elementType: ComponentDefValType,
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             let open = try lexer.next()
             guard case .leftBracket = open else {
@@ -299,8 +291,8 @@
         }
 
         private mutating func parseTuple(
-            types: [ComponentValueType],
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            types: [ComponentDefValType],
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             let open = try lexer.next()
             guard case .leftParen = open else {
@@ -336,7 +328,7 @@
 
         private mutating func parseRecord(
             fields: [ComponentRecordField],
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             let open = try lexer.next()
             guard case .leftBrace = open else {
@@ -353,7 +345,7 @@
                 // All fields must be optional and set to none
                 var result: [(name: String, value: ComponentValue)] = []
                 for field in fields {
-                    let fieldType = try resolver(field.type)
+                    let fieldType = try field.type.resolve(resolver)
                     if case .option = fieldType {
                         result.append((field.name, .option(nil)))
                     } else {
@@ -411,7 +403,7 @@
                     throw WAVEParserError("unknown field '\(fieldName)'", span: labelToken.span)
                 }
 
-                let fieldType = try resolver(fieldDef.type)
+                let fieldType = try fieldDef.type.resolve(resolver)
                 let value = try parse(type: fieldType, resolver: resolver)
                 parsedFields[fieldName] = value
 
@@ -440,7 +432,7 @@
                 if let value = parsedFields[field.name] {
                     result.append((field.name, value))
                 } else {
-                    let fieldType = try resolver(field.type)
+                    let fieldType = try field.type.resolve(resolver)
                     if case .option = fieldType {
                         result.append((field.name, .option(nil)))
                     } else {
@@ -454,7 +446,7 @@
 
         private mutating func parseVariant(
             cases: [ComponentCaseField],
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             let labelToken = try lexer.next()
             let caseName: String
@@ -493,7 +485,7 @@
                     throw WAVEParserError("expected '(' for variant payload", span: open.span)
                 }
 
-                let payloadType = try resolver(payloadTypeIdx)
+                let payloadType = try payloadTypeIdx.resolve(resolver)
                 let payload = try parse(type: payloadType, resolver: resolver)
 
                 let close = try lexer.next()
@@ -582,8 +574,8 @@
         }
 
         private mutating func parseOption(
-            innerType: ComponentValueType,
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            innerType: ComponentDefValType,
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             let token = try lexer.peek()
 
@@ -617,9 +609,9 @@
         }
 
         private mutating func parseResult(
-            okType: ComponentValueType?,
-            errType: ComponentValueType?,
-            resolver: (ComponentTypeIndex) throws -> ComponentValueType
+            okType: ComponentDefValType?,
+            errType: ComponentDefValType?,
+            resolver: (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> ComponentValue {
             let token = try lexer.peek()
 
@@ -775,8 +767,8 @@
         ///   - resolver: A function to resolve type indices to concrete types
         /// - Returns: The parsed argument values
         public mutating func parseArguments(
-            params: [ComponentValueType],
-            resolver: @escaping (ComponentTypeIndex) throws -> ComponentValueType
+            params: [ComponentDefValType],
+            resolver: @escaping (ComponentTypeIndex) throws -> ComponentDefValType
         ) throws -> [ComponentValue] {
             var parsedArgs: [ComponentValue] = []
 

--- a/Sources/WIT/WITTypeConverter.swift
+++ b/Sources/WIT/WITTypeConverter.swift
@@ -4,7 +4,7 @@
     /// Converts WIT type representations to ComponentModel types.
     ///
     /// This converter bridges WIT (WebAssembly Interface Types) definitions
-    /// to the ComponentValueType system used for runtime values.
+    /// to the ComponentDefValType system used for runtime values.
     ///
     /// Example usage:
     /// ```swift
@@ -21,41 +21,41 @@
     /// ```
     public struct WITTypeConverter {
         /// Type table for resolving indexed types
-        public private(set) var typeTable: [ComponentValueType] = []
+        public private(set) var typeTable: [ComponentDefValType] = []
 
         /// Named type definitions
-        public private(set) var namedTypes: [String: ComponentValueType] = [:]
+        public private(set) var namedTypes: [String: ComponentDefValType] = [:]
 
         public init() {}
 
         /// Add a type to the table and return its index
-        public mutating func addType(_ type: ComponentValueType) -> ComponentTypeIndex {
+        public mutating func addType(_ type: ComponentDefValType) -> ComponentTypeIndex {
             let idx = typeTable.count
             typeTable.append(type)
             return ComponentTypeIndex(rawValue: idx)
         }
 
-        /// Convert a WIT type representation to a ComponentValueType
-        public mutating func convert(_ typeRepr: TypeReprSyntax) -> ComponentValueType {
+        /// Convert a WIT type representation to a ComponentDefValType
+        public mutating func convert(_ typeRepr: TypeReprSyntax) -> ComponentDefValType {
             switch typeRepr {
-            case .bool: return .bool
-            case .u8: return .u8
-            case .u16: return .u16
-            case .u32: return .u32
-            case .u64: return .u64
-            case .s8: return .s8
-            case .s16: return .s16
-            case .s32: return .s32
-            case .s64: return .s64
-            case .float32: return .float32
-            case .float64: return .float64
-            case .char: return .char
-            case .string: return .string
+            case .bool: return .primitive(.bool)
+            case .u8: return .primitive(.u8)
+            case .u16: return .primitive(.u16)
+            case .u32: return .primitive(.u32)
+            case .u64: return .primitive(.u64)
+            case .s8: return .primitive(.s8)
+            case .s16: return .primitive(.s16)
+            case .s32: return .primitive(.s32)
+            case .s64: return .primitive(.s64)
+            case .float32: return .primitive(.float32)
+            case .float64: return .primitive(.float64)
+            case .char: return .primitive(.char)
+            case .string: return .primitive(.string)
             case .name(let id):
                 // Handle f32/f64 as aliases for float32/float64 (WIT spec uses f32/f64)
                 switch id.text {
-                case "f32": return .float32
-                case "f64": return .float64
+                case "f32": return .primitive(.float32)
+                case "f64": return .primitive(.float64)
                 default:
                     // Look up named type
                     if let type = namedTypes[id.text] {
@@ -66,11 +66,11 @@
             case .list(let element):
                 let elementType = convert(element)
                 let idx = addType(elementType)
-                return .list(idx)
+                return .list(.index(idx))
             case .option(let inner):
                 let innerType = convert(inner)
                 let idx = addType(innerType)
-                return .option(idx)
+                return .option(.index(idx))
             case .result(let resultSyntax):
                 let okIdx = resultSyntax.ok.map { ok -> ComponentTypeIndex in
                     let okType = convert(ok)
@@ -80,11 +80,11 @@
                     let errType = convert(err)
                     return addType(errType)
                 }
-                return .result(ok: okIdx, error: errIdx)
+                return .result(ok: okIdx.map { .index($0) }, error: errIdx.map { .index($0) })
             case .tuple(let elements):
-                let indices = elements.map { elem -> ComponentTypeIndex in
+                let indices = elements.map { elem -> ComponentValType in
                     let elemType = convert(elem)
-                    return addType(elemType)
+                    return .index(addType(elemType))
                 }
                 return .tuple(indices)
             case .handle, .future, .stream:
@@ -95,14 +95,14 @@
         /// Register a type definition, making it available for lookup by name
         public mutating func registerTypeDef(_ typeDef: TypeDefSyntax) {
             let typeName = typeDef.name.text
-            let componentType: ComponentValueType
+            let componentType: ComponentDefValType
 
             switch typeDef.body {
             case .record(let recordSyntax):
                 let fields = recordSyntax.fields.map { field -> ComponentRecordField in
                     let fieldType = convert(field.type)
                     let fieldIdx = addType(fieldType)
-                    return ComponentRecordField(name: field.name.text, type: fieldIdx)
+                    return ComponentRecordField(name: field.name.text, type: .index(fieldIdx))
                 }
                 componentType = .record(fields)
             case .enum(let enumSyntax):
@@ -113,9 +113,9 @@
                 componentType = .flags(flags)
             case .variant(let variantSyntax):
                 let cases = variantSyntax.cases.map { caseItem -> ComponentCaseField in
-                    let caseType = caseItem.type.map { type -> ComponentTypeIndex in
+                    let caseType = caseItem.type.map { type -> ComponentValType in
                         let converted = convert(type)
-                        return addType(converted)
+                        return .index(addType(converted))
                     }
                     return ComponentCaseField(name: caseItem.name.text, type: caseType)
                 }
@@ -129,8 +129,8 @@
             namedTypes[typeName] = componentType
         }
 
-        /// Resolve a type index to its ComponentValueType
-        public func resolve(_ idx: ComponentTypeIndex) -> ComponentValueType {
+        /// Resolve a type index to its ComponentDefValType
+        public func resolve(_ idx: ComponentTypeIndex) -> ComponentDefValType {
             return typeTable[Int(idx.rawValue)]
         }
     }
@@ -138,7 +138,7 @@
     /// Helper for extracting interface information from parsed WIT
     public struct WITInterfaceExtractor {
         /// Extracted function signatures
-        public private(set) var functions: [String: [(name: String, type: ComponentValueType)]] = [:]
+        public private(set) var functions: [String: [(name: String, type: ComponentDefValType)]] = [:]
 
         /// The type converter used during extraction
         public private(set) var converter: WITTypeConverter
@@ -161,7 +161,7 @@
                 if case .function(let funcNode) = item {
                     let funcSyntax = funcNode.syntax
                     let funcName = funcSyntax.name.text
-                    let params = funcSyntax.function.parameters.map { param -> (String, ComponentValueType) in
+                    let params = funcSyntax.function.parameters.map { param -> (String, ComponentDefValType) in
                         let paramType = converter.convert(param.type)
                         return (param.name.text, paramType)
                     }

--- a/Sources/WasmKit/Component/WAVEInvocation.swift
+++ b/Sources/WasmKit/Component/WAVEInvocation.swift
@@ -126,7 +126,7 @@
         }
 
         // Use the component's type resolver for nested type lookups.
-        let resolver: (ComponentTypeIndex) throws -> ComponentValueType = { idx in
+        let resolver: (ComponentTypeIndex) throws -> ComponentDefValType = { idx in
             try function.resolveType(idx)
         }
 

--- a/Sources/WasmKit/Execution/ComponentModel/ComponentInstance.swift
+++ b/Sources/WasmKit/Execution/ComponentModel/ComponentInstance.swift
@@ -171,7 +171,7 @@
         let instance: InternalComponentInstance
 
         /// Type resolver for nested type lookups during canonical ABI operations
-        let resolveType: (ComponentTypeIndex) throws -> ComponentValueType
+        let resolveType: (ComponentTypeIndex) throws -> ComponentDefValType
     }
 
     /// Type-safe handle to a component function entity.
@@ -196,7 +196,7 @@
 
         /// Resolves a type index to its component value type.
         /// Used for parsing nested types in WAVE arguments.
-        public func resolveType(_ index: ComponentTypeIndex) throws -> ComponentValueType {
+        public func resolveType(_ index: ComponentTypeIndex) throws -> ComponentDefValType {
             try handle.resolveType(index)
         }
 

--- a/Sources/WasmKit/Execution/ComponentModel/ComponentLoader.swift
+++ b/Sources/WasmKit/Execution/ComponentModel/ComponentLoader.swift
@@ -202,7 +202,7 @@
         var nestedComponentDefs: [ParsedComponent] = []
 
         /// Type resolver for canonical ABI operations
-        let resolveType: (ComponentTypeIndex) throws -> ComponentValueType
+        let resolveType: (ComponentTypeIndex) throws -> ComponentDefValType
 
         /// Nested component instances (from component instances index space)
         var nestedComponents: [InternalComponentInstance] = []
@@ -247,9 +247,9 @@
 
         public init() {}
 
-        /// Resolve a ComponentTypeIndex to its ComponentValueType definition.
+        /// Resolve a ComponentTypeIndex to its ComponentDefValType definition.
         /// This is used during canonical ABI lowering/lifting to resolve nested types.
-        public func resolveType(_ index: ComponentTypeIndex) throws -> ComponentValueType {
+        public func resolveType(_ index: ComponentTypeIndex) throws -> ComponentDefValType {
             let idx = Int(index.rawValue)
             guard idx < componentTypes.count else {
                 throw CanonicalABIError(description: "Type index \(idx) out of bounds (have \(componentTypes.count) types)")
@@ -507,7 +507,7 @@
         case function(ComponentFuncType)
 
         /// Import a value
-        case value(ComponentValueType)
+        case value(ComponentDefValType)
 
         /// Import an instance
         case instance

--- a/Sources/WasmKit/Execution/ComponentModel/Lift+Lower.swift
+++ b/Sources/WasmKit/Execution/ComponentModel/Lift+Lower.swift
@@ -9,77 +9,77 @@
         /// Handles both flat primitives and heap-based types (strings).
         static func lift(
             from iterator: inout some IteratorProtocol<Value>,
-            to type: ComponentValueType,
-            resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+            to type: ComponentDefValType,
+            resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
             options: CanonOptions,
             store: Store
         ) throws -> ComponentValue {
             // First, resolve indexed types to their actual type
-            let resolvedType: ComponentValueType
-            if case .indexed(let typeIndex) = type {
-                resolvedType = try resolveType(typeIndex)
+            let resolvedType: ComponentDefValType
+            if case .inlined(.index(let typeIdx)) = type {
+                resolvedType = try resolveType(typeIdx)
             } else {
                 resolvedType = type
             }
 
             switch resolvedType {
             // Flat primitives
-            case .bool:
+            case .inlined(.primitive(.bool)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for bool")
                 }
                 return .bool(v != 0)
-            case .u8:
+            case .inlined(.primitive(.u8)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for u8")
                 }
                 return .u8(UInt8(truncatingIfNeeded: v))
-            case .u16:
+            case .inlined(.primitive(.u16)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for u16")
                 }
                 return .u16(UInt16(truncatingIfNeeded: v))
-            case .u32:
+            case .inlined(.primitive(.u32)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for u32")
                 }
                 return .u32(v)
-            case .u64:
+            case .inlined(.primitive(.u64)):
                 guard case .i64(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i64 for u64")
                 }
                 return .u64(v)
-            case .s8:
+            case .inlined(.primitive(.s8)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for s8")
                 }
                 return .s8(Int8(truncatingIfNeeded: Int32(bitPattern: v)))
-            case .s16:
+            case .inlined(.primitive(.s16)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for s16")
                 }
                 return .s16(Int16(truncatingIfNeeded: Int32(bitPattern: v)))
-            case .s32:
+            case .inlined(.primitive(.s32)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for s32")
                 }
                 return .s32(Int32(bitPattern: v))
-            case .s64:
+            case .inlined(.primitive(.s64)):
                 guard case .i64(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i64 for s64")
                 }
                 return .s64(Int64(bitPattern: v))
-            case .float32:
+            case .inlined(.primitive(.float32)):
                 guard case .f32(let bits) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected f32 for float32")
                 }
                 return .float32(Float(bitPattern: bits))
-            case .float64:
+            case .inlined(.primitive(.float64)):
                 guard case .f64(let bits) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected f64 for float64")
                 }
                 return .float64(Double(bitPattern: bits))
-            case .char:
+            case .inlined(.primitive(.char)):
                 guard case .i32(let v) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 for char")
                 }
@@ -89,7 +89,7 @@
                 return .char(scalar)
 
             // String - requires memory
-            case .string:
+            case .inlined(.primitive(.string)):
                 guard case .i32(let pointer) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 pointer for string")
                 }
@@ -130,21 +130,21 @@
                 return .flags(flagSet)
 
             // Tuple - lift each element recursively
-            case .tuple(let typeIndices):
+            case .tuple(let elementValTypes):
                 var elements: [ComponentValue] = []
-                for typeIndex in typeIndices {
-                    let elementType = try resolveType(typeIndex)
+                for valType in elementValTypes {
+                    let elementType = try valType.resolve(resolveType)
                     let element = try Self.lift(from: &iterator, to: elementType, resolveType: resolveType, options: options, store: store)
                     elements.append(element)
                 }
                 return .tuple(elements)
 
             // Option - lift discriminant and optional payload
-            case .option(let someTypeIndex):
+            case .option(let someValType):
                 guard case .i32(let discriminant) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 discriminant for option")
                 }
-                let someType = try resolveType(someTypeIndex)
+                let someType = try someValType.resolve(resolveType)
                 if discriminant == 0 {
                     // none: consume payload space (zeros)
                     let flatCount = someType.flattenedCount
@@ -162,20 +162,20 @@
             case .record(let fieldDefs):
                 var fields: [(name: String, value: ComponentValue)] = []
                 for fieldDef in fieldDefs {
-                    let fieldType = try resolveType(fieldDef.type)
+                    let fieldType = try fieldDef.type.resolve(resolveType)
                     let value = try Self.lift(from: &iterator, to: fieldType, resolveType: resolveType, options: options, store: store)
                     fields.append((fieldDef.name, value))
                 }
                 return .record(fields)
 
             // Result - lift discriminant and payload
-            case .result(let okTypeIndex, let errorTypeIndex):
+            case .result(let okValType, let errorValType):
                 guard case .i32(let discriminant) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 discriminant for result")
                 }
 
-                let okType = try okTypeIndex.map(resolveType)
-                let errorType = try errorTypeIndex.map(resolveType)
+                let okType = try okValType.map { try $0.resolve(resolveType) }
+                let errorType = try errorValType.map { try $0.resolve(resolveType) }
 
                 // Calculate max payload size
                 let okFlatCount = okType.map { $0.flattenedCount } ?? 0
@@ -232,16 +232,16 @@
                 // Calculate max payload size
                 let maxPayloadCount =
                     try cases.map { variantCase -> Int in
-                        if let typeIndex = variantCase.type {
-                            return try resolveType(typeIndex).flattenedCount
+                        if let valType = variantCase.type {
+                            return try valType.resolve(resolveType).flattenedCount
                         }
                         return 0
                     }.max() ?? 0
 
                 let variantCase = cases[caseIndex]
-                if let typeIndex = variantCase.type {
+                if let valType = variantCase.type {
                     // Case with payload
-                    let caseType = try resolveType(typeIndex)
+                    let caseType = try valType.resolve(resolveType)
                     let value = try Self.lift(from: &iterator, to: caseType, resolveType: resolveType, options: options, store: store)
                     // Consume padding
                     let consumed = caseType.flattenedCount
@@ -258,7 +258,7 @@
                 }
 
             // List - lift pointer and length, then load elements from memory
-            case .list(let elementTypeIndex):
+            case .list(let elementValType):
                 guard case .i32(let pointer) = iterator.next() else {
                     throw CanonicalABIError(description: "Expected i32 pointer for list")
                 }
@@ -268,7 +268,7 @@
                 return try liftList(
                     pointer: pointer,
                     length: length,
-                    elementTypeIndex: elementTypeIndex,
+                    elementValType: elementValType,
                     resolveType: resolveType,
                     options: options,
                     store: store
@@ -282,48 +282,48 @@
         /// Lower a component value to core wasm values.
         /// Handles both flat primitives and heap-based types (strings).
         func lower(
-            to type: ComponentValueType,
-            resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+            to type: ComponentDefValType,
+            resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
             options: CanonOptions,
             store: Store
         ) throws -> [Value] {
             // First, resolve indexed types to their actual type
-            let resolvedType: ComponentValueType
-            if case .indexed(let typeIndex) = type {
-                resolvedType = try resolveType(typeIndex)
+            let resolvedType: ComponentDefValType
+            if case .inlined(.index(let typeIdx)) = type {
+                resolvedType = try resolveType(typeIdx)
             } else {
                 resolvedType = type
             }
 
             switch (self, resolvedType) {
             // Flat primitives - no memory needed
-            case (.bool(let b), .bool):
+            case (.bool(let b), .inlined(.primitive(.bool))):
                 return [.i32(b ? 1 : 0)]
-            case (.u8(let v), .u8):
+            case (.u8(let v), .inlined(.primitive(.u8))):
                 return [.i32(UInt32(v))]
-            case (.u16(let v), .u16):
+            case (.u16(let v), .inlined(.primitive(.u16))):
                 return [.i32(UInt32(v))]
-            case (.u32(let v), .u32):
+            case (.u32(let v), .inlined(.primitive(.u32))):
                 return [.i32(v)]
-            case (.u64(let v), .u64):
+            case (.u64(let v), .inlined(.primitive(.u64))):
                 return [.i64(v)]
-            case (.s8(let v), .s8):
+            case (.s8(let v), .inlined(.primitive(.s8))):
                 return [.i32(UInt32(bitPattern: Int32(v)))]
-            case (.s16(let v), .s16):
+            case (.s16(let v), .inlined(.primitive(.s16))):
                 return [.i32(UInt32(bitPattern: Int32(v)))]
-            case (.s32(let v), .s32):
+            case (.s32(let v), .inlined(.primitive(.s32))):
                 return [.i32(UInt32(bitPattern: v))]
-            case (.s64(let v), .s64):
+            case (.s64(let v), .inlined(.primitive(.s64))):
                 return [.i64(UInt64(bitPattern: v))]
-            case (.float32(let v), .float32):
+            case (.float32(let v), .inlined(.primitive(.float32))):
                 return [.f32(v.bitPattern)]
-            case (.float64(let v), .float64):
+            case (.float64(let v), .inlined(.primitive(.float64))):
                 return [.f64(v.bitPattern)]
-            case (.char(let scalar), .char):
+            case (.char(let scalar), .inlined(.primitive(.char))):
                 return [.i32(scalar.value)]
 
             // String - requires memory and realloc
-            case (.string(let s), .string):
+            case (.string(let s), .inlined(.primitive(.string))):
                 return try lowerString(s, options: options, store: store)
 
             // Enum - lower to discriminant value (u8, u16, or u32 based on case count)
@@ -355,21 +355,21 @@
                 return results
 
             // Tuple - lower each element recursively
-            case (.tuple(let elements), .tuple(let typeIndices)):
-                guard elements.count == typeIndices.count else {
-                    throw CanonicalABIError(description: "Tuple element count mismatch: expected \(typeIndices.count), got \(elements.count)")
+            case (.tuple(let elements), .tuple(let elementValTypes)):
+                guard elements.count == elementValTypes.count else {
+                    throw CanonicalABIError(description: "Tuple element count mismatch: expected \(elementValTypes.count), got \(elements.count)")
                 }
                 var results: [Value] = []
-                for (element, typeIndex) in zip(elements, typeIndices) {
-                    let elementType = try resolveType(typeIndex)
+                for (element, valType) in zip(elements, elementValTypes) {
+                    let elementType = try valType.resolve(resolveType)
                     let lowered = try element.lower(to: elementType, resolveType: resolveType, options: options, store: store)
                     results.append(contentsOf: lowered)
                 }
                 return results
 
             // Option - discriminant (0=none, 1=some) + optional payload
-            case (.option(let maybeValue), .option(let someTypeIndex)):
-                let someType = try resolveType(someTypeIndex)
+            case (.option(let maybeValue), .option(let someValType)):
+                let someType = try someValType.resolve(resolveType)
                 if let value = maybeValue {
                     // some: discriminant=1, followed by flattened value
                     var results: [Value] = [.i32(1)]
@@ -391,16 +391,16 @@
                     guard let fieldValue = fields.first(where: { $0.name == fieldDef.name })?.value else {
                         throw CanonicalABIError(description: "Missing record field: \(fieldDef.name)")
                     }
-                    let fieldType = try resolveType(fieldDef.type)
+                    let fieldType = try fieldDef.type.resolve(resolveType)
                     let lowered = try fieldValue.lower(to: fieldType, resolveType: resolveType, options: options, store: store)
                     results.append(contentsOf: lowered)
                 }
                 return results
 
             // Result - discriminant (0=ok, 1=err) + payload with variant flattening
-            case (.result(let ok, let error), .result(let okTypeIndex, let errorTypeIndex)):
-                let okType = try okTypeIndex.map(resolveType)
-                let errorType = try errorTypeIndex.map(resolveType)
+            case (.result(let ok, let error), .result(let okValType, let errorValType)):
+                let okType = try okValType.map { try $0.resolve(resolveType) }
+                let errorType = try errorValType.map { try $0.resolve(resolveType) }
 
                 // Calculate max payload size for variant union
                 let okFlatCount = okType.map { $0.flattenedCount } ?? 0
@@ -446,17 +446,17 @@
                 // Calculate max payload size across all cases
                 let maxPayloadCount =
                     try cases.map { variantCase -> Int in
-                        if let typeIndex = variantCase.type {
-                            return try resolveType(typeIndex).flattenedCount
+                        if let valType = variantCase.type {
+                            return try valType.resolve(resolveType).flattenedCount
                         }
                         return 0
                     }.max() ?? 0
 
                 var lowered: [Value] = [.i32(UInt32(caseIndex))]
 
-                if let typeIndex = cases[caseIndex].type, let payloadValue = payload {
+                if let valType = cases[caseIndex].type, let payloadValue = payload {
                     // Case with payload
-                    let caseType = try resolveType(typeIndex)
+                    let caseType = try valType.resolve(resolveType)
                     let caseLowered = try payloadValue.lower(to: caseType, resolveType: resolveType, options: options, store: store)
                     lowered.append(contentsOf: caseLowered)
                     // Pad to max payload size
@@ -469,8 +469,8 @@
                 return lowered
 
             // List - allocate memory and write elements (requires memory + realloc)
-            case (.list(let elements), .list(let elementTypeIndex)):
-                return try lowerList(elements, elementTypeIndex: elementTypeIndex, resolveType: resolveType, options: options, store: store)
+            case (.list(let elements), .list(let elementValType)):
+                return try lowerList(elements, elementValType: elementValType, resolveType: resolveType, options: options, store: store)
 
             default:
                 throw CanonicalABIError(
@@ -593,8 +593,8 @@
     /// Allocates memory using realloc and writes elements.
     private func lowerList(
         _ elements: [ComponentValue],
-        elementTypeIndex: ComponentTypeIndex,
-        resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+        elementValType: ComponentValType,
+        resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
         options: CanonOptions,
         store: Store
     ) throws -> [Value] {
@@ -605,7 +605,7 @@
             throw CanonicalABIError(description: "List lowering requires realloc option")
         }
 
-        let elementType = try resolveType(elementTypeIndex)
+        let elementType = try elementValType.resolve(resolveType)
         let elementCount = UInt32(elements.count)
 
         // Calculate element size in bytes based on type
@@ -644,34 +644,40 @@
 
     /// Calculate the byte size of a component value type.
     private func sizeOf(
-        _ type: ComponentValueType,
-        resolveType: (ComponentTypeIndex) throws -> ComponentValueType
+        _ type: ComponentDefValType,
+        resolveType: (ComponentTypeIndex) throws -> ComponentDefValType
     ) throws -> Int {
         switch type {
-        case .bool, .s8, .u8: return 1
-        case .s16, .u16: return 2
-        case .s32, .u32, .float32, .char: return 4
-        case .s64, .u64, .float64: return 8
-        case .string, .list: return 8  // pointer + length
-        case .tuple(let typeIndices):
-            return try typeIndices.reduce(0) { sum, typeIndex in
-                try sum + sizeOf(try resolveType(typeIndex), resolveType: resolveType)
+        case .inlined(.primitive(let prim)):
+            switch prim {
+            case .bool, .s8, .u8: return 1
+            case .s16, .u16: return 2
+            case .s32, .u32, .float32, .char: return 4
+            case .s64, .u64, .float64: return 8
+            case .string: return 8  // pointer + length
+            case .errorContext:
+                throw CanonicalABIError(description: "sizeOf for \(type) not yet implemented")
+            }
+        case .list: return 8  // pointer + length
+        case .tuple(let elementValTypes):
+            return try elementValTypes.reduce(0) { sum, valType in
+                try sum + sizeOf(valType.resolve(resolveType), resolveType: resolveType)
             }
         case .record(let fields):
             return try fields.reduce(0) { sum, field in
-                try sum + sizeOf(try resolveType(field.type), resolveType: resolveType)
+                try sum + sizeOf(field.type.resolve(resolveType), resolveType: resolveType)
             }
-        case .option(let someTypeIndex):
-            return try 4 + sizeOf(try resolveType(someTypeIndex), resolveType: resolveType)  // discriminant + payload
-        case .result(let okTypeIndex, let errorTypeIndex):
-            let okSize = try okTypeIndex.map { try sizeOf(resolveType($0), resolveType: resolveType) } ?? 0
-            let errSize = try errorTypeIndex.map { try sizeOf(resolveType($0), resolveType: resolveType) } ?? 0
+        case .option(let someValType):
+            return try 4 + sizeOf(someValType.resolve(resolveType), resolveType: resolveType)  // discriminant + payload
+        case .result(let okValType, let errorValType):
+            let okSize = try okValType.map { try sizeOf($0.resolve(resolveType), resolveType: resolveType) } ?? 0
+            let errSize = try errorValType.map { try sizeOf($0.resolve(resolveType), resolveType: resolveType) } ?? 0
             return 4 + max(okSize, errSize)  // discriminant + max payload
         case .variant(let cases):
             let maxPayloadSize =
                 try cases.map { variantCase -> Int in
-                    if let typeIndex = variantCase.type {
-                        return try sizeOf(try resolveType(typeIndex), resolveType: resolveType)
+                    if let valType = variantCase.type {
+                        return try sizeOf(valType.resolve(resolveType), resolveType: resolveType)
                     }
                     return 0
                 }.max() ?? 0
@@ -689,41 +695,48 @@
         case .enum: return 4  // u32 discriminant
         case .flags(let flagNames):
             return numberOfFlagsInt32(flagsCount: flagNames.count) * 4
-        case .errorContext, .future, .stream, .resource, .indexed:
+        case .future, .stream, .resource, .inlined(.index):
             throw CanonicalABIError(description: "sizeOf for \(type) not yet implemented")
         }
     }
 
     /// Calculate the alignment requirement of a component value type.
     private func alignmentOf(
-        _ type: ComponentValueType,
-        resolveType: (ComponentTypeIndex) throws -> ComponentValueType
+        _ type: ComponentDefValType,
+        resolveType: (ComponentTypeIndex) throws -> ComponentDefValType
     ) throws -> Int {
         switch type {
-        case .bool, .s8, .u8: return 1
-        case .s16, .u16: return 2
-        case .s32, .u32, .float32, .char, .enum: return 4
-        case .s64, .u64, .float64: return 8
-        case .string, .list: return 4  // pointer/length use i32 alignment
-        case .tuple(let typeIndices):
-            return try typeIndices.map { try alignmentOf(resolveType($0), resolveType: resolveType) }.max() ?? 1
+        case .inlined(.primitive(let prim)):
+            switch prim {
+            case .bool, .s8, .u8: return 1
+            case .s16, .u16: return 2
+            case .s32, .u32, .float32, .char: return 4
+            case .s64, .u64, .float64: return 8
+            case .string: return 4  // pointer/length use i32 alignment
+            case .errorContext:
+                throw CanonicalABIError(description: "alignmentOf for \(type) not yet implemented")
+            }
+        case .enum: return 4
+        case .list: return 4  // pointer/length use i32 alignment
+        case .tuple(let elementValTypes):
+            return try elementValTypes.map { try alignmentOf($0.resolve(resolveType), resolveType: resolveType) }.max() ?? 1
         case .record(let fields):
-            return try fields.map { try alignmentOf(resolveType($0.type), resolveType: resolveType) }.max() ?? 1
-        case .option(let someTypeIndex):
-            return max(4, try alignmentOf(resolveType(someTypeIndex), resolveType: resolveType))
-        case .result(let okTypeIndex, let errorTypeIndex):
-            let okAlign = try okTypeIndex.map { try alignmentOf(resolveType($0), resolveType: resolveType) } ?? 1
-            let errAlign = try errorTypeIndex.map { try alignmentOf(resolveType($0), resolveType: resolveType) } ?? 1
+            return try fields.map { try alignmentOf($0.type.resolve(resolveType), resolveType: resolveType) }.max() ?? 1
+        case .option(let someValType):
+            return max(4, try alignmentOf(someValType.resolve(resolveType), resolveType: resolveType))
+        case .result(let okValType, let errorValType):
+            let okAlign = try okValType.map { try alignmentOf($0.resolve(resolveType), resolveType: resolveType) } ?? 1
+            let errAlign = try errorValType.map { try alignmentOf($0.resolve(resolveType), resolveType: resolveType) } ?? 1
             return max(4, max(okAlign, errAlign))
         case .variant(let cases):
             let maxPayloadAlign =
                 try cases.compactMap { variantCase -> Int? in
-                    guard let typeIndex = variantCase.type else { return nil }
-                    return try alignmentOf(try resolveType(typeIndex), resolveType: resolveType)
+                    guard let valType = variantCase.type else { return nil }
+                    return try alignmentOf(valType.resolve(resolveType), resolveType: resolveType)
                 }.max() ?? 1
             return max(4, maxPayloadAlign)
         case .flags: return 4  // i32 chunks
-        case .errorContext, .future, .stream, .resource, .indexed:
+        case .future, .stream, .resource, .inlined(.index):
             throw CanonicalABIError(description: "alignmentOf for \(type) not yet implemented")
         }
     }
@@ -731,71 +744,71 @@
     /// Store a component value to memory at a given offset.
     private func storeValue(
         _ value: ComponentValue,
-        type: ComponentValueType,
+        type: ComponentDefValType,
         at offset: Int,
         memory: Memory,
-        resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+        resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
         options: CanonOptions,
         store: Store
     ) throws {
         // First, resolve indexed types to their actual type
-        let resolvedType: ComponentValueType
-        if case .indexed(let typeIndex) = type {
-            resolvedType = try resolveType(typeIndex)
+        let resolvedType: ComponentDefValType
+        if case .inlined(.index(let typeIdx)) = type {
+            resolvedType = try resolveType(typeIdx)
         } else {
             resolvedType = type
         }
 
         switch (value, resolvedType) {
-        case (.bool(let b), .bool):
+        case (.bool(let b), .inlined(.primitive(.bool))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 1) { buffer in
                 buffer.storeBytes(of: UInt8(b ? 1 : 0), as: UInt8.self)
             }
-        case (.u8(let v), .u8):
+        case (.u8(let v), .inlined(.primitive(.u8))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 1) { buffer in
                 buffer.storeBytes(of: v, as: UInt8.self)
             }
-        case (.u16(let v), .u16):
+        case (.u16(let v), .inlined(.primitive(.u16))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 2) { buffer in
                 buffer.storeBytes(of: v, as: UInt16.self)
             }
-        case (.u32(let v), .u32):
+        case (.u32(let v), .inlined(.primitive(.u32))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.storeBytes(of: v, as: UInt32.self)
             }
-        case (.u64(let v), .u64):
+        case (.u64(let v), .inlined(.primitive(.u64))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 8) { buffer in
                 buffer.storeBytes(of: v, as: UInt64.self)
             }
-        case (.s8(let v), .s8):
+        case (.s8(let v), .inlined(.primitive(.s8))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 1) { buffer in
                 buffer.storeBytes(of: v, as: Int8.self)
             }
-        case (.s16(let v), .s16):
+        case (.s16(let v), .inlined(.primitive(.s16))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 2) { buffer in
                 buffer.storeBytes(of: v, as: Int16.self)
             }
-        case (.s32(let v), .s32):
+        case (.s32(let v), .inlined(.primitive(.s32))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.storeBytes(of: v, as: Int32.self)
             }
-        case (.s64(let v), .s64):
+        case (.s64(let v), .inlined(.primitive(.s64))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 8) { buffer in
                 buffer.storeBytes(of: v, as: Int64.self)
             }
-        case (.float32(let v), .float32):
+        case (.float32(let v), .inlined(.primitive(.float32))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.storeBytes(of: v.bitPattern, as: UInt32.self)
             }
-        case (.float64(let v), .float64):
+        case (.float64(let v), .inlined(.primitive(.float64))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 8) { buffer in
                 buffer.storeBytes(of: v.bitPattern, as: UInt64.self)
             }
-        case (.char(let scalar), .char):
+        case (.char(let scalar), .inlined(.primitive(.char))):
             memory.withUnsafeMutableBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.storeBytes(of: scalar.value, as: UInt32.self)
             }
-        case (.string(let s), .string):
+        case (.string(let s), .inlined(.primitive(.string))):
             // For strings in lists, we need to lower the string (allocate + write) and store the pointer/length
             let lowered = try lowerString(s, options: options, store: store)
             guard case .i32(let ptr) = lowered[0], case .i32(let len) = lowered[1] else {
@@ -838,8 +851,8 @@
             }
 
             // Write payload if present
-            if let typeIndex = cases[caseIndex].type, let payloadValue = payload {
-                let caseType = try resolveType(typeIndex)
+            if let valType = cases[caseIndex].type, let payloadValue = payload {
+                let caseType = try valType.resolve(resolveType)
                 let payloadOffset = offset + max(4, try alignmentOf(caseType, resolveType: resolveType))
                 try storeValue(
                     payloadValue,
@@ -994,8 +1007,8 @@
     private func liftList(
         pointer: UInt32,
         length: UInt32,
-        elementTypeIndex: ComponentTypeIndex,
-        resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+        elementValType: ComponentValType,
+        resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
         options: CanonOptions,
         store: Store
     ) throws -> ComponentValue {
@@ -1003,7 +1016,7 @@
             throw CanonicalABIError(description: "List lifting requires memory option")
         }
 
-        let elementType = try resolveType(elementTypeIndex)
+        let elementType = try elementValType.resolve(resolveType)
         let elementSize = try sizeOf(elementType, resolveType: resolveType)
         let memoryInstance = Memory(handle: memory, allocator: store.allocator)
         let memorySize = memoryInstance.byteCount
@@ -1037,10 +1050,10 @@
     /// Load a component value from memory at a given offset.
     /// Used for loading list elements from memory.
     private func loadValue(
-        type: ComponentValueType,
+        type: ComponentDefValType,
         at offset: Int,
         memory: Memory,
-        resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+        resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
         options: CanonOptions,
         store: Store
     ) throws -> ComponentValue {
@@ -1055,73 +1068,73 @@
 
         switch type {
         // Primitives
-        case .bool:
+        case .inlined(.primitive(.bool)):
             try checkBounds(count: 1)
             let v: UInt8 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 1) { buffer in
                 buffer.load(as: UInt8.self)
             }
             return .bool(v != 0)
-        case .u8:
+        case .inlined(.primitive(.u8)):
             try checkBounds(count: 1)
             let v: UInt8 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 1) { buffer in
                 buffer.load(as: UInt8.self)
             }
             return .u8(v)
-        case .u16:
+        case .inlined(.primitive(.u16)):
             try checkBounds(count: 2)
             let v: UInt16 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 2) { buffer in
                 buffer.load(as: UInt16.self)
             }
             return .u16(v)
-        case .u32:
+        case .inlined(.primitive(.u32)):
             try checkBounds(count: 4)
             let v: UInt32 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.load(as: UInt32.self)
             }
             return .u32(v)
-        case .u64:
+        case .inlined(.primitive(.u64)):
             try checkBounds(count: 8)
             let v: UInt64 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                 buffer.load(as: UInt64.self)
             }
             return .u64(v)
-        case .s8:
+        case .inlined(.primitive(.s8)):
             try checkBounds(count: 1)
             let v: Int8 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 1) { buffer in
                 buffer.load(as: Int8.self)
             }
             return .s8(v)
-        case .s16:
+        case .inlined(.primitive(.s16)):
             try checkBounds(count: 2)
             let v: Int16 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 2) { buffer in
                 buffer.load(as: Int16.self)
             }
             return .s16(v)
-        case .s32:
+        case .inlined(.primitive(.s32)):
             try checkBounds(count: 4)
             let v: Int32 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.load(as: Int32.self)
             }
             return .s32(v)
-        case .s64:
+        case .inlined(.primitive(.s64)):
             try checkBounds(count: 8)
             let v: Int64 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                 buffer.load(as: Int64.self)
             }
             return .s64(v)
-        case .float32:
+        case .inlined(.primitive(.float32)):
             try checkBounds(count: 4)
             let bits: UInt32 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.load(as: UInt32.self)
             }
             return .float32(Float(bitPattern: bits))
-        case .float64:
+        case .inlined(.primitive(.float64)):
             try checkBounds(count: 8)
             let bits: UInt64 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                 buffer.load(as: UInt64.self)
             }
             return .float64(Double(bitPattern: bits))
-        case .char:
+        case .inlined(.primitive(.char)):
             try checkBounds(count: 4)
             let v: UInt32 = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                 buffer.load(as: UInt32.self)
@@ -1130,7 +1143,7 @@
                 throw CanonicalABIError(description: "invalid `char` bit pattern: \(v)")
             }
             return .char(scalar)
-        case .string:
+        case .inlined(.primitive(.string)):
             // String is stored as (pointer, length) pair
             try checkBounds(count: 8)
             let (ptr, len): (UInt32, UInt32) = memory.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
@@ -1144,12 +1157,12 @@
         }
     }
 
-    extension ComponentValueType {
+    extension ComponentDefValType {
         /// Lift a component value from memory at a given offset.
         /// Used for indirect results when flattened count > MAX_FLAT_RESULTS.
         func liftValueFromMemory(
             at offset: UInt32,
-            resolveType: (ComponentTypeIndex) throws -> ComponentValueType,
+            resolveType: (ComponentTypeIndex) throws -> ComponentDefValType,
             options: CanonOptions,
             store: Store
         ) throws -> ComponentValue {
@@ -1169,73 +1182,73 @@
 
             switch self {
             // Primitives (single values stored in memory)
-            case .bool:
+            case .inlined(.primitive(.bool)):
                 try checkBounds(offset: UInt(offset), count: 1)
                 let v: UInt8 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 1) { buffer in
                     buffer.load(as: UInt8.self)
                 }
                 return .bool(v != 0)
-            case .u8:
+            case .inlined(.primitive(.u8)):
                 try checkBounds(offset: UInt(offset), count: 1)
                 let v: UInt8 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 1) { buffer in
                     buffer.load(as: UInt8.self)
                 }
                 return .u8(v)
-            case .s8:
+            case .inlined(.primitive(.s8)):
                 try checkBounds(offset: UInt(offset), count: 1)
                 let v: Int8 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 1) { buffer in
                     buffer.load(as: Int8.self)
                 }
                 return .s8(v)
-            case .u16:
+            case .inlined(.primitive(.u16)):
                 try checkBounds(offset: UInt(offset), count: 2)
                 let v: UInt16 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 2) { buffer in
                     buffer.load(as: UInt16.self)
                 }
                 return .u16(v)
-            case .s16:
+            case .inlined(.primitive(.s16)):
                 try checkBounds(offset: UInt(offset), count: 2)
                 let v: Int16 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 2) { buffer in
                     buffer.load(as: Int16.self)
                 }
                 return .s16(v)
-            case .u32:
+            case .inlined(.primitive(.u32)):
                 try checkBounds(offset: UInt(offset), count: 4)
                 let v: UInt32 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                     buffer.load(as: UInt32.self)
                 }
                 return .u32(v)
-            case .s32:
+            case .inlined(.primitive(.s32)):
                 try checkBounds(offset: UInt(offset), count: 4)
                 let v: Int32 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                     buffer.load(as: Int32.self)
                 }
                 return .s32(v)
-            case .u64:
+            case .inlined(.primitive(.u64)):
                 try checkBounds(offset: UInt(offset), count: 8)
                 let v: UInt64 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                     buffer.load(as: UInt64.self)
                 }
                 return .u64(v)
-            case .s64:
+            case .inlined(.primitive(.s64)):
                 try checkBounds(offset: UInt(offset), count: 8)
                 let v: Int64 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                     buffer.load(as: Int64.self)
                 }
                 return .s64(v)
-            case .float32:
+            case .inlined(.primitive(.float32)):
                 try checkBounds(offset: UInt(offset), count: 4)
                 let bits: UInt32 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                     buffer.load(as: UInt32.self)
                 }
                 return .float32(Float(bitPattern: bits))
-            case .float64:
+            case .inlined(.primitive(.float64)):
                 try checkBounds(offset: UInt(offset), count: 8)
                 let bits: UInt64 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                     buffer.load(as: UInt64.self)
                 }
                 return .float64(Double(bitPattern: bits))
-            case .char:
+            case .inlined(.primitive(.char)):
                 try checkBounds(offset: UInt(offset), count: 4)
                 let v: UInt32 = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 4) { buffer in
                     buffer.load(as: UInt32.self)
@@ -1246,7 +1259,7 @@
                 return .char(scalar)
 
             // String: (ptr, len) pair at the offset
-            case .string:
+            case .inlined(.primitive(.string)):
                 try checkBounds(offset: UInt(offset), count: 8)
                 let (ptr, len): (UInt32, UInt32) = memoryInstance.withUnsafeBufferPointer(offset: UInt(offset), count: 8) { buffer in
                     let ptr = buffer.load(fromByteOffset: 0, as: UInt32.self)
@@ -1263,40 +1276,40 @@
 
     /// Lower a component value to core wasm values (flat encoding only).
     /// This handles primitive types that map directly to core wasm types.
-    func lowerFlat(_ value: ComponentValue, paramType: ComponentValueType) throws -> [Value] {
+    func lowerFlat(_ value: ComponentValue, paramType: ComponentDefValType) throws -> [Value] {
         switch (value, paramType) {
         // Boolean -> i32
-        case (.bool(let b), .bool):
+        case (.bool(let b), .inlined(.primitive(.bool))):
             return [.i32(b ? 1 : 0)]
 
         // Unsigned integers
-        case (.u8(let v), .u8):
+        case (.u8(let v), .inlined(.primitive(.u8))):
             return [.i32(UInt32(v))]
-        case (.u16(let v), .u16):
+        case (.u16(let v), .inlined(.primitive(.u16))):
             return [.i32(UInt32(v))]
-        case (.u32(let v), .u32):
+        case (.u32(let v), .inlined(.primitive(.u32))):
             return [.i32(v)]
-        case (.u64(let v), .u64):
+        case (.u64(let v), .inlined(.primitive(.u64))):
             return [.i64(v)]
 
         // Signed integers
-        case (.s8(let v), .s8):
+        case (.s8(let v), .inlined(.primitive(.s8))):
             return [.i32(UInt32(bitPattern: Int32(v)))]
-        case (.s16(let v), .s16):
+        case (.s16(let v), .inlined(.primitive(.s16))):
             return [.i32(UInt32(bitPattern: Int32(v)))]
-        case (.s32(let v), .s32):
+        case (.s32(let v), .inlined(.primitive(.s32))):
             return [.i32(UInt32(bitPattern: v))]
-        case (.s64(let v), .s64):
+        case (.s64(let v), .inlined(.primitive(.s64))):
             return [.i64(UInt64(bitPattern: v))]
 
         // Floating point
-        case (.float32(let v), .float32):
+        case (.float32(let v), .inlined(.primitive(.float32))):
             return [.f32(v.bitPattern)]
-        case (.float64(let v), .float64):
+        case (.float64(let v), .inlined(.primitive(.float64))):
             return [.f64(v.bitPattern)]
 
         // Character (Unicode scalar value as i32)
-        case (.char(let scalar), .char):
+        case (.char(let scalar), .inlined(.primitive(.char))):
             return [.i32(scalar.value)]
 
         default:
@@ -1308,7 +1321,7 @@
 
     /// Lift core wasm values to a component value (flat encoding only).
     /// This handles primitive types that map directly from core wasm types.
-    func liftFlat(_ values: [Value], to resultType: ComponentValueType) throws -> [ComponentValue] {
+    func liftFlat(_ values: [Value], to resultType: ComponentDefValType) throws -> [ComponentValue] {
         guard !values.isEmpty else {
             throw CanonicalABIError(description: "No values to lift - expected at least 1")
         }
@@ -1317,37 +1330,37 @@
 
         switch (value, resultType) {
         // i32 -> Boolean (any non-zero is true)
-        case (.i32(let v), .bool):
+        case (.i32(let v), .inlined(.primitive(.bool))):
             return [.bool(v != 0)]
 
         // i32 -> Unsigned integers (with truncation/masking)
-        case (.i32(let v), .u8):
+        case (.i32(let v), .inlined(.primitive(.u8))):
             return [.u8(UInt8(truncatingIfNeeded: v))]
-        case (.i32(let v), .u16):
+        case (.i32(let v), .inlined(.primitive(.u16))):
             return [.u16(UInt16(truncatingIfNeeded: v))]
-        case (.i32(let v), .u32):
+        case (.i32(let v), .inlined(.primitive(.u32))):
             return [.u32(v)]
-        case (.i64(let v), .u64):
+        case (.i64(let v), .inlined(.primitive(.u64))):
             return [.u64(v)]
 
         // i32 -> Signed integers (with sign extension)
-        case (.i32(let v), .s8):
+        case (.i32(let v), .inlined(.primitive(.s8))):
             return [.s8(Int8(truncatingIfNeeded: Int32(bitPattern: v)))]
-        case (.i32(let v), .s16):
+        case (.i32(let v), .inlined(.primitive(.s16))):
             return [.s16(Int16(truncatingIfNeeded: Int32(bitPattern: v)))]
-        case (.i32(let v), .s32):
+        case (.i32(let v), .inlined(.primitive(.s32))):
             return [.s32(Int32(bitPattern: v))]
-        case (.i64(let v), .s64):
+        case (.i64(let v), .inlined(.primitive(.s64))):
             return [.s64(Int64(bitPattern: v))]
 
         // Floating point
-        case (.f32(let bits), .float32):
+        case (.f32(let bits), .inlined(.primitive(.float32))):
             return [.float32(Float(bitPattern: bits))]
-        case (.f64(let bits), .float64):
+        case (.f64(let bits), .inlined(.primitive(.float64))):
             return [.float64(Double(bitPattern: bits))]
 
         // i32 -> Character
-        case (.i32(let v), .char):
+        case (.i32(let v), .inlined(.primitive(.char))):
             guard let scalar = Unicode.Scalar(v) else {
                 throw CanonicalABIError(
                     description: "invalid `char` bit pattern: \(v)"
@@ -1372,45 +1385,47 @@
     func flattenComponentFuncType(_ funcType: ComponentFuncType) -> FunctionType {
         var coreParams: [ValueType] = []
         for param in funcType.params {
-            let coreTypes = param.type.flattenedComponentValueType
+            let coreTypes = param.type.flattenedComponentDefValType
             coreParams.append(contentsOf: coreTypes)
         }
 
         var coreResults: [ValueType] = []
         if let resultType = funcType.result {
-            let flatResults = resultType.flattenedComponentValueType
+            let flatResults = resultType.flattenedComponentDefValType
             coreResults.append(contentsOf: flatResults)
         }
 
         return FunctionType(parameters: coreParams, results: coreResults)
     }
 
-    extension ComponentValueType {
+    extension ComponentDefValType {
         /// Returns the number of flat core values for a component value type.
         var flattenedCount: Int {
-            return self.flattenedComponentValueType.count
+            return self.flattenedComponentDefValType.count
         }
 
         /// Flatten a component value type to core wasm value types.
         /// For primitive types, this returns a single core type.
-        var flattenedComponentValueType: [ValueType] {
+        var flattenedComponentDefValType: [ValueType] {
             switch self {
-            case .bool, .s8, .u8, .s16, .u16, .s32, .u32:
+            case .inlined(.primitive(.bool)), .inlined(.primitive(.s8)), .inlined(.primitive(.u8)),
+                .inlined(.primitive(.s16)), .inlined(.primitive(.u16)), .inlined(.primitive(.s32)),
+                .inlined(.primitive(.u32)):
                 return [.i32]
-            case .s64, .u64:
+            case .inlined(.primitive(.s64)), .inlined(.primitive(.u64)):
                 return [.i64]
-            case .float32:
+            case .inlined(.primitive(.float32)):
                 return [.f32]
-            case .float64:
+            case .inlined(.primitive(.float64)):
                 return [.f64]
-            case .char:
+            case .inlined(.primitive(.char)):
                 return [.i32]  // Unicode scalar as i32
-            case .string:
+            case .inlined(.primitive(.string)):
                 return [.i32, .i32]  // (pointer, length)
             default:
                 // For complex types, we'll need heap-based ABI
                 // For now, return empty to avoid crashes - these will fail at runtime
-                #warning("Complex types not supported in `flattenComponentValueType`")
+                #warning("Complex types not supported in `flattenedComponentDefValType`")
                 return []
             }
         }

--- a/Sources/WasmParser/ComponentParser.swift
+++ b/Sources/WasmParser/ComponentParser.swift
@@ -124,7 +124,7 @@
     /// A component type definition (from binary section 7).
     public enum ComponentTypeDef {
         /// A defined value type
-        case definedValue(ComponentValueType)
+        case definedValue(ComponentDefValType)
         /// A function type
         case function(ComponentFuncType)
         /// A component type
@@ -264,7 +264,7 @@
         }
 
         /// Parse a value type (primitive or type index).
-        func parseValType() throws(WasmParserError) -> ComponentValueType {
+        func parseValType() throws(WasmParserError) -> ComponentDefValType {
             let byte = try stream.peek() ?? 0
             // Check if it's a type index (non-negative SLEB128)
             if byte < 0x64 {
@@ -277,18 +277,18 @@
         }
 
         /// Parse an optional value type.
-        func parseOptionalValType() throws(WasmParserError) -> ComponentTypeIndex? {
+        func parseOptionalValType() throws(WasmParserError) -> ComponentValType? {
             let present = try stream.consumeAny()
             if present == 0x00 {
                 return nil
             } else {
                 let idx: UInt32 = try parseUnsigned()
-                return ComponentTypeIndex(rawValue: Int(idx))
+                return .index(ComponentTypeIndex(rawValue: Int(idx)))
             }
         }
 
         /// Parse a defined value type.
-        func parseDefValType() throws(WasmParserError) -> ComponentValueType {
+        func parseDefValType() throws(WasmParserError) -> ComponentDefValType {
             let byte = try stream.peek() ?? 0
 
             // Check for type index first
@@ -312,7 +312,7 @@
                 let fields = try parseVector { () throws(WasmParserError) -> ComponentRecordField in
                     let name = try stream.parseName()
                     let typeIdx: UInt32 = try parseUnsigned()
-                    return ComponentRecordField(name: name, type: ComponentTypeIndex(rawValue: Int(typeIdx)))
+                    return ComponentRecordField(name: name, type: .index(ComponentTypeIndex(rawValue: Int(typeIdx))))
                 }
                 return .record(fields)
 
@@ -327,11 +327,11 @@
 
             case .list:
                 let elemIdx: UInt32 = try parseUnsigned()
-                return .list(ComponentTypeIndex(rawValue: Int(elemIdx)))
+                return .list(.index(ComponentTypeIndex(rawValue: Int(elemIdx))))
 
             case .tuple:
                 let typeIndices: [UInt32] = try parseVector { () throws(WasmParserError) -> UInt32 in try parseUnsigned() }
-                return .tuple(typeIndices.map { ComponentTypeIndex(rawValue: Int($0)) })
+                return .tuple(typeIndices.map { .index(ComponentTypeIndex(rawValue: Int($0))) })
 
             case .flags:
                 let labels = try parseVector { () throws(WasmParserError) -> String in try stream.parseName() }
@@ -343,7 +343,7 @@
 
             case .option:
                 let someIdx: UInt32 = try parseUnsigned()
-                return .option(ComponentTypeIndex(rawValue: Int(someIdx)))
+                return .option(.index(ComponentTypeIndex(rawValue: Int(someIdx))))
 
             case .result:
                 let okIdx = try parseOptionalValType()
@@ -364,26 +364,26 @@
         }
 
         /// Parse a primitive value type from an already-consumed opcode.
-        func parsePrimValTypeFromOpcode(_ opcode: UInt8) throws(WasmParserError) -> ComponentValueType {
+        func parsePrimValTypeFromOpcode(_ opcode: UInt8) throws(WasmParserError) -> ComponentDefValType {
             guard let type = PrimitiveValTypeOpcode(rawValue: opcode) else {
                 throw makeError(.malformedValueType(opcode))
             }
 
             switch type {
-            case .bool: return .bool
-            case .s8: return .s8
-            case .u8: return .u8
-            case .s16: return .s16
-            case .u16: return .u16
-            case .s32: return .s32
-            case .u32: return .u32
-            case .s64: return .s64
-            case .u64: return .u64
-            case .float32: return .float32
-            case .float64: return .float64
-            case .char: return .char
-            case .string: return .string
-            case .errorContext: return .errorContext
+            case .bool: return .primitive(.bool)
+            case .s8: return .primitive(.s8)
+            case .u8: return .primitive(.u8)
+            case .s16: return .primitive(.s16)
+            case .u16: return .primitive(.u16)
+            case .s32: return .primitive(.s32)
+            case .u32: return .primitive(.u32)
+            case .s64: return .primitive(.s64)
+            case .u64: return .primitive(.u64)
+            case .float32: return .primitive(.float32)
+            case .float64: return .primitive(.float64)
+            case .char: return .primitive(.char)
+            case .string: return .primitive(.string)
+            case .errorContext: return .primitive(.errorContext)
             }
         }
 
@@ -602,7 +602,7 @@
                     return ComponentFuncType.Param(name: name, type: valType)
                 }
                 let resultKind = try stream.consumeAny()
-                let result: ComponentValueType?
+                let result: ComponentDefValType?
                 if resultKind == 0x00 {
                     result = try parseValType()
                 } else {

--- a/Tests/ComponentLinkerTests/ComponentTypeSerializerTests.swift
+++ b/Tests/ComponentLinkerTests/ComponentTypeSerializerTests.swift
@@ -196,8 +196,8 @@
             let ft = typeDecls[0]
             #expect(ft.params.count == 1)
             #expect(ft.params[0].name == "name")
-            #expect(ft.params[0].type == .string)
-            #expect(ft.result == .string)
+            #expect(ft.params[0].type == .primitive(.string))
+            #expect(ft.result == .primitive(.string))
 
             // Decl 1: export → "do-stuff" → function(0)
             let exportDecls = iDecls.compactMap { d -> ComponentExportDecl? in
@@ -296,8 +296,8 @@
             if case .type(.function(let ft)) = it.declarations[0] {
                 #expect(ft.params.count == 1)
                 #expect(ft.params[0].name == "x")
-                #expect(ft.params[0].type == .u32)
-                #expect(ft.result == .u32)
+                #expect(ft.params[0].type == .primitive(.u32))
+                #expect(ft.result == .primitive(.u32))
             } else {
                 Issue.record("Expected functype in instance decl[0]")
             }
@@ -402,7 +402,7 @@
             let it = try #require(instanceTypes.first)
 
             // Find record type def
-            var records: [ComponentValueType] = []
+            var records: [ComponentDefValType] = []
             for d in it.declarations {
                 if case .type(.definedValue(let vt)) = d {
                     if case .record = vt { records.append(vt) }
@@ -418,8 +418,8 @@
             #expect(fields[1].name == "y")
             // Field types are read as type indices by the parser since they're
             // encoded as primitive opcodes (s32 = 0x7A = 122 as unsigned LEB128)
-            #expect(fields[0].type.rawValue == Int(0x7A))
-            #expect(fields[1].type.rawValue == Int(0x7A))
+            #expect(fields[0].type == .index(ComponentTypeIndex(rawValue: Int(0x7A))))
+            #expect(fields[1].type == .index(ComponentTypeIndex(rawValue: Int(0x7A))))
         }
 
         @Test func interfaceWithEnumType() throws {
@@ -721,9 +721,9 @@
             #expect(funcTypes.count == 13)
 
             // Each function has 1 param and 1 result, both the same primitive type
-            let expectedTypes: [ComponentValueType] = [
-                .bool, .u8, .u16, .u32, .u64, .s8, .s16, .s32, .s64,
-                .float32, .float64, .char, .string,
+            let expectedTypes: [ComponentDefValType] = [
+                .primitive(.bool), .primitive(.u8), .primitive(.u16), .primitive(.u32), .primitive(.u64), .primitive(.s8), .primitive(.s16), .primitive(.s32), .primitive(.s64),
+                .primitive(.float32), .primitive(.float64), .primitive(.char), .primitive(.string),
             ]
             for (i, expected) in expectedTypes.enumerated() {
                 #expect(funcTypes[i].params.count == 1)
@@ -769,7 +769,7 @@
             let it = try #require(instanceTypes.first)
 
             // Collect type defs in order
-            var typeDefs: [ComponentValueType] = []
+            var typeDefs: [ComponentDefValType] = []
             for d in it.declarations {
                 if case .type(.definedValue(let vt)) = d { typeDefs.append(vt) }
             }
@@ -791,8 +791,8 @@
             #expect(lineFields[0].name == "start")
             #expect(lineFields[1].name == "end")
             // point is type index 0 in this instancetype
-            #expect(lineFields[0].type.rawValue == 0)
-            #expect(lineFields[1].type.rawValue == 0)
+            #expect(lineFields[0].type == .index(ComponentTypeIndex(rawValue: 0)))
+            #expect(lineFields[1].type == .index(ComponentTypeIndex(rawValue: 0)))
         }
 
         // MARK: - Error path tests
@@ -981,7 +981,7 @@
             if let ft = funcTypesByIndex[3] {
                 // The result references point which is type 0; but since point is a
                 // named type, the serializer writes its index (0) as a type reference
-                if case .indexed(let idx) = ft.result {
+                if case .inlined(.index(let idx)) = ft.result {
                     #expect(idx.rawValue == 0, "get-point should return type 0 (point)")
                 } else {
                     Issue.record("Expected indexed result for get-point, got \(String(describing: ft.result))")
@@ -990,7 +990,7 @@
 
             // Verify get-color returns type index 1 (color)
             if let ft = funcTypesByIndex[4] {
-                if case .indexed(let idx) = ft.result {
+                if case .inlined(.index(let idx)) = ft.result {
                     #expect(idx.rawValue == 1, "get-color should return type 1 (color)")
                 } else {
                     Issue.record("Expected indexed result for get-color, got \(String(describing: ft.result))")
@@ -1017,7 +1017,7 @@
 
             // First should be a type def (the alias u32 → just writes u32 primitive)
             if case .type(.definedValue(let vt)) = iDecls[0] {
-                #expect(vt == .u32, "type my-id = u32 should produce u32 defined value")
+                #expect(vt == .primitive(.u32), "type my-id = u32 should produce u32 defined value")
             } else {
                 Issue.record("Expected defined value type for my-id, got \(iDecls[0])")
             }
@@ -1172,12 +1172,12 @@
             let ft = funcTypes[0]
             #expect(ft.params.count == 3)
             #expect(ft.params[0].name == "a")
-            #expect(ft.params[0].type == .u32)
+            #expect(ft.params[0].type == .primitive(.u32))
             #expect(ft.params[1].name == "b")
-            #expect(ft.params[1].type == .string)
+            #expect(ft.params[1].type == .primitive(.string))
             #expect(ft.params[2].name == "c")
-            #expect(ft.params[2].type == .bool)
-            #expect(ft.result == .u64)
+            #expect(ft.params[2].type == .primitive(.bool))
+            #expect(ft.result == .primitive(.u64))
         }
     }
 

--- a/Tests/WAVETests/GoldenTests.swift
+++ b/Tests/WAVETests/GoldenTests.swift
@@ -20,7 +20,7 @@
         private let extractor: WITInterfaceExtractor
 
         // Function parameter types
-        var functions: [String: [(name: String, type: ComponentValueType)]] {
+        var functions: [String: [(name: String, type: ComponentDefValType)]] {
             extractor.functions
         }
 
@@ -33,7 +33,7 @@
             self.extractor = extractor
         }
 
-        func resolver(_ idx: ComponentTypeIndex) -> ComponentValueType {
+        func resolver(_ idx: ComponentTypeIndex) -> ComponentDefValType {
             return extractor.converter.resolve(idx)
         }
     }

--- a/Tests/WAVETests/WAVETests.swift
+++ b/Tests/WAVETests/WAVETests.swift
@@ -197,29 +197,29 @@
         @Test
         func parseBool() throws {
             var parser = WAVEParser("true")
-            let value = try parser.parse(type: .bool)
+            let value = try parser.parse(type: .primitive(.bool))
             if case .bool(true) = value {} else { Issue.record("Expected bool(true)") }
 
             var parser2 = WAVEParser("false")
-            let value2 = try parser2.parse(type: .bool)
+            let value2 = try parser2.parse(type: .primitive(.bool))
             if case .bool(false) = value2 {} else { Issue.record("Expected bool(false)") }
         }
 
         @Test
         func parseIntegers() throws {
             var parser = WAVEParser("42")
-            let value = try parser.parse(type: .u32)
+            let value = try parser.parse(type: .primitive(.u32))
             if case .u32(42) = value {} else { Issue.record("Expected u32(42)") }
 
             var parser2 = WAVEParser("-123")
-            let value2 = try parser2.parse(type: .s32)
+            let value2 = try parser2.parse(type: .primitive(.s32))
             if case .s32(-123) = value2 {} else { Issue.record("Expected s32(-123)") }
         }
 
         @Test
         func parseFloats() throws {
             var parser = WAVEParser("3.14")
-            let value = try parser.parse(type: .float32)
+            let value = try parser.parse(type: .primitive(.float32))
             if case .float32(let f) = value {
                 #expect(abs(f - 3.14) < 0.001)
             } else {
@@ -227,7 +227,7 @@
             }
 
             var parser2 = WAVEParser("nan")
-            let value2 = try parser2.parse(type: .float64)
+            let value2 = try parser2.parse(type: .primitive(.float64))
             if case .float64(let f) = value2 {
                 #expect(f.isNaN)
             } else {
@@ -238,14 +238,14 @@
         @Test
         func parseString() throws {
             var parser = WAVEParser(#""hello world""#)
-            let value = try parser.parse(type: .string)
+            let value = try parser.parse(type: .primitive(.string))
             if case .string("hello world") = value {} else { Issue.record("Expected string") }
         }
 
         @Test
         func parseChar() throws {
             var parser = WAVEParser("'x'")
-            let value = try parser.parse(type: .char)
+            let value = try parser.parse(type: .primitive(.char))
             if case .char(let c) = value, c == "x" {} else { Issue.record("Expected char 'x'") }
         }
 

--- a/Tests/WasmKitTests/Execution/ComponentLoaderTests.swift
+++ b/Tests/WasmKitTests/Execution/ComponentLoaderTests.swift
@@ -98,7 +98,7 @@
             component.coreInstanceDefs.append(.instantiate(moduleIndex: 0, args: []))
 
             // Try to lift a function that doesn't exist
-            let funcType = ComponentFuncType(params: [], result: .s32)
+            let funcType = ComponentFuncType(params: [], result: .primitive(.s32))
             component.canonicalDefinitions.append(
                 ParsedCanonicalDefinition(
                     kind: .lift(coreInstanceIndex: 0, functionName: "nonexistent", type: funcType)
@@ -175,7 +175,7 @@
             component.imports.append(
                 ParsedComponentImport(
                     name: "my-import",
-                    kind: .function(ComponentFuncType(params: [], result: .s32))
+                    kind: .function(ComponentFuncType(params: [], result: .primitive(.s32)))
                 ))
 
             // Provide a coreInstance instead of a function
@@ -285,7 +285,7 @@
 
             #expect(doubleFunc.type.params.count == 1)
             #expect(doubleFunc.type.params[0].name == "value")
-            #expect(doubleFunc.type.result == .s32)
+            #expect(doubleFunc.type.result == .primitive(.s32))
 
             // Test invocation
             let results = try doubleFunc.invoke([.s32(21)])


### PR DESCRIPTION
`ComponentValueType`'s composite cases (`list`, `tuple`, `option`, `result`, record and variant fields) referenced their element types only by `ComponentTypeIndex`, so the binary spec's `valtype ::= typeidx | primvaltype` could not encode an inline primitive. This adds `ComponentValType` (a type index or a `ComponentPrimValType`) for those element positions and renames `ComponentValueType` to `ComponentDefValType`, mapping the three Swift types one-to-one onto the spec grammar. Every producer still emits type indices, so the change is behavior-preserving and the inline-primitive path is dormant until a later change emits it.