### PR TITLE
Per-node locking for the in-memory WASI file system

### DIFF
--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -7,7 +7,7 @@ struct FileAccessMode: OptionSet {
     static let write = FileAccessMode(rawValue: 1 << 1)
 }
 
-protocol WASIEntry {
+protocol WASIEntry: Sendable {
     /// Whether this entry wraps a borrowed file descriptor that should not be
     /// closed when the WASI instance is torn down (e.g. process stdio).
     var isBorrowed: Bool { get }
@@ -119,9 +119,14 @@ struct FdTable {
         set { self.map[fd] = newValue }
     }
 
+    /// Whether another descriptor can be installed, i.e. the table is below capacity.
+    var hasCapacity: Bool {
+        map.count < WASIAbi.Fd.max
+    }
+
     /// Inserts an entry and returns the corresponding file descriptor
     mutating func push(_ entry: FdEntry) throws -> WASIAbi.Fd {
-        guard map.count < WASIAbi.Fd.max else {
+        guard hasCapacity else {
             throw WASIAbi.Errno.ENFILE
         }
         // Find a free fd
@@ -155,7 +160,7 @@ struct FdTable {
 }
 
 /// Content of a file that can be retrieved from the file system.
-public enum FileContent {
+public enum FileContent: Sendable {
     case bytes([UInt8])
     case handle(FileDescriptor)
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
@@ -14,13 +14,11 @@ struct MemoryDirEntry: WASIDir {
     }
 
     func attributes() throws -> WASIAbi.Filestat {
-        let timestamps = fileSystem.withTreeLock { dirNode.timestamps }
+        let timestamps = dirNode.timestamps
         return WASIAbi.Filestat(
             dev: 0, ino: 0, filetype: .DIRECTORY,
             nlink: 1, size: 0,
-            atim: timestamps.atim,
-            mtim: timestamps.mtim,
-            ctim: timestamps.ctim
+            atim: timestamps.atim, mtim: timestamps.mtim, ctim: timestamps.ctim
         )
     }
 
@@ -55,9 +53,7 @@ struct MemoryDirEntry: WASIDir {
             newMtim = nil
         }
 
-        fileSystem.withTreeLock {
-            dirNode.setTimes(atim: newAtim, mtim: newMtim)
-        }
+        dirNode.setTimes(atim: newAtim, mtim: newMtim)
     }
 
     func advise(
@@ -77,14 +73,13 @@ struct MemoryDirEntry: WASIDir {
         accessMode: FileAccessMode,
         fdflags: WASIAbi.Fdflags
     ) throws -> FileDescriptor {
-        // Memory filesystem doesn't return real file descriptors for this method
-        // File opening is handled through the WASI bridge's path_open implementation
+        // Memory filesystem doesn't return real file descriptors for this method.
+        // File opening is handled through the WASI bridge's path_open implementation.
         throw WASIAbi.Errno.ENOTSUP
     }
 
     func createDirectory(atPath path: String) throws {
-        let fullPath = self.path.hasSuffix("/") ? self.path + path : self.path + "/" + path
-        try fileSystem.ensureDirectory(at: fullPath)
+        try fileSystem.ensureDirectory(at: MemoryFileSystem.joinGuestPath(self.path, path))
     }
 
     func removeDirectory(atPath path: String) throws {
@@ -112,14 +107,17 @@ struct MemoryDirEntry: WASIDir {
     }
 
     func readEntries(cookie: WASIAbi.DirCookie) throws -> AnyIterator<Result<ReaddirElement, any Error>> {
-        let children = fileSystem.withTreeLock { dirNode.listChildren() }
+        let children = dirNode.listChildren()
+
+        let fs = self.fileSystem
+        let basePath = self.path
 
         let iterator = children.enumerated()
             .dropFirst(Int(cookie))
             .map { (index, name) -> Result<ReaddirElement, any Error> in
                 return Result(catching: {
-                    let childPath = self.path.hasSuffix("/") ? self.path + name : self.path + "/" + name
-                    guard let childNode = fileSystem.lookup(at: childPath) else {
+                    let childPath = MemoryFileSystem.joinGuestPath(basePath, name)
+                    guard let childNode = fs.lookup(at: childPath) else {
                         throw WASIAbi.Errno.ENOENT
                     }
 
@@ -146,8 +144,7 @@ struct MemoryDirEntry: WASIDir {
     }
 
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat {
-        let fullPath = self.path.hasSuffix("/") ? self.path + path : self.path + "/" + path
-        guard let node = fileSystem.lookup(at: fullPath) else {
+        guard let node = fileSystem.lookup(at: MemoryFileSystem.joinGuestPath(self.path, path)) else {
             throw WASIAbi.Errno.ENOENT
         }
 
@@ -169,8 +166,8 @@ struct MemoryDirEntry: WASIDir {
         case .file:
             fileType = .REGULAR_FILE
             if let fileNode = node as? MemoryFileNode {
-                size = WASIAbi.FileSize(fileNode.size)
-                let timestamps = fileNode.timestamps
+                size = WASIAbi.FileSize(try fileNode.size)
+                let timestamps = try fileNode.timestamps
                 atim = timestamps.atim
                 mtim = timestamps.mtim
                 ctim = timestamps.ctim
@@ -191,8 +188,7 @@ struct MemoryDirEntry: WASIDir {
         atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags, symlinkFollow: Bool
     ) throws {
-        let fullPath = self.path.hasSuffix("/") ? self.path + path : self.path + "/" + path
-        guard let node = fileSystem.lookup(at: fullPath) else {
+        guard let node = fileSystem.lookup(at: MemoryFileSystem.joinGuestPath(self.path, path)) else {
             throw WASIAbi.Errno.ENOENT
         }
 
@@ -216,7 +212,7 @@ struct MemoryDirEntry: WASIDir {
         }
 
         if let dirNode = node as? MemoryDirectoryNode {
-            fileSystem.withTreeLock { dirNode.setTimes(atim: newAtim, mtim: newMtim) }
+            dirNode.setTimes(atim: newAtim, mtim: newMtim)
             return
         }
 
@@ -224,36 +220,30 @@ struct MemoryDirEntry: WASIDir {
             return
         }
 
-        switch fileNode.content {
-        case .bytes:
-            fileSystem.withTreeLock { fileNode.setTimes(atim: newAtim, mtim: newMtim) }
-
-        case .handle(let handle):
-            let accessTime: FileTime
-            if fstFlags.contains(.ATIM) {
-                accessTime = FileTime(
-                    seconds: Int(atim / 1_000_000_000),
-                    nanoseconds: Int(atim % 1_000_000_000)
-                )
-            } else if fstFlags.contains(.ATIM_NOW) {
-                accessTime = .now
-            } else {
-                accessTime = .omit
-            }
-
-            let modTime: FileTime
-            if fstFlags.contains(.MTIM) {
-                modTime = FileTime(
-                    seconds: Int(mtim / 1_000_000_000),
-                    nanoseconds: Int(mtim % 1_000_000_000)
-                )
-            } else if fstFlags.contains(.MTIM_NOW) {
-                modTime = .now
-            } else {
-                modTime = .omit
-            }
-
-            try handle.setTimes(access: accessTime, modification: modTime)
+        // nil means the times were applied in memory; a non-nil handle is a host
+        // fd whose times we set below.
+        guard let handle = fileNode.setTimesInMemory(atim: newAtim, mtim: newMtim) else {
+            return
         }
+
+        let accessTime: FileTime
+        if fstFlags.contains(.ATIM) {
+            accessTime = FileTime(seconds: Int(atim / 1_000_000_000), nanoseconds: Int(atim % 1_000_000_000))
+        } else if fstFlags.contains(.ATIM_NOW) {
+            accessTime = .now
+        } else {
+            accessTime = .omit
+        }
+
+        let modTime: FileTime
+        if fstFlags.contains(.MTIM) {
+            modTime = FileTime(seconds: Int(mtim / 1_000_000_000), nanoseconds: Int(mtim % 1_000_000_000))
+        } else if fstFlags.contains(.MTIM_NOW) {
+            modTime = .now
+        } else {
+            modTime = .omit
+        }
+
+        try handle.setTimes(access: accessTime, modification: modTime)
     }
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
@@ -1,8 +1,13 @@
+import Synchronization
+import SystemExtras
 import SystemPackage
 import WasmTypes
 
-/// Base protocol for all file system nodes in memory.
-protocol MemFSNode: AnyObject {
+/// Base protocol for file system nodes.
+///
+/// Each node guards its own state, so a reference can be shared across concurrent
+/// file descriptors without a single global lock.
+protocol MemFSNode: AnyObject, Sendable {
     var type: MemFSNodeType { get }
 }
 
@@ -13,90 +18,132 @@ enum MemFSNodeType {
     case characterDevice
 }
 
-/// A directory node in the memory file system.
+/// A directory node.
+///
+/// Timestamp bumps are inlined into each mutating method rather than delegated to
+/// a locking helper, since the lock is non-reentrant.
 package final class MemoryDirectoryNode: MemFSNode {
     let type: MemFSNodeType = .directory
-    private var children: [String: MemFSNode] = [:]
 
-    private var _atim: WASIAbi.Timestamp
-    private var _mtim: WASIAbi.Timestamp
-    private var _ctim: WASIAbi.Timestamp
+    private struct State {
+        var children: [String: MemFSNode] = [:]
+        var atim: WASIAbi.Timestamp
+        var mtim: WASIAbi.Timestamp
+        var ctim: WASIAbi.Timestamp
+    }
+
+    private let state: Mutex<State>
 
     init() {
         let now = WASIAbi.Timestamp.currentWallClock()
-        self._atim = now
-        self._mtim = now
-        self._ctim = now
+        self.state = Mutex(State(atim: now, mtim: now, ctim: now))
     }
 
     var timestamps: (atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp, ctim: WASIAbi.Timestamp) {
-        return (_atim, _mtim, _ctim)
-    }
-
-    func touchAccessTime() {
-        _atim = WASIAbi.Timestamp.currentWallClock()
-    }
-
-    func touchModificationTime() {
-        let now = WASIAbi.Timestamp.currentWallClock()
-        _mtim = now
-        _ctim = now
+        state.withLock { ($0.atim, $0.mtim, $0.ctim) }
     }
 
     func setTimes(atim: WASIAbi.Timestamp?, mtim: WASIAbi.Timestamp?) {
-        let now = WASIAbi.Timestamp.currentWallClock()
-        if let atim = atim {
-            _atim = atim
+        state.withLock { s in
+            if let atim { s.atim = atim }
+            if let mtim { s.mtim = mtim }
+            s.ctim = WASIAbi.Timestamp.currentWallClock()
         }
-        if let mtim = mtim {
-            _mtim = mtim
-        }
-        _ctim = now
     }
 
     func getChild(name: String) -> MemFSNode? {
-        return children[name]
+        state.withLock { $0.children[name] }
     }
 
     func setChild(name: String, node: MemFSNode) {
-        children[name] = node
-        touchModificationTime()
+        state.withLock { s in
+            s.children[name] = node
+            let now = WASIAbi.Timestamp.currentWallClock()
+            s.mtim = now
+            s.ctim = now
+        }
     }
 
     @discardableResult
     func removeChild(name: String) -> Bool {
-        let removed = children.removeValue(forKey: name) != nil
-        if removed {
-            touchModificationTime()
+        state.withLock { s in
+            guard s.children.removeValue(forKey: name) != nil else { return false }
+            let now = WASIAbi.Timestamp.currentWallClock()
+            s.mtim = now
+            s.ctim = now
+            return true
         }
-        return removed
+    }
+
+    /// Returns the existing child directory `name`, creating one if absent.
+    /// Throws `ENOTDIR` if a non-directory already occupies the name.
+    func getOrCreateChildDirectory(name: String) throws -> MemoryDirectoryNode {
+        try state.withLock { s in
+            if let existing = s.children[name] {
+                guard let dir = existing as? MemoryDirectoryNode else {
+                    throw WASIAbi.Errno.ENOTDIR
+                }
+                return dir
+            }
+            let dir = MemoryDirectoryNode()
+            s.children[name] = dir
+            let now = WASIAbi.Timestamp.currentWallClock()
+            s.mtim = now
+            s.ctim = now
+            return dir
+        }
+    }
+
+    /// Returns the existing regular file `name`, creating an empty one if absent.
+    /// Throws `EISDIR` if a directory already occupies the name.
+    func getOrCreateChildFile(name: String) throws -> MemoryFileNode {
+        try state.withLock { s in
+            if let existing = s.children[name] {
+                guard let file = existing as? MemoryFileNode else {
+                    throw WASIAbi.Errno.EISDIR
+                }
+                return file
+            }
+            let file = MemoryFileNode(bytes: [])
+            s.children[name] = file
+            let now = WASIAbi.Timestamp.currentWallClock()
+            s.mtim = now
+            s.ctim = now
+            return file
+        }
     }
 
     func listChildren() -> [String] {
-        touchAccessTime()
-        return Array(children.keys).sorted()
+        state.withLock { s in
+            s.atim = WASIAbi.Timestamp.currentWallClock()
+            return s.children.keys.sorted()
+        }
     }
 
     func childCount() -> Int {
-        return children.count
+        state.withLock { $0.children.count }
     }
 }
 
-/// A regular file node in the memory file system.
+/// A regular file node.
+///
+/// `.bytes` reads and writes run under the node lock; `.handle` IO extracts the
+/// descriptor under the lock and runs the syscall outside it.
 final class MemoryFileNode: MemFSNode {
     let type: MemFSNodeType = .file
-    var content: FileContent
 
-    private var _atim: WASIAbi.Timestamp
-    private var _mtim: WASIAbi.Timestamp
-    private var _ctim: WASIAbi.Timestamp
+    private struct State {
+        var content: FileContent
+        var atim: WASIAbi.Timestamp
+        var mtim: WASIAbi.Timestamp
+        var ctim: WASIAbi.Timestamp
+    }
+
+    private let state: Mutex<State>
 
     init(content: FileContent) {
-        self.content = content
         let now = WASIAbi.Timestamp.currentWallClock()
-        self._atim = now
-        self._mtim = now
-        self._ctim = now
+        self.state = Mutex(State(content: content, atim: now, mtim: now, ctim: now))
     }
 
     convenience init(bytes: some Sequence<UInt8>) {
@@ -107,66 +154,270 @@ final class MemoryFileNode: MemFSNode {
         self.init(content: .handle(handle))
     }
 
+    /// A snapshot of the current content. `.bytes` copies the array; `.handle`
+    /// returns the descriptor.
+    var content: FileContent {
+        state.withLock { $0.content }
+    }
+
+    /// The host descriptor for a `.handle`-backed file, or nil for an in-memory file.
+    var handle: FileDescriptor? {
+        state.withLock { if case .handle(let fd) = $0.content { return fd }; return nil }
+    }
+
     var size: Int {
-        switch content {
-        case .bytes(let bytes):
-            return bytes.count
-        case .handle(let fd):
-            do {
-                let attrs = try fd.attributes()
-                return Int(attrs.size)
-            } catch {
-                return 0
+        get throws {
+            let content = state.withLock { $0.content }
+            switch content {
+            case .bytes(let bytes):
+                return bytes.count
+            case .handle(let fd):
+                return Int(try fd.attributes().size)
             }
         }
     }
 
     var timestamps: (atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp, ctim: WASIAbi.Timestamp) {
-        switch content {
-        case .bytes:
-            return (_atim, _mtim, _ctim)
-        case .handle(let fd):
-            do {
+        get throws {
+            let snapshot = state.withLock { (content: $0.content, atim: $0.atim, mtim: $0.mtim, ctim: $0.ctim) }
+            switch snapshot.content {
+            case .bytes:
+                return (snapshot.atim, snapshot.mtim, snapshot.ctim)
+            case .handle(let fd):
                 let attrs = try fd.attributes()
-                let atim = WASIAbi.Timestamp(platformTimeSpec: attrs.accessTime)
-                let mtim = WASIAbi.Timestamp(platformTimeSpec: attrs.modificationTime)
-                let ctim = WASIAbi.Timestamp(platformTimeSpec: attrs.creationTime)
-                return (atim, mtim, ctim)
-            } catch {
-                return (0, 0, 0)
+                return (
+                    WASIAbi.Timestamp(platformTimeSpec: attrs.accessTime),
+                    WASIAbi.Timestamp(platformTimeSpec: attrs.modificationTime),
+                    WASIAbi.Timestamp(platformTimeSpec: attrs.creationTime)
+                )
             }
         }
     }
 
-    func touchAccessTime() {
-        if case .bytes = content {
-            _atim = WASIAbi.Timestamp.currentWallClock()
-        }
-    }
-
-    func touchModificationTime() {
-        if case .bytes = content {
+    /// Resets a `.bytes` file to empty content (used for `O_TRUNC`). No-op for `.handle`.
+    func truncateToEmpty() {
+        state.withLock { s in
+            guard case .bytes = s.content else { return }
+            s.content = .bytes([])
             let now = WASIAbi.Timestamp.currentWallClock()
-            _mtim = now
-            _ctim = now
+            s.mtim = now
+            s.ctim = now
         }
     }
 
-    func setTimes(atim: WASIAbi.Timestamp?, mtim: WASIAbi.Timestamp?) {
-        if case .bytes = content {
-            let now = WASIAbi.Timestamp.currentWallClock()
-            if let atim = atim {
-                _atim = atim
-            }
-            if let mtim = mtim {
-                _mtim = mtim
-            }
-            _ctim = now
+    /// Sets in-memory times on a `.bytes` file; returns the host descriptor for a
+    /// `.handle` file so the caller applies the change with a syscall outside the lock.
+    func setTimesInMemory(atim: WASIAbi.Timestamp?, mtim: WASIAbi.Timestamp?) -> FileDescriptor? {
+        state.withLock { s in
+            if case .handle(let fd) = s.content { return fd }
+            if let atim { s.atim = atim }
+            if let mtim { s.mtim = mtim }
+            s.ctim = WASIAbi.Timestamp.currentWallClock()
+            return nil
         }
+    }
+
+    /// Truncates or extends a `.bytes` file; calls `truncate` on the host descriptor
+    /// for a `.handle` file outside the lock.
+    func setFilestatSize(_ size: WASIAbi.FileSize) throws {
+        let handle: FileDescriptor? = state.withLock { s in
+            switch s.content {
+            case .bytes(var bytes):
+                let newSize = Int(size)
+                if newSize < bytes.count {
+                    bytes = Array(bytes.prefix(newSize))
+                } else if newSize > bytes.count {
+                    bytes.append(contentsOf: Array(repeating: 0, count: newSize - bytes.count))
+                }
+                s.content = .bytes(bytes)
+                let now = WASIAbi.Timestamp.currentWallClock()
+                s.mtim = now
+                s.ctim = now
+                return nil
+            case .handle(let fd):
+                return fd
+            }
+        }
+        if let handle { try handle.truncate(size: Int64(size)) }
+    }
+
+    /// The byte count of a `.bytes` file, or the host descriptor for a `.handle` file
+    /// (so the caller can seek on it directly).
+    func seekPrep() -> (byteCount: Int, handle: FileDescriptor?) {
+        state.withLock { s in
+            switch s.content {
+            case .bytes(let bytes): return (bytes.count, nil)
+            case .handle(let fd): return (0, fd)
+            }
+        }
+    }
+
+    func read<M: GuestMemory, Buffer: Sequence>(
+        into buffer: Buffer, memory: M, position: Int
+    ) throws -> (count: WASIAbi.Size, newPosition: Int) where Buffer.Element == WASIAbi.IOVec {
+        let (count, newPosition, handle): (WASIAbi.Size, Int, FileDescriptor?) = state.withLock { s in
+            switch s.content {
+            case .bytes(let bytes):
+                var cur = position
+                var total: UInt32 = 0
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let available = max(0, bytes.count - cur)
+                        let toRead = min(bufferPtr.count, available)
+                        guard toRead > 0 else { return }
+                        bytes.withUnsafeBytes { contentBytes in
+                            bufferPtr.baseAddress!.copyMemory(
+                                from: contentBytes.baseAddress!.advanced(by: cur), byteCount: toRead)
+                        }
+                        cur += toRead
+                        total += UInt32(toRead)
+                    }
+                }
+                s.atim = WASIAbi.Timestamp.currentWallClock()
+                return (total, cur, nil)
+            case .handle(let fd):
+                return (0, position, fd)
+            }
+        }
+        guard let handle else { return (count, newPosition) }
+        var currentOffset = Int64(position)
+        var total: UInt32 = 0
+        for iovec in buffer {
+            let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
+            }
+            currentOffset += Int64(nread)
+            total += UInt32(nread)
+        }
+        return (total, Int(currentOffset))
+    }
+
+    func pread<M: GuestMemory, Buffer: Sequence>(
+        into buffer: Buffer, memory: M, offset: Int
+    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        let (count, handle): (WASIAbi.Size, FileDescriptor?) = state.withLock { s in
+            switch s.content {
+            case .bytes(let bytes):
+                var cur = offset
+                var total: UInt32 = 0
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let available = max(0, bytes.count - cur)
+                        let toRead = min(bufferPtr.count, available)
+                        guard toRead > 0 else { return }
+                        bytes.withUnsafeBytes { contentBytes in
+                            bufferPtr.baseAddress!.copyMemory(
+                                from: contentBytes.baseAddress!.advanced(by: cur), byteCount: toRead)
+                        }
+                        cur += toRead
+                        total += UInt32(toRead)
+                    }
+                }
+                s.atim = WASIAbi.Timestamp.currentWallClock()
+                return (total, nil)
+            case .handle(let fd):
+                return (0, fd)
+            }
+        }
+        guard let handle else { return count }
+        var currentOffset = Int64(offset)
+        var total: UInt32 = 0
+        for iovec in buffer {
+            let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
+            }
+            currentOffset += Int64(nread)
+            total += UInt32(nread)
+        }
+        return total
+    }
+
+    func write<M: GuestMemory, Buffer: Sequence>(
+        vectored buffer: Buffer, memory: M, position: Int
+    ) throws -> (count: WASIAbi.Size, newPosition: Int) where Buffer.Element == WASIAbi.IOVec {
+        let (count, newPosition, handle): (WASIAbi.Size, Int, FileDescriptor?) = state.withLock { s in
+            switch s.content {
+            case .bytes(var bytes):
+                var cur = position
+                var total: UInt32 = 0
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let bytesToWrite = bufferPtr.count
+                        let requiredSize = cur + bytesToWrite
+                        if requiredSize > bytes.count {
+                            bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
+                        }
+                        bytes.replaceSubrange(cur..<(cur + bytesToWrite), with: bufferPtr)
+                        cur += bytesToWrite
+                        total += UInt32(bytesToWrite)
+                    }
+                }
+                s.content = .bytes(bytes)
+                let now = WASIAbi.Timestamp.currentWallClock()
+                s.mtim = now
+                s.ctim = now
+                return (total, cur, nil)
+            case .handle(let fd):
+                return (0, position, fd)
+            }
+        }
+        guard let handle else { return (count, newPosition) }
+        var currentOffset = Int64(position)
+        var total: UInt32 = 0
+        for iovec in buffer {
+            let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
+            }
+            currentOffset += Int64(nwritten)
+            total += UInt32(nwritten)
+        }
+        return (total, Int(currentOffset))
+    }
+
+    func pwrite<M: GuestMemory, Buffer: Sequence>(
+        vectored buffer: Buffer, memory: M, offset: Int
+    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        let (count, handle): (WASIAbi.Size, FileDescriptor?) = state.withLock { s in
+            switch s.content {
+            case .bytes(var bytes):
+                var cur = offset
+                var total: UInt32 = 0
+                for iovec in buffer {
+                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                        let bytesToWrite = bufferPtr.count
+                        let requiredSize = cur + bytesToWrite
+                        if requiredSize > bytes.count {
+                            bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
+                        }
+                        bytes.replaceSubrange(cur..<(cur + bytesToWrite), with: bufferPtr)
+                        cur += bytesToWrite
+                        total += UInt32(bytesToWrite)
+                    }
+                }
+                s.content = .bytes(bytes)
+                let now = WASIAbi.Timestamp.currentWallClock()
+                s.mtim = now
+                s.ctim = now
+                return (total, nil)
+            case .handle(let fd):
+                return (0, fd)
+            }
+        }
+        guard let handle else { return count }
+        var currentOffset = Int64(offset)
+        var total: UInt32 = 0
+        for iovec in buffer {
+            let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
+            }
+            currentOffset += Int64(nwritten)
+            total += UInt32(nwritten)
+        }
+        return total
     }
 }
 
-/// A character device node in the memory file system.
+/// A character device node.
 final class MemoryCharacterDeviceNode: MemFSNode {
     let type: MemFSNodeType = .characterDevice
 

--- a/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
@@ -162,7 +162,10 @@ final class MemoryFileNode: MemFSNode {
 
     /// The host descriptor for a `.handle`-backed file, or nil for an in-memory file.
     var handle: FileDescriptor? {
-        state.withLock { if case .handle(let fd) = $0.content { return fd }; return nil }
+        state.withLock {
+            if case .handle(let fd) = $0.content { return fd }
+            return nil
+        }
     }
 
     var size: Int {

--- a/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
@@ -1,33 +1,34 @@
+import Synchronization
 import SystemExtras
 import SystemPackage
 import WasmTypes
 
-/// A WASIFile implementation for regular files in the memory file system.
+/// A `WASIFile` for regular files.
+///
+/// Holds the file node by reference, so an fd opened before the file is unlinked
+/// keeps working until its last close. Content is synchronized by the node; only
+/// the per-fd `position` lives here.
 final class MemoryFileEntry: WASIFile {
     let fileNode: MemoryFileNode
     let fileSystem: MemoryFileSystem
     let accessMode: FileAccessMode
-    var position: Int
+    let position: Mutex<Int>
 
     init(fileNode: MemoryFileNode, fileSystem: MemoryFileSystem, accessMode: FileAccessMode, position: Int = 0) {
         self.fileNode = fileNode
         self.fileSystem = fileSystem
         self.accessMode = accessMode
-        self.position = position
+        self.position = Mutex(position)
     }
 
     // MARK: - WASIEntry
 
     func attributes() throws -> WASIAbi.Filestat {
-        let (timestamps, size) = fileSystem.withTreeLock {
-            (fileNode.timestamps, fileNode.size)
-        }
+        let timestamps = try fileNode.timestamps
         return WASIAbi.Filestat(
             dev: 0, ino: 0, filetype: .REGULAR_FILE,
-            nlink: 1, size: WASIAbi.FileSize(size),
-            atim: timestamps.atim,
-            mtim: timestamps.mtim,
-            ctim: timestamps.ctim
+            nlink: 1, size: WASIAbi.FileSize(try fileNode.size),
+            atim: timestamps.atim, mtim: timestamps.mtim, ctim: timestamps.ctim
         )
     }
 
@@ -43,58 +44,50 @@ final class MemoryFileEntry: WASIFile {
         atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags
     ) throws {
-        switch fileNode.content {
-        case .bytes:
-            let now = WASIAbi.Timestamp.currentWallClock()
-            let newAtim: WASIAbi.Timestamp?
-            if fstFlags.contains(.ATIM) {
-                newAtim = atim
-            } else if fstFlags.contains(.ATIM_NOW) {
-                newAtim = now
-            } else {
-                newAtim = nil
-            }
-
-            let newMtim: WASIAbi.Timestamp?
-            if fstFlags.contains(.MTIM) {
-                newMtim = mtim
-            } else if fstFlags.contains(.MTIM_NOW) {
-                newMtim = now
-            } else {
-                newMtim = nil
-            }
-
-            fileSystem.withTreeLock {
-                fileNode.setTimes(atim: newAtim, mtim: newMtim)
-            }
-
-        case .handle(let handle):
-            let accessTime: FileTime
-            if fstFlags.contains(.ATIM) {
-                accessTime = FileTime(
-                    seconds: Int(atim / 1_000_000_000),
-                    nanoseconds: Int(atim % 1_000_000_000)
-                )
-            } else if fstFlags.contains(.ATIM_NOW) {
-                accessTime = .now
-            } else {
-                accessTime = .omit
-            }
-
-            let modTime: FileTime
-            if fstFlags.contains(.MTIM) {
-                modTime = FileTime(
-                    seconds: Int(mtim / 1_000_000_000),
-                    nanoseconds: Int(mtim % 1_000_000_000)
-                )
-            } else if fstFlags.contains(.MTIM_NOW) {
-                modTime = .now
-            } else {
-                modTime = .omit
-            }
-
-            try handle.setTimes(access: accessTime, modification: modTime)
+        let now = WASIAbi.Timestamp.currentWallClock()
+        let newAtim: WASIAbi.Timestamp?
+        if fstFlags.contains(.ATIM) {
+            newAtim = atim
+        } else if fstFlags.contains(.ATIM_NOW) {
+            newAtim = now
+        } else {
+            newAtim = nil
         }
+
+        let newMtim: WASIAbi.Timestamp?
+        if fstFlags.contains(.MTIM) {
+            newMtim = mtim
+        } else if fstFlags.contains(.MTIM_NOW) {
+            newMtim = now
+        } else {
+            newMtim = nil
+        }
+
+        // nil means the times were applied in memory; a non-nil handle is a host
+        // fd whose times we set below.
+        guard let handle = fileNode.setTimesInMemory(atim: newAtim, mtim: newMtim) else {
+            return
+        }
+
+        let accessTime: FileTime
+        if fstFlags.contains(.ATIM) {
+            accessTime = FileTime(seconds: Int(atim / 1_000_000_000), nanoseconds: Int(atim % 1_000_000_000))
+        } else if fstFlags.contains(.ATIM_NOW) {
+            accessTime = .now
+        } else {
+            accessTime = .omit
+        }
+
+        let modTime: FileTime
+        if fstFlags.contains(.MTIM) {
+            modTime = FileTime(seconds: Int(mtim / 1_000_000_000), nanoseconds: Int(mtim % 1_000_000_000))
+        } else if fstFlags.contains(.MTIM_NOW) {
+            modTime = .now
+        } else {
+            modTime = .omit
+        }
+
+        try handle.setTimes(access: accessTime, modification: modTime)
     }
 
     func advise(
@@ -104,7 +97,7 @@ final class MemoryFileEntry: WASIFile {
     }
 
     func close() throws {
-        // No-op for memory filesystem - no resources to release
+        // No-op: the node is ARC-owned, so there is nothing to release here.
     }
 
     // MARK: - WASIFile
@@ -133,261 +126,88 @@ final class MemoryFileEntry: WASIFile {
     }
 
     func setFilestatSize(_ size: WASIAbi.FileSize) throws {
-        switch fileNode.content {
-        case .bytes:
-            fileSystem.withTreeLock {
-                guard case .bytes(var bytes) = fileNode.content else { return }
-                let newSize = Int(size)
-                if newSize < bytes.count {
-                    bytes = Array(bytes.prefix(newSize))
-                } else if newSize > bytes.count {
-                    bytes.append(contentsOf: Array(repeating: 0, count: newSize - bytes.count))
-                }
-                fileNode.content = .bytes(bytes)
-                fileNode.touchModificationTime()
-            }
-
-        case .handle(let handle):
-            try handle.truncate(size: Int64(size))
-        }
+        try fileNode.setFilestatSize(size)
     }
 
     func sync() throws {
-        if case .handle(let handle) = fileNode.content {
+        if let handle = fileNode.handle {
             try handle.sync()
         }
     }
 
     func datasync() throws {
-        if case .handle(let handle) = fileNode.content {
+        if let handle = fileNode.handle {
             try handle.datasync()
         }
     }
 
     func tell() throws -> WASIAbi.FileSize {
-        return WASIAbi.FileSize(position)
+        position.withLock { WASIAbi.FileSize($0) }
     }
 
     func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize {
-        let newPosition: Int
+        try position.withLock { pos -> WASIAbi.FileSize in
+            let prep = fileNode.seekPrep()
 
-        switch fileNode.content {
-        case .bytes:
-            let byteCount = fileSystem.withTreeLock {
-                guard case .bytes(let bytes) = fileNode.content else { return 0 }
-                return bytes.count
+            if let handle = prep.handle {
+                let platformWhence: FileDescriptor.SeekOrigin
+                switch whence {
+                case .SET: platformWhence = .start
+                case .CUR: platformWhence = .current
+                case .END: platformWhence = .end
+                }
+                let result = try handle.seek(offset: offset, from: platformWhence)
+                pos = Int(result)
+                return WASIAbi.FileSize(result)
             }
+
+            let newPosition: Int
             switch whence {
-            case .SET:
-                newPosition = Int(offset)
-            case .CUR:
-                newPosition = position + Int(offset)
-            case .END:
-                newPosition = byteCount + Int(offset)
+            case .SET: newPosition = Int(offset)
+            case .CUR: newPosition = pos + Int(offset)
+            case .END: newPosition = prep.byteCount + Int(offset)
             }
-
-        case .handle(let handle):
-            let platformWhence: FileDescriptor.SeekOrigin
-            switch whence {
-            case .SET:
-                platformWhence = .start
-            case .CUR:
-                platformWhence = .current
-            case .END:
-                platformWhence = .end
+            guard newPosition >= 0 else {
+                throw WASIAbi.Errno.EINVAL
             }
-            let result = try handle.seek(offset: offset, from: platformWhence)
-            position = Int(result)
-            return WASIAbi.FileSize(result)
+            pos = newPosition
+            return WASIAbi.FileSize(newPosition)
         }
-
-        guard newPosition >= 0 else {
-            throw WASIAbi.Errno.EINVAL
-        }
-
-        position = newPosition
-        return WASIAbi.FileSize(newPosition)
     }
 
     func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
-
-        var totalWritten: UInt32 = 0
-
-        switch fileNode.content {
-        case .bytes:
-            fileSystem.withTreeLock {
-                guard case .bytes(var bytes) = fileNode.content else { return }
-                var currentPosition = position
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                        let bytesToWrite = bufferPtr.count
-                        let requiredSize = currentPosition + bytesToWrite
-
-                        if requiredSize > bytes.count {
-                            bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
-                        }
-
-                        bytes.replaceSubrange(currentPosition..<(currentPosition + bytesToWrite), with: bufferPtr)
-                        currentPosition += bytesToWrite
-                        totalWritten += UInt32(bytesToWrite)
-                    }
-                }
-                fileNode.content = .bytes(bytes)
-                position = currentPosition
-                fileNode.touchModificationTime()
-            }
-
-        case .handle(let handle):
-            var currentOffset = Int64(position)
-            for iovec in buffer {
-                let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
-                }
-                currentOffset += Int64(nwritten)
-                totalWritten += UInt32(nwritten)
-            }
-            position = Int(currentOffset)
+        return try position.withLock { pos in
+            let result = try fileNode.write(vectored: buffer, memory: memory, position: pos)
+            pos = result.newPosition
+            return result.count
         }
-
-        return totalWritten
     }
 
     func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
-
-        var totalWritten: UInt32 = 0
-
-        switch fileNode.content {
-        case .bytes:
-            fileSystem.withTreeLock {
-                guard case .bytes(var bytes) = fileNode.content else { return }
-                var currentOffset = Int(offset)
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                        let bytesToWrite = bufferPtr.count
-                        let requiredSize = currentOffset + bytesToWrite
-
-                        if requiredSize > bytes.count {
-                            bytes.append(contentsOf: Array(repeating: 0, count: requiredSize - bytes.count))
-                        }
-
-                        bytes.replaceSubrange(currentOffset..<(currentOffset + bytesToWrite), with: bufferPtr)
-                        currentOffset += bytesToWrite
-                        totalWritten += UInt32(bytesToWrite)
-                    }
-                }
-                fileNode.content = .bytes(bytes)
-                fileNode.touchModificationTime()
-            }
-
-        case .handle(let handle):
-            var currentOffset = Int64(offset)
-            for iovec in buffer {
-                let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
-                }
-                currentOffset += Int64(nwritten)
-                totalWritten += UInt32(nwritten)
-            }
-        }
-
-        return totalWritten
+        return try fileNode.pwrite(vectored: buffer, memory: memory, offset: Int(offset))
     }
 
     func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
-
-        var totalRead: UInt32 = 0
-
-        switch fileNode.content {
-        case .bytes:
-            fileSystem.withTreeLock {
-                guard case .bytes(let bytes) = fileNode.content else { return }
-                var currentPosition = position
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                        let available = max(0, bytes.count - currentPosition)
-                        let toRead = min(bufferPtr.count, available)
-
-                        guard toRead > 0 else { return }
-
-                        bytes.withUnsafeBytes { contentBytes in
-                            let sourcePtr = contentBytes.baseAddress!.advanced(by: currentPosition)
-                            bufferPtr.baseAddress!.copyMemory(from: sourcePtr, byteCount: toRead)
-                        }
-
-                        currentPosition += toRead
-                        totalRead += UInt32(toRead)
-                    }
-                }
-                position = currentPosition
-                fileNode.touchAccessTime()
-            }
-
-        case .handle(let handle):
-            var currentOffset = Int64(position)
-            for iovec in buffer {
-                let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
-                }
-                currentOffset += Int64(nread)
-                totalRead += UInt32(nread)
-            }
-            position = Int(currentOffset)
+        return try position.withLock { pos in
+            let result = try fileNode.read(into: buffer, memory: memory, position: pos)
+            pos = result.newPosition
+            return result.count
         }
-
-        return totalRead
     }
 
     func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
-
-        var totalRead: UInt32 = 0
-
-        switch fileNode.content {
-        case .bytes:
-            fileSystem.withTreeLock {
-                guard case .bytes(let bytes) = fileNode.content else { return }
-                var currentOffset = Int(offset)
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                        let available = max(0, bytes.count - currentOffset)
-                        let toRead = min(bufferPtr.count, available)
-
-                        guard toRead > 0 else { return }
-
-                        bytes.withUnsafeBytes { contentBytes in
-                            let sourcePtr = contentBytes.baseAddress!.advanced(by: currentOffset)
-                            bufferPtr.baseAddress!.copyMemory(from: sourcePtr, byteCount: toRead)
-                        }
-
-                        currentOffset += toRead
-                        totalRead += UInt32(toRead)
-                    }
-                }
-                fileNode.touchAccessTime()
-            }
-
-        case .handle(let handle):
-            var currentOffset = Int64(offset)
-            for iovec in buffer {
-                let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
-                    try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
-                }
-                currentOffset += Int64(nread)
-                totalRead += UInt32(nread)
-            }
-        }
-
-        return totalRead
+        return try fileNode.pread(into: buffer, memory: memory, offset: Int(offset))
     }
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryFileSystem.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileSystem.swift
@@ -1,4 +1,3 @@
-import Synchronization
 import SystemPackage
 
 /// An in-memory file system implementation for WASI environments.
@@ -21,28 +20,22 @@ import SystemPackage
 public final class MemoryFileSystem: FileSystemImplementation, Sendable {
     private static let rootPath = "/"
 
-    private let root: Mutex<MemoryDirectoryNode>
+    /// The directory tree. Synchronization lives in the nodes, so the file system
+    /// needs no lock of its own.
+    private let root: MemoryDirectoryNode
 
     /// Creates a new in-memory file system.
     public init() throws {
-        self.root = Mutex(MemoryDirectoryNode())
+        self.root = MemoryDirectoryNode()
     }
 
-    // MARK: - Tree Lock
-
-    /// Acquires the tree-wide lock for use by MemoryDirEntry / MemoryFileEntry.
-    /// All node mutations must be performed under this lock.
-    func withTreeLock<R>(_ body: () throws -> R) rethrows -> R {
-        try root.withLock { _ in try body() }
-    }
-
-    // MARK: - Static Unlocked Helpers (must be called under root lock)
+    // MARK: - Tree Helpers
     //
-    // These are static to avoid capturing `self` inside Mutex.withLock closures,
-    // which would connect the `inout sending` lock parameter to the task-isolated
-    // `self` region and violate region isolation constraints.
+    // Each structural step is atomic on the node it touches, but a multi-node
+    // operation (e.g. rename across directories) is a sequence of such steps, not
+    // one critical section: a concurrent observer can briefly see an intermediate
+    // tree, though the moved node is held by reference and never lost.
 
-    /// Traverses the tree from `root` to `path`. Must be called under root lock.
     private static func lookupNode(from root: MemoryDirectoryNode, at path: String) -> MemFSNode? {
         let normalized = normalizePath(path)
         if normalized == Self.rootPath {
@@ -65,7 +58,6 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
         return current
     }
 
-    /// Resolves a relative path from a directory node. Must be called under root lock.
     private static func resolveNode(root: MemoryDirectoryNode, from directory: MemoryDirectoryNode, at directoryPath: String, path relativePath: String) -> MemFSNode? {
         if relativePath.isEmpty {
             return directory
@@ -75,12 +67,7 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
             return lookupNode(from: root, at: relativePath)
         }
 
-        let fullPath: String
-        if directoryPath == Self.rootPath {
-            fullPath = Self.rootPath + relativePath
-        } else {
-            fullPath = directoryPath + "/" + relativePath
-        }
+        let fullPath = joinGuestPath(directoryPath, relativePath)
 
         let components = fullPath.split(separator: "/").map(String.init)
         var stack: [String] = []
@@ -101,7 +88,7 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
         return lookupNode(from: root, at: resolvedPath)
     }
 
-    /// Ensures all directory components exist. Must be called under root lock.
+    @discardableResult
     private static func ensureDirectoryNode(from root: MemoryDirectoryNode, at path: String) throws -> MemoryDirectoryNode {
         let normalized = normalizePath(path)
         if normalized == Self.rootPath {
@@ -110,24 +97,12 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
 
         let components = normalized.split(separator: "/").map(String.init)
         var current = root
-
         for component in components {
-            if let existing = current.getChild(name: component) {
-                guard let dir = existing as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-                current = dir
-            } else {
-                let newDir = MemoryDirectoryNode()
-                current.setChild(name: component, node: newDir)
-                current = newDir
-            }
+            current = try current.getOrCreateChildDirectory(name: component)
         }
-
         return current
     }
 
-    /// Must be called under root lock.
     @discardableResult
     private static func createFileNode(in directory: MemoryDirectoryNode, at relativePath: String, oflags: WASIAbi.Oflags) throws -> MemoryFileNode {
         try validateRelativePath(relativePath)
@@ -138,20 +113,11 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
         }
 
         let parentDir = try traverseToParent(from: directory, components: Array(components.dropLast()))
-
-        if let existing = parentDir.getChild(name: fileName) {
-            guard let fileNode = existing as? MemoryFileNode else {
-                throw WASIAbi.Errno.EISDIR
-            }
-            if oflags.contains(.TRUNC) {
-                fileNode.content = .bytes([])
-            }
-            return fileNode
-        } else {
-            let fileNode = MemoryFileNode(bytes: [])
-            parentDir.setChild(name: fileName, node: fileNode)
-            return fileNode
+        let fileNode = try parentDir.getOrCreateChildFile(name: fileName)
+        if oflags.contains(.TRUNC) {
+            fileNode.truncateToEmpty()
         }
+        return fileNode
     }
 
     private static func validateRelativePath(_ path: String) throws {
@@ -163,16 +129,7 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
     private static func traverseToParent(from directory: MemoryDirectoryNode, components: [String]) throws -> MemoryDirectoryNode {
         var current = directory
         for component in components {
-            if let existing = current.getChild(name: component) {
-                guard let dir = existing as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-                current = dir
-            } else {
-                let newDir = MemoryDirectoryNode()
-                current.setChild(name: component, node: newDir)
-                current = newDir
-            }
+            current = try current.getOrCreateChildDirectory(name: component)
         }
         return current
     }
@@ -180,75 +137,48 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
     // MARK: - Public API
 
     /// Adds a file to the file system with the given byte content.
-    ///
-    /// - Parameters:
-    ///   - path: The path where the file should be created
-    ///   - content: The file content as a sequence of bytes
     public func addFile(at path: String, content: some Sequence<UInt8>) throws {
         let normalized = Self.normalizePath(path)
         let (parentPath, fileName) = try Self.splitPath(normalized)
-        let bytes = Array(content)
-
-        try root.withLock { root in
-            let parent = try Self.ensureDirectoryNode(from: root, at: parentPath)
-            parent.setChild(name: fileName, node: MemoryFileNode(content: .bytes(bytes)))
-        }
+        let parent = try Self.ensureDirectoryNode(from: root, at: parentPath)
+        parent.setChild(name: fileName, node: MemoryFileNode(content: .bytes(Array(content))))
     }
 
     /// Adds a file to the file system with the given string content.
-    ///
-    /// - Parameters:
-    ///   - path: The path where the file should be created
-    ///   - content: The file content as string (converted to UTF-8)
     public func addFile(at path: String, content: String) throws {
         try addFile(at: path, content: content.utf8)
     }
 
     /// Adds a file to the file system backed by a file descriptor.
-    ///
-    /// - Parameters:
-    ///   - path: The path where the file should be created
-    ///   - handle: The file descriptor handle
     public func addFile(at path: String, handle: FileDescriptor) throws {
         let normalized = Self.normalizePath(path)
         let (parentPath, fileName) = try Self.splitPath(normalized)
-
-        try root.withLock { root in
-            let parent = try Self.ensureDirectoryNode(from: root, at: parentPath)
-            parent.setChild(name: fileName, node: MemoryFileNode(handle: handle))
-        }
+        let parent = try Self.ensureDirectoryNode(from: root, at: parentPath)
+        parent.setChild(name: fileName, node: MemoryFileNode(handle: handle))
     }
 
     /// Gets the content of a file at the specified path.
-    ///
-    /// - Parameter path: The path of the file to retrieve
-    /// - Returns: The file content
     public func getFile(at path: String) throws -> FileContent {
-        try root.withLock { root in
-            guard let node = Self.lookupNode(from: root, at: path) else {
-                throw WASIAbi.Errno.ENOENT
-            }
-            guard let fileNode = node as? MemoryFileNode else {
-                throw WASIAbi.Errno.EISDIR
-            }
-            return fileNode.content
+        guard let node = Self.lookupNode(from: root, at: path) else {
+            throw WASIAbi.Errno.ENOENT
         }
+        guard let fileNode = node as? MemoryFileNode else {
+            throw WASIAbi.Errno.EISDIR
+        }
+        return fileNode.content
     }
 
-    /// Removes a file from the file system.
-    ///
-    /// - Parameter path: The path of the file to remove
+    /// Removes a file. A currently-open fd to the removed file keeps working until
+    /// its last close: the open `MemoryFileEntry` holds the node by reference, so
+    /// unlinking only drops the directory edge.
     public func removeFile(at path: String) throws {
         let normalized = Self.normalizePath(path)
         let (parentPath, fileName) = try Self.splitPath(normalized)
-
-        try root.withLock { root in
-            guard let parent = Self.lookupNode(from: root, at: parentPath) as? MemoryDirectoryNode else {
-                throw WASIAbi.Errno.ENOENT
-            }
-            guard parent.removeChild(name: fileName) else {
-                throw WASIAbi.Errno.ENOENT
-            }
+        guard let parent = Self.lookupNode(from: root, at: parentPath) as? MemoryDirectoryNode else {
+            throw WASIAbi.Errno.ENOENT
+        }
+        guard parent.removeChild(name: fileName) else {
+            throw WASIAbi.Errno.ENOENT
         }
     }
 
@@ -256,13 +186,7 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
 
     func preopenDirectory(guestPath: String, hostPath: String) throws -> any WASIDir {
         let node = try ensureDirectory(at: guestPath)
-
-        return MemoryDirEntry(
-            preopenPath: guestPath,
-            dirNode: node,
-            path: guestPath,
-            fileSystem: self
-        )
+        return MemoryDirEntry(preopenPath: guestPath, dirNode: node, path: guestPath, fileSystem: self)
     }
 
     func openAt(
@@ -278,204 +202,195 @@ public final class MemoryFileSystem: FileSystemImplementation, Sendable {
             throw WASIAbi.Errno.EBADF
         }
 
-        // Extract Sendable values before the lock closure to avoid capturing
-        // non-Sendable MemoryDirEntry in the lock's region.
         let dirPath = memoryDir.path
-        let fullPath = dirPath.hasSuffix("/") ? dirPath + path : dirPath + "/" + path
+        let fullPath = Self.joinGuestPath(dirPath, path)
 
-        return try root.withLock { root in
-            // Re-resolve the directory from root using the path
-            guard let dirNode = Self.lookupNode(from: root, at: dirPath) as? MemoryDirectoryNode else {
+        guard let dirNode = Self.lookupNode(from: root, at: dirPath) as? MemoryDirectoryNode else {
+            throw WASIAbi.Errno.EBADF
+        }
+
+        var node = Self.resolveNode(root: root, from: dirNode, at: dirPath, path: path)
+
+        if node != nil {
+            if oflags.contains(.EXCL) && oflags.contains(.CREAT) {
+                throw WASIAbi.Errno.EEXIST
+            }
+        } else {
+            if oflags.contains(.CREAT) {
+                node = try Self.createFileNode(in: dirNode, at: path, oflags: oflags)
+            } else {
+                throw WASIAbi.Errno.ENOENT
+            }
+        }
+
+        guard let resolvedNode = node else {
+            throw WASIAbi.Errno.ENOENT
+        }
+
+        if oflags.contains(.DIRECTORY) {
+            guard resolvedNode.type == .directory else {
+                throw WASIAbi.Errno.ENOTDIR
+            }
+        }
+
+        if resolvedNode.type == .directory {
+            guard let dirNode = resolvedNode as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOTDIR
+            }
+            return .directory(
+                MemoryDirEntry(preopenPath: nil, dirNode: dirNode, path: fullPath, fileSystem: self))
+        }
+
+        if resolvedNode.type == .file {
+            guard let fileNode = resolvedNode as? MemoryFileNode else {
                 throw WASIAbi.Errno.EBADF
             }
 
-            var node = Self.resolveNode(root: root, from: dirNode, at: dirPath, path: path)
-
-            if node != nil {
-                if oflags.contains(.EXCL) && oflags.contains(.CREAT) {
-                    throw WASIAbi.Errno.EEXIST
-                }
-            } else {
-                if oflags.contains(.CREAT) {
-                    node = try Self.createFileNode(in: dirNode, at: path, oflags: oflags)
-                } else {
-                    throw WASIAbi.Errno.ENOENT
-                }
+            if oflags.contains(.TRUNC) && fsRightsBase.contains(.FD_WRITE) {
+                fileNode.truncateToEmpty()
             }
 
-            guard let resolvedNode = node else {
-                throw WASIAbi.Errno.ENOENT
+            var accessMode: FileAccessMode = []
+            if fsRightsBase.contains(.FD_READ) {
+                accessMode.insert(.read)
+            }
+            if fsRightsBase.contains(.FD_WRITE) {
+                accessMode.insert(.write)
             }
 
-            if oflags.contains(.DIRECTORY) {
-                guard resolvedNode.type == .directory else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-            }
-
-            if resolvedNode.type == .directory {
-                guard let dirNode = resolvedNode as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-                return .directory(
-                    MemoryDirEntry(
-                        preopenPath: nil,
-                        dirNode: dirNode,
-                        path: fullPath,
-                        fileSystem: self
-                    ))
-            }
-
-            if resolvedNode.type == .file {
-                guard let fileNode = resolvedNode as? MemoryFileNode else {
-                    throw WASIAbi.Errno.EBADF
-                }
-
-                if oflags.contains(.TRUNC) && fsRightsBase.contains(.FD_WRITE) {
-                    fileNode.content = .bytes([])
-                }
-
-                var accessMode: FileAccessMode = []
-                if fsRightsBase.contains(.FD_READ) {
-                    accessMode.insert(.read)
-                }
-                if fsRightsBase.contains(.FD_WRITE) {
-                    accessMode.insert(.write)
-                }
-
-                return .file(MemoryFileEntry(fileNode: fileNode, fileSystem: self, accessMode: accessMode, position: 0))
-            }
-
-            if resolvedNode.type == .characterDevice {
-                guard let deviceNode = resolvedNode as? MemoryCharacterDeviceNode else {
-                    throw WASIAbi.Errno.EBADF
-                }
-
-                var accessMode: FileAccessMode = []
-                if fsRightsBase.contains(.FD_READ) {
-                    accessMode.insert(.read)
-                }
-                if fsRightsBase.contains(.FD_WRITE) {
-                    accessMode.insert(.write)
-                }
-
-                return .file(MemoryCharacterDeviceEntry(deviceNode: deviceNode, accessMode: accessMode))
-            }
-
-            throw WASIAbi.Errno.ENOTSUP
+            return .file(MemoryFileEntry(fileNode: fileNode, fileSystem: self, accessMode: accessMode, position: 0))
         }
+
+        if resolvedNode.type == .characterDevice {
+            guard let deviceNode = resolvedNode as? MemoryCharacterDeviceNode else {
+                throw WASIAbi.Errno.EBADF
+            }
+
+            var accessMode: FileAccessMode = []
+            if fsRightsBase.contains(.FD_READ) {
+                accessMode.insert(.read)
+            }
+            if fsRightsBase.contains(.FD_WRITE) {
+                accessMode.insert(.write)
+            }
+
+            return .file(MemoryCharacterDeviceEntry(deviceNode: deviceNode, accessMode: accessMode))
+        }
+
+        throw WASIAbi.Errno.ENOTSUP
     }
 
     // MARK: - File Operations
 
     func lookup(at path: String) -> MemFSNode? {
-        root.withLock { root in
-            Self.lookupNode(from: root, at: path)
-        }
+        Self.lookupNode(from: root, at: path)
     }
 
-    func resolve(at directoryPath: String, path relativePath: String) -> MemFSNode? {
-        root.withLock { root in
-            guard let directory = Self.lookupNode(from: root, at: directoryPath) as? MemoryDirectoryNode else {
-                return nil
-            }
-            return Self.resolveNode(root: root, from: directory, at: directoryPath, path: relativePath)
+    /// The type of the node reached by resolving `relativePath` from `directoryPath`.
+    func resolveType(at directoryPath: String, path relativePath: String) -> MemFSNodeType? {
+        guard let directory = Self.lookupNode(from: root, at: directoryPath) as? MemoryDirectoryNode else {
+            return nil
         }
+        return Self.resolveNode(root: root, from: directory, at: directoryPath, path: relativePath)?.type
+    }
+
+    /// The type of the node at `path`, or nil if nothing is there.
+    func nodeType(at path: String) -> MemFSNodeType? {
+        Self.lookupNode(from: root, at: path)?.type
     }
 
     @discardableResult
     package func ensureDirectory(at path: String) throws -> MemoryDirectoryNode {
-        try root.withLock { root in
-            try Self.ensureDirectoryNode(from: root, at: path)
-        }
+        try Self.ensureDirectoryNode(from: root, at: path)
     }
 
     /// Remove a node relative to the directory at `directoryPath`.
-    /// Accepts paths (Sendable) rather than node references to satisfy
-    /// Mutex.withLock's `inout sending` constraint.
     func removeNode(at directoryPath: String, relativePath: String, mustBeDirectory: Bool) throws {
-        try root.withLock { root in
-            guard let directory = Self.lookupNode(from: root, at: directoryPath) as? MemoryDirectoryNode else {
-                throw WASIAbi.Errno.ENOENT
-            }
-
-            try Self.validateRelativePath(relativePath)
-
-            let components = relativePath.split(separator: "/").map(String.init)
-            guard let fileName = components.last else {
-                throw WASIAbi.Errno.EINVAL
-            }
-
-            var current = directory
-            for component in components.dropLast() {
-                guard let next = current.getChild(name: component) as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOENT
-                }
-                current = next
-            }
-
-            guard let node = current.getChild(name: fileName) else {
-                throw WASIAbi.Errno.ENOENT
-            }
-
-            if mustBeDirectory {
-                guard let dirNode = node as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOTDIR
-                }
-                if dirNode.childCount() > 0 {
-                    throw WASIAbi.Errno.ENOTEMPTY
-                }
-            } else {
-                if node.type == .directory {
-                    throw WASIAbi.Errno.EISDIR
-                }
-            }
-
-            current.removeChild(name: fileName)
+        guard let directory = Self.lookupNode(from: root, at: directoryPath) as? MemoryDirectoryNode else {
+            throw WASIAbi.Errno.ENOENT
         }
+
+        try Self.validateRelativePath(relativePath)
+
+        let components = relativePath.split(separator: "/").map(String.init)
+        guard let fileName = components.last else {
+            throw WASIAbi.Errno.EINVAL
+        }
+
+        var current = directory
+        for component in components.dropLast() {
+            guard let next = current.getChild(name: component) as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOENT
+            }
+            current = next
+        }
+
+        guard let node = current.getChild(name: fileName) else {
+            throw WASIAbi.Errno.ENOENT
+        }
+
+        if mustBeDirectory {
+            guard let dirNode = node as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOTDIR
+            }
+            if dirNode.childCount() > 0 {
+                throw WASIAbi.Errno.ENOTEMPTY
+            }
+        } else {
+            if node.type == .directory {
+                throw WASIAbi.Errno.EISDIR
+            }
+        }
+
+        current.removeChild(name: fileName)
     }
 
     /// Rename a node from `sourcePath` (relative to `sourceDirectoryPath`) to
     /// `destPath` (relative to `destDirectoryPath`).
     func rename(from sourcePath: String, at sourceDirectoryPath: String, to destPath: String, at destDirectoryPath: String) throws {
-        try root.withLock { root in
-            guard let sourceDir = Self.lookupNode(from: root, at: sourceDirectoryPath) as? MemoryDirectoryNode else {
-                throw WASIAbi.Errno.ENOENT
-            }
-            guard let destDir = Self.lookupNode(from: root, at: destDirectoryPath) as? MemoryDirectoryNode else {
-                throw WASIAbi.Errno.ENOENT
-            }
-
-            guard let sourceNode = Self.resolveNode(root: root, from: sourceDir, at: sourceDirectoryPath, path: sourcePath) else {
-                throw WASIAbi.Errno.ENOENT
-            }
-
-            let destComponents = destPath.split(separator: "/").map(String.init)
-            guard let destFileName = destComponents.last else {
-                throw WASIAbi.Errno.EINVAL
-            }
-
-            let destParentDir = try Self.traverseToParent(from: destDir, components: Array(destComponents.dropLast()))
-
-            let sourceComponents = sourcePath.split(separator: "/").map(String.init)
-            guard let sourceFileName = sourceComponents.last else {
-                throw WASIAbi.Errno.EINVAL
-            }
-
-            var sourceParentDir = sourceDir
-            for component in sourceComponents.dropLast() {
-                guard let next = sourceParentDir.getChild(name: component) as? MemoryDirectoryNode else {
-                    throw WASIAbi.Errno.ENOENT
-                }
-                sourceParentDir = next
-            }
-
-            sourceParentDir.removeChild(name: sourceFileName)
-            destParentDir.setChild(name: destFileName, node: sourceNode)
+        guard let sourceDir = Self.lookupNode(from: root, at: sourceDirectoryPath) as? MemoryDirectoryNode else {
+            throw WASIAbi.Errno.ENOENT
         }
+        guard let destDir = Self.lookupNode(from: root, at: destDirectoryPath) as? MemoryDirectoryNode else {
+            throw WASIAbi.Errno.ENOENT
+        }
+
+        guard let sourceNode = Self.resolveNode(root: root, from: sourceDir, at: sourceDirectoryPath, path: sourcePath) else {
+            throw WASIAbi.Errno.ENOENT
+        }
+
+        let destComponents = destPath.split(separator: "/").map(String.init)
+        guard let destFileName = destComponents.last else {
+            throw WASIAbi.Errno.EINVAL
+        }
+
+        let destParentDir = try Self.traverseToParent(from: destDir, components: Array(destComponents.dropLast()))
+
+        let sourceComponents = sourcePath.split(separator: "/").map(String.init)
+        guard let sourceFileName = sourceComponents.last else {
+            throw WASIAbi.Errno.EINVAL
+        }
+
+        var sourceParentDir = sourceDir
+        for component in sourceComponents.dropLast() {
+            guard let next = sourceParentDir.getChild(name: component) as? MemoryDirectoryNode else {
+                throw WASIAbi.Errno.ENOENT
+            }
+            sourceParentDir = next
+        }
+
+        sourceParentDir.removeChild(name: sourceFileName)
+        destParentDir.setChild(name: destFileName, node: sourceNode)
     }
 
     // MARK: - Private Helpers
+
+    /// Joins a base guest path and a relative component with a single "/".
+    /// `relative` must be non-empty and must not start with "/" — callers guarantee this;
+    /// an empty `relative` would leave a trailing slash and an absolute one a doubled "//".
+    package static func joinGuestPath(_ base: String, _ relative: String) -> String {
+        base.hasSuffix("/") ? base + relative : base + "/" + relative
+    }
 
     private static func normalizePath(_ path: String) -> String {
         if path.isEmpty {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1860,18 +1860,10 @@ final class WASIImplementation: Sendable {
 
     /// Open a file or directory.
     ///
-    /// The lookup, open, and push are done in a single lock scope so that the
-    /// new entry (which contains non-Sendable existentials) is created inside
-    /// the closure, satisfying Mutex's `sending` contract. The openAt call is
-    /// non-blocking (opens a host fd or traverses an in-memory tree).
-    ///
-    /// - Note: This holds the fdTable lock during `fileSystem.openAt()`, which
-    ///   performs `openat(2)` + `fstat(2)` for `HostFileSystem`. These are
-    ///   normally sub-millisecond on local filesystems but can block on network
-    ///   mounts (NFS, FUSE). In a multi-threaded WASI context, this means all
-    ///   fd operations on all threads stall during any single `path_open`. A
-    ///   two-phase approach (reserve fd slot under lock, fill entry separately)
-    ///   would reduce contention but requires FdTable to support reserved slots.
+    /// Lookup, open, and push share one `fdTable` lock scope: the new entry holds
+    /// non-Sendable existentials, so it must be built inside the closure to satisfy
+    /// the lock's `sending` requirement. A full table is rejected before the open,
+    /// so a successful open is never orphaned by a failing install.
     func path_open(
         dirFd: WASIAbi.Fd,
         dirFlags: WASIAbi.LookupFlags,
@@ -1884,6 +1876,9 @@ final class WASIImplementation: Sendable {
         try fdTable.withLock { table in
             guard case .directory(let dirEntry) = table[dirFd] else {
                 throw WASIAbi.Errno.ENOTDIR
+            }
+            guard table.hasCapacity else {
+                throw WASIAbi.Errno.ENFILE
             }
             let newEntry = try fileSystem.openAt(
                 dirFd: dirEntry,

--- a/Tests/WASITests/GuestPathJoinTests.swift
+++ b/Tests/WASITests/GuestPathJoinTests.swift
@@ -1,5 +1,4 @@
 import Testing
-
 import WASI
 
 @Test func joinGuestPathContract() {

--- a/Tests/WASITests/GuestPathJoinTests.swift
+++ b/Tests/WASITests/GuestPathJoinTests.swift
@@ -1,0 +1,9 @@
+import Testing
+
+import WASI
+
+@Test func joinGuestPathContract() {
+    #expect(MemoryFileSystem.joinGuestPath("/", "f.txt") == "/f.txt")  // root base
+    #expect(MemoryFileSystem.joinGuestPath("/a", "b") == "/a/b")  // common case
+    #expect(MemoryFileSystem.joinGuestPath("/sandbox/", "foo") == "/sandbox/foo")  // trailing-slash base collapses to one "/"
+}

--- a/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
+++ b/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
@@ -1,6 +1,5 @@
-import Testing
-
 import SystemExtras
+import Testing
 
 @testable import WASI
 

--- a/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
+++ b/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
@@ -1,5 +1,7 @@
 import Testing
 
+import SystemExtras
+
 @testable import WASI
 
 @Suite struct MemoryFileSystemConcurrencyTests {
@@ -114,6 +116,140 @@ import Testing
         } catch {
             try bridge.close()
             throw error
+        }
+    }
+
+    // MARK: - Node lifetime (unlink-while-open, shared content, reclaim stress)
+    //
+    // A node's lifetime is governed by ARC: an open `MemoryFileEntry` holds it by
+    // reference, so unlinking only drops the directory edge and the node is freed
+    // once the last fd closes. These tests assert that contract via `weak` references.
+
+    /// An fd opened before its file is unlinked keeps working until it is closed,
+    /// and the node is reclaimed by ARC on last close.
+    @Test func unlinkWhileOpenReclaimsViaARC() throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/")
+        try fs.addFile(at: "/f.txt", content: Array("WORLD".utf8))
+
+        // Weak reference to the node: it must stay alive while an fd holds it and
+        // be reclaimed once unlinked and closed.
+        weak let weakNode = fs.lookup(at: "/f.txt") as? MemoryFileNode
+        #expect(weakNode != nil)
+
+        let bridge = try WASIBridgeToHost(
+            fileSystem: .memory(fs).withPreopens([.init(guestPath: "/", hostPath: "/")])
+        )
+        try bridge.runAndClose { _ in
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
+
+            let fd = try wasi.path_open(
+                dirFd: rootFd, dirFlags: [], path: "f.txt", oflags: [],
+                fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+            )
+
+            // Unlink while the fd is open.
+            try wasi.path_unlink_file(dirFd: rootFd, path: "f.txt")
+
+            // The directory edge is gone...
+            #expect(fs.nodeType(at: "/f.txt") == nil)
+
+            // ...but the open fd still resolves its node: fd_filestat_get succeeds
+            // and reports the original content size.
+            let stat = try wasi.fd_filestat_get(fd: fd)
+            #expect(stat.filetype == .REGULAR_FILE)
+            #expect(stat.size == 5)
+            #expect(weakNode != nil)  // the open fd keeps the node alive
+
+            // Last close drops the only remaining reference: ARC reclaims the node,
+            // and a fresh open is then ENOENT.
+            try wasi.fd_close(fd: fd)
+            #expect(weakNode == nil)
+            #expect(throws: WASIAbi.Errno.ENOENT) {
+                _ = try wasi.path_open(
+                    dirFd: rootFd, dirFlags: [], path: "f.txt", oflags: [],
+                    fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+                )
+            }
+        }
+    }
+
+    /// Two fds to the same path share the underlying node (same size) but have
+    /// independent positions.
+    @Test func sharedContentAcrossFds() throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/")
+        try fs.addFile(at: "/s.txt", content: Array("abcdefg".utf8))  // size 7
+
+        let bridge = try WASIBridgeToHost(
+            fileSystem: .memory(fs).withPreopens([.init(guestPath: "/", hostPath: "/")])
+        )
+        try bridge.runAndClose { _ in
+            let wasi = bridge.underlying
+            let rootFd: WASIAbi.Fd = 3
+            let rights: WASIAbi.Rights = [.FD_READ, .FD_SEEK, .FD_TELL]
+
+            let fd1 = try wasi.path_open(dirFd: rootFd, dirFlags: [], path: "s.txt", oflags: [], fsRightsBase: rights, fsRightsInheriting: [], fdflags: [])
+            let fd2 = try wasi.path_open(dirFd: rootFd, dirFlags: [], path: "s.txt", oflags: [], fsRightsBase: rights, fsRightsInheriting: [], fdflags: [])
+
+            // Same underlying file → both report size 7.
+            #expect(try wasi.fd_filestat_get(fd: fd1).size == 7)
+            #expect(try wasi.fd_filestat_get(fd: fd2).size == 7)
+
+            // Independent positions.
+            _ = try wasi.fd_seek(fd: fd1, offset: 0, whence: .END)
+            #expect(try wasi.fd_tell(fd: fd1) == 7)
+            #expect(try wasi.fd_tell(fd: fd2) == 0)
+
+            try wasi.fd_close(fd: fd1)
+            try wasi.fd_close(fd: fd2)
+        }
+    }
+
+    /// Stress the open/unlink/recreate/close transitions concurrently. A
+    /// `fd_filestat_get` through a still-open fd must never spuriously fail with
+    /// EBADF, and the run must complete without crash or corruption.
+    @Test func concurrentOpenUnlinkRecreate() async throws {
+        let fs = try MemoryFileSystem()
+        try fs.ensureDirectory(at: "/")
+        let path = "/race.txt"
+        try fs.addFile(at: path, content: Array("seed".utf8))
+
+        let bridge = try WASIBridgeToHost(
+            fileSystem: .memory(fs).withPreopens([.init(guestPath: "/", hostPath: "/")])
+        )
+        let wasi = bridge.underlying
+        let rootFd: WASIAbi.Fd = 3
+
+        try await withAsyncThrowing {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for t in 0..<8 {
+                    group.addTask {
+                        for i in 0..<100 {
+                            switch (t + i) % 3 {
+                            case 0:
+                                // ENOENT (file currently unlinked) is fine; but an
+                                // open fd must never see EBADF from fd_filestat_get.
+                                if let fd = try? wasi.path_open(
+                                    dirFd: rootFd, dirFlags: [], path: "race.txt", oflags: [],
+                                    fsRightsBase: [.FD_READ], fsRightsInheriting: [], fdflags: []
+                                ) {
+                                    _ = try wasi.fd_filestat_get(fd: fd)
+                                    try wasi.fd_close(fd: fd)
+                                }
+                            case 1:
+                                try? fs.removeFile(at: path)
+                            default:
+                                try? fs.addFile(at: path, content: Array("data".utf8))
+                            }
+                        }
+                    }
+                }
+                try await group.waitForAll()
+            }
+        } defer: {
+            try bridge.close()
         }
     }
 }

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -147,32 +147,25 @@ struct WASITests {
         _ = try fs.ensureDirectory(at: "/")
 
         try fs.addFile(at: "/hello.txt", content: Array("Hello, World!".utf8))
-        let node = fs.lookup(at: "/hello.txt")
-        #expect(node != nil)
-        #expect(node?.type == .file)
+        #expect(fs.nodeType(at: "/hello.txt") == .file)
 
-        guard let fileNode = node as? MemoryFileNode else {
-            #expect(Bool(false), "Expected FileNode")
-            return
-        }
-
-        guard case .bytes(let content) = fileNode.content else {
+        guard case .bytes(let content) = try fs.getFile(at: "/hello.txt") else {
             #expect(Bool(false), "Expected bytes content")
             return
         }
 
         #expect(content == Array("Hello, World!".utf8))
-        #expect(fileNode.size == 13)
+        #expect(content.count == 13)
 
         try fs.ensureDirectory(at: "/dir/subdir")
-        #expect(fs.lookup(at: "/dir") != nil)
-        #expect(fs.lookup(at: "/dir/subdir") != nil)
+        #expect(fs.nodeType(at: "/dir") != nil)
+        #expect(fs.nodeType(at: "/dir/subdir") != nil)
 
         try fs.addFile(at: "/dir/file.txt", content: Array("test".utf8))
-        #expect(fs.lookup(at: "/dir/file.txt") != nil)
+        #expect(fs.nodeType(at: "/dir/file.txt") != nil)
 
         try fs.removeFile(at: "/dir/file.txt")
-        #expect(fs.lookup(at: "/dir/file.txt") == nil)
+        #expect(fs.nodeType(at: "/dir/file.txt") == nil)
     }
 
     @Test
@@ -260,7 +253,7 @@ struct WASITests {
             let rootFd: WASIAbi.Fd = 3
 
             try wasi.path_create_directory(dirFd: rootFd, path: "newdir")
-            #expect(fs.lookup(at: "/newdir") != nil)
+            #expect(fs.nodeType(at: "/newdir") != nil)
 
             let dirStat = try wasi.path_filestat_get(dirFd: rootFd, flags: [], path: "newdir")
             #expect(dirStat.filetype == .DIRECTORY)
@@ -281,8 +274,8 @@ struct WASITests {
             try wasi.fd_close(fd: dirFd)
 
             try wasi.path_unlink_file(dirFd: rootFd, path: "newdir/file1.txt")
-            #expect(fs.lookup(at: "/newdir/file1.txt") == nil)
-            #expect(fs.lookup(at: "/newdir/file2.txt") != nil)
+            #expect(fs.nodeType(at: "/newdir/file1.txt") == nil)
+            #expect(fs.nodeType(at: "/newdir/file2.txt") != nil)
         }
     }
 
@@ -311,7 +304,7 @@ struct WASITests {
             )
             try wasi.fd_close(fd: fd1)
 
-            #expect(fs.lookup(at: "/created.txt") != nil)
+            #expect(fs.nodeType(at: "/created.txt") != nil)
 
             try fs.addFile(at: "/truncate.txt", content: Array("Long content here".utf8))
 
@@ -428,8 +421,8 @@ struct WASITests {
         }
         let wasi = try WASIBridgeToHost(fileSystem: .memory(fs).withPreopens(preopens))
         try wasi.runAndClose { _ in
-            #expect(fs.lookup(at: "/tmp") != nil)
-            #expect(fs.lookup(at: "/data") != nil)
+            #expect(fs.nodeType(at: "/tmp") != nil)
+            #expect(fs.nodeType(at: "/data") != nil)
         }
     }
 
@@ -489,14 +482,14 @@ struct WASITests {
 
         try fs.addFile(at: "/test.txt", content: [1, 2, 3])
 
-        #expect(fs.lookup(at: "/test.txt") != nil)
-        #expect(fs.lookup(at: "//test.txt") != nil)
-        #expect(fs.lookup(at: "/./test.txt") == nil)
+        #expect(fs.nodeType(at: "/test.txt") != nil)
+        #expect(fs.nodeType(at: "//test.txt") != nil)
+        #expect(fs.nodeType(at: "/./test.txt") == nil)
 
         try fs.ensureDirectory(at: "/a/b/c")
-        #expect(fs.lookup(at: "/a/b/c") != nil)
-        #expect(fs.lookup(at: "/a/b") != nil)
-        #expect(fs.lookup(at: "/a") != nil)
+        #expect(fs.nodeType(at: "/a/b/c") != nil)
+        #expect(fs.nodeType(at: "/a/b") != nil)
+        #expect(fs.nodeType(at: "/a") != nil)
     }
 
     @Test
@@ -505,16 +498,14 @@ struct WASITests {
         try fs.ensureDirectory(at: "/")
         try fs.ensureDirectory(at: "/dir")
         try fs.addFile(at: "/dir/file.txt", content: [])
-        let resolved = fs.resolve(at: "/dir", path: "file.txt")
-        #expect(resolved != nil)
-        #expect(resolved?.type == .file)
+        let resolved = fs.resolveType(at: "/dir", path: "file.txt")
+        #expect(resolved == .file)
 
-        let dotResolved = fs.resolve(at: "/dir", path: ".")
+        let dotResolved = fs.resolveType(at: "/dir", path: ".")
         #expect(dotResolved != nil)
 
-        let parentResolved = fs.resolve(at: "/dir", path: "..")
-        #expect(parentResolved != nil)
-        #expect(parentResolved?.type == .directory)
+        let parentResolved = fs.resolveType(at: "/dir", path: "..")
+        #expect(parentResolved == .directory)
     }
 
     @Test
@@ -881,8 +872,8 @@ struct WASITests {
                 newPath: "new.txt"
             )
 
-            #expect(fs.lookup(at: "/old.txt") == nil)
-            #expect(fs.lookup(at: "/new.txt") != nil)
+            #expect(fs.nodeType(at: "/old.txt") == nil)
+            #expect(fs.nodeType(at: "/new.txt") != nil)
 
             let content = try fs.getFile(at: "/new.txt")
             guard case .bytes(let bytes) = content else {
@@ -916,8 +907,8 @@ struct WASITests {
                 newPath: "subdir/moved.txt"
             )
 
-            #expect(fs.lookup(at: "/file.txt") == nil)
-            #expect(fs.lookup(at: "/subdir/moved.txt") != nil)
+            #expect(fs.nodeType(at: "/file.txt") == nil)
+            #expect(fs.nodeType(at: "/subdir/moved.txt") != nil)
         }
     }
 
@@ -937,7 +928,7 @@ struct WASITests {
             let rootFd: WASIAbi.Fd = 3
 
             try wasi.path_remove_directory(dirFd: rootFd, path: "emptydir")
-            #expect(fs.lookup(at: "/emptydir") == nil)
+            #expect(fs.nodeType(at: "/emptydir") == nil)
         }
     }
 
@@ -964,7 +955,7 @@ struct WASITests {
                 #expect(error == .ENOTEMPTY)
             }
 
-            #expect(fs.lookup(at: "/nonempty") != nil)
+            #expect(fs.nodeType(at: "/nonempty") != nil)
         }
     }
 


### PR DESCRIPTION
On `main` the in-memory WASI file system trips region-based isolation checks: one tree-wide `Mutex` forces node state out of the `withLock` closure, which the checker rejects. Each node now holds its own lock, so nothing non-`Sendable` escapes a lock boundary. Adds concurrency tests for unlink-while-open and fd leaks.