### PR TITLE
Update benchmark package dependency URL

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -19,11 +19,11 @@ package.targets += [
         dependencies: [
             .product(name: "WasmKit", package: "WasmKit"),
             .product(name: "WasmKitWASI", package: "WasmKit"),
-            .product(name: "Benchmark", package: "package-benchmark"),
+            .product(name: "Benchmark", package: "benchmark"),
         ],
         path: "Benchmarks/WishYouWereFast",
         plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            .plugin(name: "BenchmarkPlugin", package: "benchmark")
         ]
     ),
 ]
@@ -36,11 +36,11 @@ package.targets += [
             .product(name: "WAT", package: "WasmKit"),
             .product(name: "WasmKit", package: "WasmKit"),
             .product(name: "WasmKitWASI", package: "WasmKit"),
-            .product(name: "Benchmark", package: "package-benchmark"),
+            .product(name: "Benchmark", package: "benchmark"),
         ],
         path: "Benchmarks/MicroBench",
         plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            .plugin(name: "BenchmarkPlugin", package: "benchmark")
         ]
     ),
 ]
@@ -52,11 +52,11 @@ package.targets += [
         dependencies: [
             .product(name: "WasmKit", package: "WasmKit"),
             .product(name: "WasmKitWASI", package: "WasmKit"),
-            .product(name: "Benchmark", package: "package-benchmark"),
+            .product(name: "Benchmark", package: "benchmark"),
         ],
         path: "Benchmarks/MacroPlugin",
         plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            .plugin(name: "BenchmarkPlugin", package: "benchmark")
         ]
     ),
 ]
@@ -66,14 +66,14 @@ package.targets += [
     .executableTarget(
         name: "WasmParserBenchmark",
         dependencies: [
-            .product(name: "Benchmark", package: "package-benchmark"),
+            .product(name: "Benchmark", package: "benchmark"),
             .product(name: "SystemPackage", package: "swift-system"),
             .product(name: "WasmKit", package: "WasmKit"),
             .product(name: "WAT", package: "WasmKit"),
         ],
         path: "Benchmarks/WasmParserBenchmark",
         plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            .plugin(name: "BenchmarkPlugin", package: "benchmark")
         ]
     ),
 ]

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v15)],
     dependencies: [
         .package(name: "WasmKit", path: "../"),
-        .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),
+        .package(url: "https://github.com/ordo-one/benchmark", .upToNextMajor(from: "1.4.0")),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.6.4"),
     ]
 )

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -4,7 +4,7 @@ This directory contains a set of benchmarks that can be used to compare the perf
 
 The benchmarks are divided in two types:
 
-* Bencmarking WasmKit library via [`package-benchmark`](https://github.com/ordo-one/package-benchmark) harness;
+* Bencmarking WasmKit library via [`ordo-one/benchmark`](https://github.com/ordo-one/benchmark) harness;
 * Benchmarking Wasm runtime executables end-to-end, implemented with a `bench.py` script.
 
 Setup and running instructions depend on the type of benchmarking you're interested.


### PR DESCRIPTION
Fixed a CI warning:

```
Warning: this project depends on the benchmark package using its legacy
identifier 'package-benchmark'. The repository has been renamed; please update
your Package.swift to use the new URL and identifier:

  .package(url: "https://github.com/ordo-one/benchmark", ...)
  .product(name: "Benchmark", package: "benchmark"),
  .plugin(name: "BenchmarkPlugin", package: "benchmark"),

Support for the legacy 'package-benchmark' identifier will be removed in a
future release.
```