### PR TITLE
Add shared linear memory as prerequisite for `wasip1-threads`

### DIFF
--- a/Sources/WasmKit/CMakeLists.txt
+++ b/Sources/WasmKit/CMakeLists.txt
@@ -39,6 +39,7 @@ add_wasmkit_library(WasmKit
   Execution/NameRegistry.swift
   Execution/Profiler.swift
   Execution/Runtime.swift
+  Execution/SharedMemoryStorage.swift
   Execution/SignpostTracer.swift
   Execution/Store.swift
   Execution/StoreAllocator.swift

--- a/Sources/WasmKit/Execution/AtomicParkingLot.swift
+++ b/Sources/WasmKit/Execution/AtomicParkingLot.swift
@@ -1,175 +1,258 @@
 /// Synchronization primitives for atomic memory wait and notify operations.
 ///
 /// Provides thread-safe waiting and notification mechanisms for shared memory
-/// operations. The current implementation uses a simple mutex-protected queue
-/// with busy-waiting, but the interface is designed to allow future
-/// optimizations with more efficient blocking mechanisms.
+/// operations. Uses pthread condition variables for OS-level blocking.
 ///
 /// API design inspired by WebKit's ParkingLot:
 /// https://github.com/WebKit/WebKit/blob/main/Source/WTF/wtf/ParkingLot.h
 
 import Synchronization
 
-/// Represents a thread waiting on a memory address
-final class WaitingThread: @unchecked Sendable {
-    let isWoken: Atomic<Bool>
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
+/// Per-wait blocking context wrapping a pthread condvar + mutex pair.
+///
+/// A class because the same slot is referenced simultaneously from the
+/// registry (where `unpark` finds it) and the parked thread (blocking in
+/// `wait()`). `woken` is only accessed under `pthread_mutex_lock(mutex)`.
+final class BlockingSlot: @unchecked Sendable {
+    private let mutex: UnsafeMutablePointer<pthread_mutex_t>
+    private let cond: UnsafeMutablePointer<pthread_cond_t>
+    private var woken: Bool
 
     init() {
-        self.isWoken = Atomic(false)
+        mutex = .allocate(capacity: 1)
+        mutex.initialize(to: pthread_mutex_t())
+        pthread_mutex_init(mutex, nil)
+
+        cond = .allocate(capacity: 1)
+        cond.initialize(to: pthread_cond_t())
+        #if canImport(Darwin)
+            pthread_cond_init(cond, nil)
+        #else
+            var attr = pthread_condattr_t()
+            pthread_condattr_init(&attr)
+            pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)
+            pthread_cond_init(cond, &attr)
+            pthread_condattr_destroy(&attr)
+        #endif
+
+        woken = false
+    }
+
+    deinit {
+        pthread_cond_destroy(cond)
+        cond.deinitialize(count: 1)
+        cond.deallocate()
+
+        pthread_mutex_destroy(mutex)
+        mutex.deinitialize(count: 1)
+        mutex.deallocate()
+    }
+
+    /// Block until woken or timeout expires.
+    /// - Parameter timeoutNs: relative timeout in nanoseconds.
+    ///   `< 0` = wait indefinitely, `0` = return immediately, `> 0` = timed wait.
+    /// - Returns: `true` if woken by `wake()`, `false` if timed out.
+    func wait(timeoutNs: Int64) -> Bool {
+        pthread_mutex_lock(mutex)
+        defer { pthread_mutex_unlock(mutex) }
+
+        if timeoutNs == 0 {
+            return woken
+        }
+
+        if timeoutNs < 0 {
+            while !woken {
+                pthread_cond_wait(cond, mutex)
+            }
+            return true
+        }
+
+        var deadline = timespec()
+        #if canImport(Darwin)
+            clock_gettime(CLOCK_REALTIME, &deadline)
+        #else
+            clock_gettime(CLOCK_MONOTONIC, &deadline)
+        #endif
+        let extraSec = timeoutNs / 1_000_000_000
+        let extraNsec = timeoutNs % 1_000_000_000
+        deadline.tv_sec += Int(extraSec)
+        deadline.tv_nsec += Int(extraNsec)
+        if deadline.tv_nsec >= 1_000_000_000 {
+            deadline.tv_sec += 1
+            deadline.tv_nsec -= 1_000_000_000
+        }
+
+        while !woken {
+            let rc = pthread_cond_timedwait(cond, mutex, &deadline)
+            if rc == ETIMEDOUT { break }
+        }
+        return woken
+    }
+
+    /// Wake the thread blocked on this slot.
+    func wake() {
+        pthread_mutex_lock(mutex)
+        woken = true
+        pthread_cond_signal(cond)
+        pthread_mutex_unlock(mutex)
     }
 }
 
 /// Manages waiting threads for atomic memory operations.
-final class AtomicParkingLot {
-    /// Synchronized map from memory address to waiting threads
-    private let lock: Mutex<[UInt64: [WaitingThread]]>
+package final class AtomicParkingLot: Sendable {
+    private let registry: Mutex<[UInt64: [BlockingSlot]]>
+
+    #if DEBUG
+        /// Test-only hook fired inside `unpark` after the slots are removed and counted
+        /// (registry lock released) and before `wake()` runs, used to deterministically
+        /// exercise the timeout/notify race. Never set outside tests; compiled out of release.
+        let _afterDequeueBeforeWake = Mutex<(@Sendable () -> Void)?>(nil)
+    #endif
 
     init() {
-        self.lock = Mutex([:])
+        self.registry = Mutex([:])
     }
 
-    /// Parks the thread in a queue associated with the given address.
+    /// Parks the calling thread until woken, timed out, or validation fails.
     ///
-    /// The parking only succeeds if the validation function returns true while
-    /// the queue lock is held. If validation returns false, it will return
-    /// `.mismatch` without doing anything else.
-    ///
-    /// If validation returns true, it will enqueue the thread, unlock the
-    /// parking queue lock, and then sleep so long as the thread continues to be
-    /// on the queue and the timeout hasn't fired. Returns `.woken` if we
-    /// actually got unparked, `.timedOut` if the timeout was hit, or `.mismatch`
-    /// if validation failed.
-    ///
+    /// Validation runs twice: once before acquiring the registry lock (quick
+    /// path) and once while holding it (definitive check). If either returns
+    /// false, returns `.mismatch` without blocking.
     /// - Parameters:
-    ///   - address: Memory address to park on (cannot be null conceptually)
+    ///   - address: Memory address to park on
     ///   - validate: Closure that checks if the wait condition is still valid
     ///   - deadline: Optional deadline after which to timeout
-    ///   - threadState: Thread-local state for this wait operation
-    /// - Returns: Result indicating woken, mismatch, or timeout
+    ///   - beforeSleep: Optional callback invoked after the thread is queued
+    ///     in the registry but before it blocks. Callers can use this to
+    ///     signal readiness, knowing that a subsequent `unpark` on the same
+    ///     address will find this thread.
     func parkConditionally(
         address: UInt64,
         validate: () -> Bool,
         deadline: (() -> ContinuousClock.Instant)?,
-        threadState: inout ThreadWaitState
+        beforeSleep: (() -> Void)? = nil
     ) -> WaitOutcome {
-        // Quick check before acquiring lock
         if !validate() {
-            return WaitOutcome.mismatch
+            return .mismatch
         }
 
-        // Initialize thread state if needed
-        let thread = threadState.thread ?? WaitingThread()
-        threadState.thread = thread
-        thread.isWoken.store(false, ordering: .relaxed)
+        let slot = BlockingSlot()
 
-        // Register this thread as waiting
-        let shouldBlock = lock.withLock { registry -> Bool in
-            // Re-check condition while holding lock
+        let shouldBlock = registry.withLock { reg -> Bool in
             if !validate() {
-                thread.isWoken.store(true, ordering: .relaxed)
                 return false
             }
-
-            // Add to waiting list for this address
-            registry[address, default: []].append(thread)
+            reg[address, default: []].append(slot)
             return true
         }
 
-        // Exit early if condition no longer holds
-        if !shouldBlock || thread.isWoken.load(ordering: .acquiring) {
-            return WaitOutcome.mismatch
+        if !shouldBlock {
+            return .mismatch
         }
 
-        // Wait for wake signal with timeout handling
-        let deadlineTime = deadline?()
-        var expired = false
-        var spinCount = 1
+        beforeSleep?()
 
-        while !thread.isWoken.load(ordering: .acquiring) {
-            if let deadlineTime = deadlineTime {
-                let currentTime = ContinuousClock.now
-                if currentTime >= deadlineTime {
-                    expired = true
-                    break
+        let timeoutNs: Int64
+        if let deadline = deadline?() {
+            let remaining = deadline - ContinuousClock.now
+            let (seconds, attoseconds) = remaining.components
+            let ns = seconds * 1_000_000_000 + attoseconds / 1_000_000_000
+            timeoutNs = max(ns, 0)
+        } else {
+            timeoutNs = -1
+        }
+
+        let wasWoken = slot.wait(timeoutNs: timeoutNs)
+
+        if !wasWoken {
+            // `slot.wait` reported a timeout, but the pthread `woken` flag and registry
+            // membership are two views of one wakeup. The registry — mutated only under
+            // `registry`'s lock — is authoritative: `unpark` removes a slot from the
+            // registry (under the lock) before it calls `wake()` (outside the lock). So if
+            // our slot is still queued here we genuinely timed out; if it is already gone,
+            // a concurrent `unpark` claimed and counted us in the gap between our timeout
+            // and its `wake()`, and we report `.woken` to keep `unpark`'s returned count
+            // equal to the wakeups waiters observe. Each slot is appended exactly once, so
+            // `firstIndex` finds the unique entry. This relies on `unpark` being the only
+            // dequeuer; `unparkAll`, when wired for termination, must revisit it (see Risks).
+            let genuinelyTimedOut = registry.withLock { reg -> Bool in
+                guard var slots = reg[address],
+                    let index = slots.firstIndex(where: { $0 === slot })
+                else {
+                    return false
                 }
+                slots.remove(at: index)
+                setOrRemove(slots, for: address, in: &reg)
+                return true
             }
-
-            // Progressive backoff to reduce CPU spinning
-            for _ in 0..<spinCount {
-                _ = spinCount & 1
-            }
-            spinCount = min(spinCount * 2, 1024)
+            return genuinelyTimedOut ? .timedOut : .woken
         }
 
-        // Clean up if we timed out
-        if expired {
-            lock.withLock { registry in
-                if var threads = registry[address] {
-                    threads.removeAll { $0 === thread }
-                    if threads.isEmpty {
-                        registry.removeValue(forKey: address)
-                    } else {
-                        registry[address] = threads
-                    }
-                }
-            }
-            return WaitOutcome.timedOut
-        }
-
-        return WaitOutcome.woken
+        return .woken
     }
 
-    /// Unparks up to `count` threads from the queue associated with the given address.
-    ///
-    /// - Parameters:
-    ///   - address: Memory address to unpark threads for (cannot be null conceptually)
-    ///   - count: Maximum number of threads to unpark
-    /// - Returns: Number of threads actually unparked
+    /// Stores the waiter list for `address`, or removes the key entirely when the list
+    /// is empty so empty buckets do not accumulate.
+    private func setOrRemove(
+        _ slots: [BlockingSlot], for address: UInt64, in reg: inout [UInt64: [BlockingSlot]]
+    ) {
+        if slots.isEmpty {
+            reg.removeValue(forKey: address)
+        } else {
+            reg[address] = slots
+        }
+    }
+
+    /// Unparks up to `count` threads from the queue at `address`.
     func unpark(address: UInt64, count: UInt32) -> UInt32 {
-        if count == 0 {
-            return 0
+        if count == 0 { return 0 }
+
+        let toWake: [BlockingSlot] = registry.withLock { reg in
+            guard var slots = reg[address], !slots.isEmpty else {
+                return []
+            }
+            let wakeCount = min(Int(count), slots.count)
+            let result = Array(slots.prefix(wakeCount))
+            slots.removeFirst(wakeCount)
+            setOrRemove(slots, for: address, in: &reg)
+            return result
         }
 
-        var wokenCount: UInt32 = 0
+        #if DEBUG
+            _afterDequeueBeforeWake.withLock { $0 }?()
+        #endif
 
-        lock.withLock { registry in
-            guard var threads = registry[address], !threads.isEmpty else {
-                return
-            }
-
-            let wakeCount = min(Int(count), threads.count)
-            let toWake = Array(threads.prefix(wakeCount))
-            threads.removeFirst(wakeCount)
-
-            if threads.isEmpty {
-                registry.removeValue(forKey: address)
-            } else {
-                registry[address] = threads
-            }
-
-            // Signal waiting threads
-            for thread in toWake {
-                thread.isWoken.store(true, ordering: .releasing)
-            }
-
-            wokenCount = UInt32(wakeCount)
+        for slot in toWake {
+            slot.wake()
         }
-
-        return wokenCount
+        return UInt32(toWake.count)
     }
-}
 
-/// Per-thread state for wait operations
-struct ThreadWaitState {
-    var thread: WaitingThread?
-
-    init() {
-        self.thread = nil
+    /// Wake all parked threads across all addresses.
+    func unparkAll() {
+        let allSlots: [[BlockingSlot]] = registry.withLock { reg in
+            let result = Array(reg.values)
+            reg.removeAll()
+            return result
+        }
+        for slots in allSlots {
+            for slot in slots {
+                slot.wake()
+            }
+        }
     }
 }
 
 /// Result of a wait operation
-enum WaitOutcome {
+enum WaitOutcome: Equatable {
     case woken  // 0 - successfully woken by notify
     case mismatch  // 1 - value didn't match expected
     case timedOut  // 2 - deadline expired

--- a/Sources/WasmKit/Execution/AtomicParkingLot.swift
+++ b/Sources/WasmKit/Execution/AtomicParkingLot.swift
@@ -27,250 +27,250 @@ import Synchronization
 // excluded there; the wait/notify instructions handle its absence directly.
 #if !os(Windows)
 
-/// Per-wait blocking context wrapping a pthread condvar + mutex pair.
-///
-/// A class because the same slot is referenced simultaneously from the
-/// registry (where `unpark` finds it) and the parked thread (blocking in
-/// `wait()`). `woken` is only accessed under `pthread_mutex_lock(mutex)`.
-final class BlockingSlot: @unchecked Sendable {
-    private let mutex: UnsafeMutablePointer<pthread_mutex_t>
-    private let cond: UnsafeMutablePointer<pthread_cond_t>
-    private var woken: Bool
+    /// Per-wait blocking context wrapping a pthread condvar + mutex pair.
+    ///
+    /// A class because the same slot is referenced simultaneously from the
+    /// registry (where `unpark` finds it) and the parked thread (blocking in
+    /// `wait()`). `woken` is only accessed under `pthread_mutex_lock(mutex)`.
+    final class BlockingSlot: @unchecked Sendable {
+        private let mutex: UnsafeMutablePointer<pthread_mutex_t>
+        private let cond: UnsafeMutablePointer<pthread_cond_t>
+        private var woken: Bool
 
-    init() {
-        mutex = .allocate(capacity: 1)
-        mutex.initialize(to: pthread_mutex_t())
-        pthread_mutex_init(mutex, nil)
+        init() {
+            mutex = .allocate(capacity: 1)
+            mutex.initialize(to: pthread_mutex_t())
+            pthread_mutex_init(mutex, nil)
 
-        cond = .allocate(capacity: 1)
-        cond.initialize(to: pthread_cond_t())
-        #if canImport(Darwin) || canImport(WASILibc)
-            // Darwin has no `pthread_condattr_setclock`; wasi-libc's `CLOCK_MONOTONIC`
-            // is a time64 clock object (not an importable constant). Both use the
-            // default clock, so the timed wait below reads `CLOCK_REALTIME` to match.
-            pthread_cond_init(cond, nil)
-        #else
-            var attr = pthread_condattr_t()
-            pthread_condattr_init(&attr)
-            pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)
-            pthread_cond_init(cond, &attr)
-            pthread_condattr_destroy(&attr)
-        #endif
+            cond = .allocate(capacity: 1)
+            cond.initialize(to: pthread_cond_t())
+            #if canImport(Darwin) || canImport(WASILibc)
+                // Darwin has no `pthread_condattr_setclock`; wasi-libc's `CLOCK_MONOTONIC`
+                // is a time64 clock object (not an importable constant). Both use the
+                // default clock, so the timed wait below reads `CLOCK_REALTIME` to match.
+                pthread_cond_init(cond, nil)
+            #else
+                var attr = pthread_condattr_t()
+                pthread_condattr_init(&attr)
+                pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)
+                pthread_cond_init(cond, &attr)
+                pthread_condattr_destroy(&attr)
+            #endif
 
-        woken = false
-    }
+            woken = false
+        }
 
-    deinit {
-        pthread_cond_destroy(cond)
-        cond.deinitialize(count: 1)
-        cond.deallocate()
+        deinit {
+            pthread_cond_destroy(cond)
+            cond.deinitialize(count: 1)
+            cond.deallocate()
 
-        pthread_mutex_destroy(mutex)
-        mutex.deinitialize(count: 1)
-        mutex.deallocate()
-    }
+            pthread_mutex_destroy(mutex)
+            mutex.deinitialize(count: 1)
+            mutex.deallocate()
+        }
 
-    /// Block until woken or timeout expires.
-    /// - Parameter timeoutNs: relative timeout in nanoseconds.
-    ///   `< 0` = wait indefinitely, `0` = return immediately, `> 0` = timed wait.
-    /// - Returns: `true` if woken by `wake()`, `false` if timed out.
-    func wait(timeoutNs: Int64) -> Bool {
-        pthread_mutex_lock(mutex)
-        defer { pthread_mutex_unlock(mutex) }
+        /// Block until woken or timeout expires.
+        /// - Parameter timeoutNs: relative timeout in nanoseconds.
+        ///   `< 0` = wait indefinitely, `0` = return immediately, `> 0` = timed wait.
+        /// - Returns: `true` if woken by `wake()`, `false` if timed out.
+        func wait(timeoutNs: Int64) -> Bool {
+            pthread_mutex_lock(mutex)
+            defer { pthread_mutex_unlock(mutex) }
 
-        if timeoutNs == 0 {
+            if timeoutNs == 0 {
+                return woken
+            }
+
+            if timeoutNs < 0 {
+                while !woken {
+                    pthread_cond_wait(cond, mutex)
+                }
+                return true
+            }
+
+            var deadline = timespec()
+            #if canImport(Darwin)
+                clock_gettime(CLOCK_REALTIME, &deadline)
+            #elseif canImport(WASILibc)
+                // wasi-libc's `CLOCK_REALTIME` is a time64 clock object, not an importable
+                // constant, so seed the (default-clock) deadline from `gettimeofday`.
+                var now = timeval()
+                gettimeofday(&now, nil)
+                deadline.tv_sec = now.tv_sec
+                deadline.tv_nsec = Int(now.tv_usec) * 1000
+            #else
+                clock_gettime(CLOCK_MONOTONIC, &deadline)
+            #endif
+            let extraSec = timeoutNs / 1_000_000_000
+            let extraNsec = timeoutNs % 1_000_000_000
+            deadline.tv_sec += time_t(extraSec)
+            deadline.tv_nsec += Int(extraNsec)
+            if deadline.tv_nsec >= 1_000_000_000 {
+                deadline.tv_sec += 1
+                deadline.tv_nsec -= 1_000_000_000
+            }
+
+            while !woken {
+                let rc = pthread_cond_timedwait(cond, mutex, &deadline)
+                if rc == ETIMEDOUT { break }
+            }
             return woken
         }
 
-        if timeoutNs < 0 {
-            while !woken {
-                pthread_cond_wait(cond, mutex)
-            }
-            return true
-        }
-
-        var deadline = timespec()
-        #if canImport(Darwin)
-            clock_gettime(CLOCK_REALTIME, &deadline)
-        #elseif canImport(WASILibc)
-            // wasi-libc's `CLOCK_REALTIME` is a time64 clock object, not an importable
-            // constant, so seed the (default-clock) deadline from `gettimeofday`.
-            var now = timeval()
-            gettimeofday(&now, nil)
-            deadline.tv_sec = now.tv_sec
-            deadline.tv_nsec = Int(now.tv_usec) * 1000
-        #else
-            clock_gettime(CLOCK_MONOTONIC, &deadline)
-        #endif
-        let extraSec = timeoutNs / 1_000_000_000
-        let extraNsec = timeoutNs % 1_000_000_000
-        deadline.tv_sec += time_t(extraSec)
-        deadline.tv_nsec += Int(extraNsec)
-        if deadline.tv_nsec >= 1_000_000_000 {
-            deadline.tv_sec += 1
-            deadline.tv_nsec -= 1_000_000_000
-        }
-
-        while !woken {
-            let rc = pthread_cond_timedwait(cond, mutex, &deadline)
-            if rc == ETIMEDOUT { break }
-        }
-        return woken
-    }
-
-    /// Wake the thread blocked on this slot.
-    func wake() {
-        pthread_mutex_lock(mutex)
-        woken = true
-        pthread_cond_signal(cond)
-        pthread_mutex_unlock(mutex)
-    }
-}
-
-/// Manages waiting threads for atomic memory operations.
-package final class AtomicParkingLot: Sendable {
-    private let registry: Mutex<[UInt64: [BlockingSlot]]>
-
-    #if DEBUG
-        /// Test-only hook fired inside `unpark` after the slots are removed and counted
-        /// (registry lock released) and before `wake()` runs, used to deterministically
-        /// exercise the timeout/notify race. Never set outside tests; compiled out of release.
-        let _afterDequeueBeforeWake = Mutex<(@Sendable () -> Void)?>(nil)
-    #endif
-
-    init() {
-        self.registry = Mutex([:])
-    }
-
-    /// Parks the calling thread until woken, timed out, or validation fails.
-    ///
-    /// Validation runs twice: once before acquiring the registry lock (quick
-    /// path) and once while holding it (definitive check). If either returns
-    /// false, returns `.mismatch` without blocking.
-    /// - Parameters:
-    ///   - address: Memory address to park on
-    ///   - validate: Closure that checks if the wait condition is still valid
-    ///   - deadline: Optional deadline after which to timeout
-    ///   - beforeSleep: Optional callback invoked after the thread is queued
-    ///     in the registry but before it blocks. Callers can use this to
-    ///     signal readiness, knowing that a subsequent `unpark` on the same
-    ///     address will find this thread.
-    func parkConditionally(
-        address: UInt64,
-        validate: () -> Bool,
-        deadline: (() -> ContinuousClock.Instant)?,
-        beforeSleep: (() -> Void)? = nil
-    ) -> WaitOutcome {
-        if !validate() {
-            return .mismatch
-        }
-
-        let slot = BlockingSlot()
-
-        let shouldBlock = registry.withLock { reg -> Bool in
-            if !validate() {
-                return false
-            }
-            reg[address, default: []].append(slot)
-            return true
-        }
-
-        if !shouldBlock {
-            return .mismatch
-        }
-
-        beforeSleep?()
-
-        let timeoutNs: Int64
-        if let deadline = deadline?() {
-            let remaining = deadline - ContinuousClock.now
-            let (seconds, attoseconds) = remaining.components
-            let ns = seconds * 1_000_000_000 + attoseconds / 1_000_000_000
-            timeoutNs = max(ns, 0)
-        } else {
-            timeoutNs = -1
-        }
-
-        let wasWoken = slot.wait(timeoutNs: timeoutNs)
-
-        if !wasWoken {
-            // `slot.wait` reported a timeout, but the pthread `woken` flag and registry
-            // membership are two views of one wakeup. The registry — mutated only under
-            // `registry`'s lock — is authoritative: `unpark` removes a slot from the
-            // registry (under the lock) before it calls `wake()` (outside the lock). So if
-            // our slot is still queued here we genuinely timed out; if it is already gone,
-            // a concurrent `unpark` claimed and counted us in the gap between our timeout
-            // and its `wake()`, and we report `.woken` to keep `unpark`'s returned count
-            // equal to the wakeups waiters observe. Each slot is appended exactly once, so
-            // `firstIndex` finds the unique entry. This relies on `unpark` being the only
-            // dequeuer; `unparkAll`, when wired for termination, must revisit it (see Risks).
-            let genuinelyTimedOut = registry.withLock { reg -> Bool in
-                guard var slots = reg[address],
-                    let index = slots.firstIndex(where: { $0 === slot })
-                else {
-                    return false
-                }
-                slots.remove(at: index)
-                setOrRemove(slots, for: address, in: &reg)
-                return true
-            }
-            return genuinelyTimedOut ? .timedOut : .woken
-        }
-
-        return .woken
-    }
-
-    /// Stores the waiter list for `address`, or removes the key entirely when the list
-    /// is empty so empty buckets do not accumulate.
-    private func setOrRemove(
-        _ slots: [BlockingSlot], for address: UInt64, in reg: inout [UInt64: [BlockingSlot]]
-    ) {
-        if slots.isEmpty {
-            reg.removeValue(forKey: address)
-        } else {
-            reg[address] = slots
+        /// Wake the thread blocked on this slot.
+        func wake() {
+            pthread_mutex_lock(mutex)
+            woken = true
+            pthread_cond_signal(cond)
+            pthread_mutex_unlock(mutex)
         }
     }
 
-    /// Unparks up to `count` threads from the queue at `address`.
-    func unpark(address: UInt64, count: UInt32) -> UInt32 {
-        if count == 0 { return 0 }
-
-        let toWake: [BlockingSlot] = registry.withLock { reg in
-            guard var slots = reg[address], !slots.isEmpty else {
-                return []
-            }
-            let wakeCount = min(Int(count), slots.count)
-            let result = Array(slots.prefix(wakeCount))
-            slots.removeFirst(wakeCount)
-            setOrRemove(slots, for: address, in: &reg)
-            return result
-        }
+    /// Manages waiting threads for atomic memory operations.
+    package final class AtomicParkingLot: Sendable {
+        private let registry: Mutex<[UInt64: [BlockingSlot]]>
 
         #if DEBUG
-            _afterDequeueBeforeWake.withLock { $0 }?()
+            /// Test-only hook fired inside `unpark` after the slots are removed and counted
+            /// (registry lock released) and before `wake()` runs, used to deterministically
+            /// exercise the timeout/notify race. Never set outside tests; compiled out of release.
+            let _afterDequeueBeforeWake = Mutex<(@Sendable () -> Void)?>(nil)
         #endif
 
-        for slot in toWake {
-            slot.wake()
+        init() {
+            self.registry = Mutex([:])
         }
-        return UInt32(toWake.count)
-    }
 
-    /// Wake all parked threads across all addresses.
-    func unparkAll() {
-        let allSlots: [[BlockingSlot]] = registry.withLock { reg in
-            let result = Array(reg.values)
-            reg.removeAll()
-            return result
+        /// Parks the calling thread until woken, timed out, or validation fails.
+        ///
+        /// Validation runs twice: once before acquiring the registry lock (quick
+        /// path) and once while holding it (definitive check). If either returns
+        /// false, returns `.mismatch` without blocking.
+        /// - Parameters:
+        ///   - address: Memory address to park on
+        ///   - validate: Closure that checks if the wait condition is still valid
+        ///   - deadline: Optional deadline after which to timeout
+        ///   - beforeSleep: Optional callback invoked after the thread is queued
+        ///     in the registry but before it blocks. Callers can use this to
+        ///     signal readiness, knowing that a subsequent `unpark` on the same
+        ///     address will find this thread.
+        func parkConditionally(
+            address: UInt64,
+            validate: () -> Bool,
+            deadline: (() -> ContinuousClock.Instant)?,
+            beforeSleep: (() -> Void)? = nil
+        ) -> WaitOutcome {
+            if !validate() {
+                return .mismatch
+            }
+
+            let slot = BlockingSlot()
+
+            let shouldBlock = registry.withLock { reg -> Bool in
+                if !validate() {
+                    return false
+                }
+                reg[address, default: []].append(slot)
+                return true
+            }
+
+            if !shouldBlock {
+                return .mismatch
+            }
+
+            beforeSleep?()
+
+            let timeoutNs: Int64
+            if let deadline = deadline?() {
+                let remaining = deadline - ContinuousClock.now
+                let (seconds, attoseconds) = remaining.components
+                let ns = seconds * 1_000_000_000 + attoseconds / 1_000_000_000
+                timeoutNs = max(ns, 0)
+            } else {
+                timeoutNs = -1
+            }
+
+            let wasWoken = slot.wait(timeoutNs: timeoutNs)
+
+            if !wasWoken {
+                // `slot.wait` reported a timeout, but the pthread `woken` flag and registry
+                // membership are two views of one wakeup. The registry — mutated only under
+                // `registry`'s lock — is authoritative: `unpark` removes a slot from the
+                // registry (under the lock) before it calls `wake()` (outside the lock). So if
+                // our slot is still queued here we genuinely timed out; if it is already gone,
+                // a concurrent `unpark` claimed and counted us in the gap between our timeout
+                // and its `wake()`, and we report `.woken` to keep `unpark`'s returned count
+                // equal to the wakeups waiters observe. Each slot is appended exactly once, so
+                // `firstIndex` finds the unique entry. This relies on `unpark` being the only
+                // dequeuer; `unparkAll`, when wired for termination, must revisit it (see Risks).
+                let genuinelyTimedOut = registry.withLock { reg -> Bool in
+                    guard var slots = reg[address],
+                        let index = slots.firstIndex(where: { $0 === slot })
+                    else {
+                        return false
+                    }
+                    slots.remove(at: index)
+                    setOrRemove(slots, for: address, in: &reg)
+                    return true
+                }
+                return genuinelyTimedOut ? .timedOut : .woken
+            }
+
+            return .woken
         }
-        for slots in allSlots {
-            for slot in slots {
+
+        /// Stores the waiter list for `address`, or removes the key entirely when the list
+        /// is empty so empty buckets do not accumulate.
+        private func setOrRemove(
+            _ slots: [BlockingSlot], for address: UInt64, in reg: inout [UInt64: [BlockingSlot]]
+        ) {
+            if slots.isEmpty {
+                reg.removeValue(forKey: address)
+            } else {
+                reg[address] = slots
+            }
+        }
+
+        /// Unparks up to `count` threads from the queue at `address`.
+        func unpark(address: UInt64, count: UInt32) -> UInt32 {
+            if count == 0 { return 0 }
+
+            let toWake: [BlockingSlot] = registry.withLock { reg in
+                guard var slots = reg[address], !slots.isEmpty else {
+                    return []
+                }
+                let wakeCount = min(Int(count), slots.count)
+                let result = Array(slots.prefix(wakeCount))
+                slots.removeFirst(wakeCount)
+                setOrRemove(slots, for: address, in: &reg)
+                return result
+            }
+
+            #if DEBUG
+                _afterDequeueBeforeWake.withLock { $0 }?()
+            #endif
+
+            for slot in toWake {
                 slot.wake()
+            }
+            return UInt32(toWake.count)
+        }
+
+        /// Wake all parked threads across all addresses.
+        func unparkAll() {
+            let allSlots: [[BlockingSlot]] = registry.withLock { reg in
+                let result = Array(reg.values)
+                reg.removeAll()
+                return result
+            }
+            for slots in allSlots {
+                for slot in slots {
+                    slot.wake()
+                }
             }
         }
     }
-}
 
 #endif
 

--- a/Sources/WasmKit/Execution/AtomicParkingLot.swift
+++ b/Sources/WasmKit/Execution/AtomicParkingLot.swift
@@ -14,7 +14,18 @@ import Synchronization
     import Musl
 #elseif canImport(Glibc)
     import Glibc
+#elseif canImport(Android)
+    import Android
+#elseif canImport(WASILibc)
+    import WASILibc
+    import wasi_pthread
 #endif
+
+// `memory.atomic.wait`/`notify` need an OS primitive to block and wake a thread.
+// pthread provides it on Darwin, Linux (Glibc/Musl), Android (Bionic), and WASI
+// (wasi-libc's `wasi_pthread`). Windows has no pthread here, so the parking lot is
+// excluded there; the wait/notify instructions handle its absence directly.
+#if !os(Windows)
 
 /// Per-wait blocking context wrapping a pthread condvar + mutex pair.
 ///
@@ -33,7 +44,10 @@ final class BlockingSlot: @unchecked Sendable {
 
         cond = .allocate(capacity: 1)
         cond.initialize(to: pthread_cond_t())
-        #if canImport(Darwin)
+        #if canImport(Darwin) || canImport(WASILibc)
+            // Darwin has no `pthread_condattr_setclock`; wasi-libc's `CLOCK_MONOTONIC`
+            // is a time64 clock object (not an importable constant). Both use the
+            // default clock, so the timed wait below reads `CLOCK_REALTIME` to match.
             pthread_cond_init(cond, nil)
         #else
             var attr = pthread_condattr_t()
@@ -78,12 +92,19 @@ final class BlockingSlot: @unchecked Sendable {
         var deadline = timespec()
         #if canImport(Darwin)
             clock_gettime(CLOCK_REALTIME, &deadline)
+        #elseif canImport(WASILibc)
+            // wasi-libc's `CLOCK_REALTIME` is a time64 clock object, not an importable
+            // constant, so seed the (default-clock) deadline from `gettimeofday`.
+            var now = timeval()
+            gettimeofday(&now, nil)
+            deadline.tv_sec = now.tv_sec
+            deadline.tv_nsec = Int(now.tv_usec) * 1000
         #else
             clock_gettime(CLOCK_MONOTONIC, &deadline)
         #endif
         let extraSec = timeoutNs / 1_000_000_000
         let extraNsec = timeoutNs % 1_000_000_000
-        deadline.tv_sec += Int(extraSec)
+        deadline.tv_sec += time_t(extraSec)
         deadline.tv_nsec += Int(extraNsec)
         if deadline.tv_nsec >= 1_000_000_000 {
             deadline.tv_sec += 1
@@ -250,6 +271,8 @@ package final class AtomicParkingLot: Sendable {
         }
     }
 }
+
+#endif
 
 /// Result of a wait operation
 enum WaitOutcome: Equatable {

--- a/Sources/WasmKit/Execution/DispatchInstruction.swift
+++ b/Sources/WasmKit/Execution/DispatchInstruction.swift
@@ -287,6 +287,29 @@ extension Execution {
         case 271: return try self.execute_throwRef(sp: &sp, pc: &pc, md: &md, ms: &ms)
         case 272: return self.execute_catchHandlers(sp: &sp, pc: &pc, md: &md, ms: &ms)
         case 273: return self.execute_catchHandlersEnd(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 274: return try self.execute_i32LoadShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 275: return try self.execute_i64LoadShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 276: return try self.execute_f32LoadShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 277: return try self.execute_f64LoadShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 278: return try self.execute_i32Load8SShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 279: return try self.execute_i32Load8UShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 280: return try self.execute_i32Load16SShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 281: return try self.execute_i32Load16UShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 282: return try self.execute_i64Load8SShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 283: return try self.execute_i64Load8UShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 284: return try self.execute_i64Load16SShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 285: return try self.execute_i64Load16UShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 286: return try self.execute_i64Load32SShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 287: return try self.execute_i64Load32UShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 288: return try self.execute_i32StoreShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 289: return try self.execute_i64StoreShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 290: return try self.execute_f32StoreShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 291: return try self.execute_f64StoreShared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 292: return try self.execute_i32Store8Shared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 293: return try self.execute_i32Store16Shared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 294: return try self.execute_i64Store8Shared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 295: return try self.execute_i64Store16Shared(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 296: return try self.execute_i64Store32Shared(sp: &sp, pc: &pc, md: &md, ms: &ms)
         default: preconditionFailure("Unknown instruction!?")
 
         }
@@ -2460,6 +2483,190 @@ extension Execution {
     mutating func execute_catchHandlersEnd(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) -> CodeSlot {
         let immediate = Instruction.CatchHandlersEndOperand.load(from: &pc.pointee)
         self.catchHandlersEnd(sp: sp.pointee, immediate: immediate)
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32LoadShared") @inline(__always)
+    mutating func execute_i32LoadShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt32.self, castToValue: { .i32($0) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64LoadShared") @inline(__always)
+    mutating func execute_i64LoadShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt64.self, castToValue: { .i64($0) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_f32LoadShared") @inline(__always)
+    mutating func execute_f32LoadShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt32.self, castToValue: { .rawF32($0) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_f64LoadShared") @inline(__always)
+    mutating func execute_f64LoadShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt64.self, castToValue: { .rawF64($0) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32Load8SShared") @inline(__always)
+    mutating func execute_i32Load8SShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: Int8.self, castToValue: { .init(signed: Int32($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32Load8UShared") @inline(__always)
+    mutating func execute_i32Load8UShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt8.self, castToValue: { .i32(UInt32($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32Load16SShared") @inline(__always)
+    mutating func execute_i32Load16SShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: Int16.self, castToValue: { .init(signed: Int32($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32Load16UShared") @inline(__always)
+    mutating func execute_i32Load16UShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt16.self, castToValue: { .i32(UInt32($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Load8SShared") @inline(__always)
+    mutating func execute_i64Load8SShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: Int8.self, castToValue: { .init(signed: Int64($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Load8UShared") @inline(__always)
+    mutating func execute_i64Load8UShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt8.self, castToValue: { .i64(UInt64($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Load16SShared") @inline(__always)
+    mutating func execute_i64Load16SShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: Int16.self, castToValue: { .init(signed: Int64($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Load16UShared") @inline(__always)
+    mutating func execute_i64Load16UShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt16.self, castToValue: { .i64(UInt64($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Load32SShared") @inline(__always)
+    mutating func execute_i64Load32SShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: Int32.self, castToValue: { .init(signed: Int64($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Load32UShared") @inline(__always)
+    mutating func execute_i64Load32UShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.LoadOperand.load(from: &pc.pointee)
+        try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: UInt32.self, castToValue: { .i64(UInt64($0)) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32StoreShared") @inline(__always)
+    mutating func execute_i32StoreShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { $0.i32 })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64StoreShared") @inline(__always)
+    mutating func execute_i64StoreShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { $0.i64 })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_f32StoreShared") @inline(__always)
+    mutating func execute_f32StoreShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { $0.rawF32 })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_f64StoreShared") @inline(__always)
+    mutating func execute_f64StoreShared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { $0.rawF64 })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32Store8Shared") @inline(__always)
+    mutating func execute_i32Store8Shared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { UInt8(truncatingIfNeeded: $0.i32) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i32Store16Shared") @inline(__always)
+    mutating func execute_i32Store16Shared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { UInt16(truncatingIfNeeded: $0.i32) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Store8Shared") @inline(__always)
+    mutating func execute_i64Store8Shared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { UInt8(truncatingIfNeeded: $0.i64) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Store16Shared") @inline(__always)
+    mutating func execute_i64Store16Shared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { UInt16(truncatingIfNeeded: $0.i64) })
+        let next = pc.pointee.pointee
+        pc.pointee = pc.pointee.advanced(by: 1)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_i64Store32Shared") @inline(__always)
+    mutating func execute_i64Store32Shared(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) throws -> CodeSlot {
+        let immediate = Instruction.StoreOperand.load(from: &pc.pointee)
+        try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { UInt32(truncatingIfNeeded: $0.i64) })
         let next = pc.pointee.pointee
         pc.pointee = pc.pointee.advanced(by: 1)
         return next

--- a/Sources/WasmKit/Execution/Errors.swift
+++ b/Sources/WasmKit/Execution/Errors.swift
@@ -80,8 +80,8 @@ public struct WasmKitException: Error, CustomStringConvertible {
 }
 
 /// A reason for a trap that occurred during execution of a WebAssembly module.
-package enum TrapReason: Error, CustomStringConvertible {
-    package struct Message {
+package enum TrapReason: Error, Equatable, CustomStringConvertible {
+    package struct Message: Equatable {
         let text: String
 
         init(_ text: String) {
@@ -157,6 +157,12 @@ extension TrapReason.Message {
     }
     static var cannotAssignToImmutableGlobal: Self {
         Self("cannot assign to an immutable global")
+    }
+    static func mmapFailed(reserveBytes: Int) -> Self {
+        Self("failed to reserve \(reserveBytes) bytes of virtual address space for shared memory")
+    }
+    static var sharedMemoryGuardRegistryFull: Self {
+        Self("shared memory guard registry is full (too many concurrent shared memories)")
     }
     static func noGlobalExportWithName(globalName: String, instance: Instance) -> Self {
         Self("no global export with name \(globalName) in a module instance \(instance)")

--- a/Sources/WasmKit/Execution/Errors.swift
+++ b/Sources/WasmKit/Execution/Errors.swift
@@ -164,6 +164,9 @@ extension TrapReason.Message {
     static var sharedMemoryGuardRegistryFull: Self {
         Self("shared memory guard registry is full (too many concurrent shared memories)")
     }
+    static var atomicWaitUnsupported: Self {
+        Self("memory.atomic.wait is not supported on this platform (no thread-blocking primitive)")
+    }
     static func noGlobalExportWithName(globalName: String, instance: Instance) -> Self {
         Self("no global export with name \(globalName) in a module instance \(instance)")
     }

--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -513,7 +513,13 @@ extension Execution {
             var pc = pc
             var md = md
             var ms = ms
-            let shouldUseMprotectTrapGuards = store.value.engine.configuration.memoryBoundsChecking == .mprotect
+            // Shared memory always uses software bounds checking. A guard-page fault
+            // recovered by siglongjmp would unwind the interpreter past a lock held by a
+            // concurrent grow or atomic operation, so the multi-threaded path must stay
+            // free of non-local jumps. mprotect guards are reserved for non-shared memory.
+            let isNonSharedMemory = sp.currentInstance?.memories.first?.withValue { $0.sharedStorage == nil } ?? true
+            let shouldUseMprotectTrapGuards =
+                store.value.engine.configuration.memoryBoundsChecking == .mprotect && isNonSharedMemory
             let storeValue = store.value
             while true {
                 let handler = pc.read(wasmkit_tc_exec.self)

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -66,6 +66,30 @@ package struct EntityHandle<T: ~Copyable>: Equatable, Hashable, Copyable {
     }
 }
 
+/// A `Sendable` reference to a `SharedMemoryStorage` allocation.
+///
+/// `EntityHandle<T>` wraps `UnsafeMutablePointer<T>`, which is not `Sendable` in
+/// Swift 6. Shared memory is the only entity that must cross thread boundaries
+/// (via `ThreadGroup`), so this purpose-built type stores the pointer as a `UInt`
+/// bit pattern that the compiler can verify as `Sendable`.
+///
+/// The underlying `SharedMemoryStorage` must outlive all threads holding a
+/// `SharedMemoryEntity`. This is guaranteed by the `StoreAllocator`'s
+/// `BumpAllocator<SharedMemoryStorage>`, which lives as long as the parent `Store`.
+package struct SharedMemoryEntity: Sendable, Equatable, Hashable {
+    private let bits: UInt
+
+    init(unsafe pointer: UnsafeMutablePointer<SharedMemoryStorage>) {
+        self.bits = UInt(bitPattern: pointer)
+    }
+
+    @inline(__always)
+    func withValue<R>(_ body: (inout SharedMemoryStorage) throws -> R) rethrows -> R {
+        let pointer = UnsafeMutablePointer<SharedMemoryStorage>(bitPattern: bits)!
+        return try body(&pointer.pointee)
+    }
+}
+
 extension EntityHandle: ValidatableEntity where T: ValidatableEntity, T: ~Copyable {
     static func createOutOfBoundsError(index: Int, count: Int) -> WasmKitError {
         T.createOutOfBoundsError(index: index, count: count)
@@ -589,7 +613,10 @@ struct MemoryEntity: ~Copyable {
     private var storage: Storage
     let maxPageCount: UInt64
     let limit: Limits
-    let sharedMutex: Mutex<Void>?
+
+    /// If this memory is shared, the mmap-backed storage is held here.
+    /// Multiple `MemoryEntity` instances (across threads) may reference the same `SharedMemoryStorage`.
+    let sharedStorage: SharedMemoryEntity?
 
     init(_ memoryType: MemoryType, engineConfiguration: EngineConfiguration, resourceLimiter: any ResourceLimiter) throws {
         let byteSize = Int(memoryType.min) * Self.pageSize
@@ -600,26 +627,80 @@ struct MemoryEntity: ~Copyable {
         let defaultMaxPageCount = Self.maxPageCount(isMemory64: memoryType.isMemory64)
         maxPageCount = memoryType.max ?? defaultMaxPageCount
         limit = memoryType
-        sharedMutex = memoryType.shared ? Mutex<Void>(()) : nil
+        sharedStorage = nil
+    }
+
+    /// Creates a memory entity for a shared memory backed by pre-allocated `SharedMemoryStorage`.
+    ///
+    /// The inline `storage` is an empty placeholder; every accessor routes through
+    /// `sharedStorage` first.
+    init(_ memoryType: MemoryType, sharedStorage: SharedMemoryEntity) {
+        precondition(memoryType.shared)
+        // The inline storage is never accessed for shared memories (all accessors
+        // route through `sharedStorage`), so allocate an empty software-backed
+        // placeholder to avoid reserving any mprotect address space.
+        var placeholderConfiguration = EngineConfiguration()
+        placeholderConfiguration.memoryBoundsChecking = .software
+        self.storage = Storage(byteSize: 0, isMemory64: memoryType.isMemory64, engineConfiguration: placeholderConfiguration)
+        self.maxPageCount = memoryType.max ?? Self.maxPageCount(isMemory64: memoryType.isMemory64)
+        self.limit = memoryType
+        self.sharedStorage = sharedStorage
     }
 
     deinit {
+        // Only deallocate inline storage for non-shared memories.
+        // `SharedMemoryStorage` cleanup is managed by its own `BumpAllocator`.
+        guard sharedStorage == nil else { return }
         storage.deallocate()
     }
 
-    var data: UnsafeBufferPointer<UInt8> { storage.data }
+    var data: UnsafeBufferPointer<UInt8> {
+        if let sharedStorage {
+            return sharedStorage.withValue { shared in
+                let count = shared.currentByteCount.load(ordering: .acquiring)
+                return UnsafeBufferPointer(
+                    start: shared.basePointer.assumingMemoryBound(to: UInt8.self),
+                    count: count
+                )
+            }
+        }
+        return storage.data
+    }
 
-    var baseAddress: UnsafeMutableRawPointer? { storage.baseAddress }
+    var baseAddress: UnsafeMutableRawPointer? {
+        if let sharedStorage {
+            return sharedStorage.withValue { $0.basePointer }
+        }
+        return storage.baseAddress
+    }
 
-    var byteCount: Int { storage.byteCount }
+    var byteCount: Int {
+        if let sharedStorage {
+            return sharedStorage.withValue { $0.currentByteCount.load(ordering: .acquiring) }
+        }
+        return storage.byteCount
+    }
 
     var trapGuardReservationSize: Int {
-        storage.trapGuardReservationSize
+        if let sharedStorage {
+            return sharedStorage.withValue { $0.reservationSize }
+        }
+        return storage.trapGuardReservationSize
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/exec/modules.html#grow-mem>
     mutating func grow(by pageCount: Int, resourceLimiter: any ResourceLimiter) throws -> Value {
+        if let sharedStorage {
+            let oldPages = try sharedStorage.withValue { shared in
+                try shared.grow(by: pageCount, resourceLimiter: resourceLimiter)
+            }
+            if oldPages < 0 {
+                return limit.isMemory64 ? .i64((-1 as Int64).unsigned) : .i32((-1 as Int32).unsigned)
+            }
+            return limit.isMemory64 ? .i64(UInt64(oldPages)) : .i32(UInt32(oldPages))
+        }
+
         let currentByteCount = byteCount
         let newPageCount = currentByteCount / Self.pageSize + pageCount
 
@@ -753,6 +834,22 @@ public struct Memory: Equatable {
 
         self.init(
             handle: try store.allocator.allocate(memoryType: type, engineConfiguration: store.engine.configuration, resourceLimiter: store.resourceLimiter),
+            allocator: store.allocator
+        )
+    }
+
+    /// The shared memory entity backing this memory, if shared.
+    package var sharedStorage: SharedMemoryEntity? {
+        handle.withValue { $0.sharedStorage }
+    }
+
+    /// Create a `Memory` in `store` that wraps an existing `SharedMemoryEntity`.
+    ///
+    /// Used by `wasi_thread_spawn` to provide the same shared memory as an
+    /// import to child `Store` instances.
+    package init(store: Store, type: MemoryType, sharedStorage: SharedMemoryEntity) {
+        self.init(
+            handle: store.allocator.allocate(memoryType: type, sharedStorage: sharedStorage),
             allocator: store.allocator
         )
     }

--- a/Sources/WasmKit/Execution/Instructions/Instruction.swift
+++ b/Sources/WasmKit/Execution/Instructions/Instruction.swift
@@ -565,6 +565,52 @@ enum Instruction: Equatable {
     case catchHandlers(Instruction.CatchHandlersOperand)
     /// Unregister exception handlers for a `try_table` block
     case catchHandlersEnd(Instruction.CatchHandlersEndOperand)
+    /// WebAssembly Core Instruction `i32.load` on shared memory
+    case i32LoadShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load` on shared memory
+    case i64LoadShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `f32.load` on shared memory
+    case f32LoadShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `f64.load` on shared memory
+    case f64LoadShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i32.load8_s` on shared memory
+    case i32Load8SShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i32.load8_u` on shared memory
+    case i32Load8UShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i32.load16_s` on shared memory
+    case i32Load16SShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i32.load16_u` on shared memory
+    case i32Load16UShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load8_s` on shared memory
+    case i64Load8SShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load8_u` on shared memory
+    case i64Load8UShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load16_s` on shared memory
+    case i64Load16SShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load16_u` on shared memory
+    case i64Load16UShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load32_s` on shared memory
+    case i64Load32SShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i64.load32_u` on shared memory
+    case i64Load32UShared(Instruction.LoadOperand)
+    /// WebAssembly Core Instruction `i32.store` on shared memory
+    case i32StoreShared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `i64.store` on shared memory
+    case i64StoreShared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `f32.store` on shared memory
+    case f32StoreShared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `f64.store` on shared memory
+    case f64StoreShared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `i32.store8` on shared memory
+    case i32Store8Shared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `i32.store16` on shared memory
+    case i32Store16Shared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `i64.store8` on shared memory
+    case i64Store8Shared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `i64.store16` on shared memory
+    case i64Store16Shared(Instruction.StoreOperand)
+    /// WebAssembly Core Instruction `i64.store32` on shared memory
+    case i64Store32Shared(Instruction.StoreOperand)
 }
 
 extension Instruction {
@@ -1473,6 +1519,29 @@ extension Instruction {
         case .throwRef(let immediate): return immediate
         case .catchHandlers(let immediate): return immediate
         case .catchHandlersEnd(let immediate): return immediate
+        case .i32LoadShared(let immediate): return immediate
+        case .i64LoadShared(let immediate): return immediate
+        case .f32LoadShared(let immediate): return immediate
+        case .f64LoadShared(let immediate): return immediate
+        case .i32Load8SShared(let immediate): return immediate
+        case .i32Load8UShared(let immediate): return immediate
+        case .i32Load16SShared(let immediate): return immediate
+        case .i32Load16UShared(let immediate): return immediate
+        case .i64Load8SShared(let immediate): return immediate
+        case .i64Load8UShared(let immediate): return immediate
+        case .i64Load16SShared(let immediate): return immediate
+        case .i64Load16UShared(let immediate): return immediate
+        case .i64Load32SShared(let immediate): return immediate
+        case .i64Load32UShared(let immediate): return immediate
+        case .i32StoreShared(let immediate): return immediate
+        case .i64StoreShared(let immediate): return immediate
+        case .f32StoreShared(let immediate): return immediate
+        case .f64StoreShared(let immediate): return immediate
+        case .i32Store8Shared(let immediate): return immediate
+        case .i32Store16Shared(let immediate): return immediate
+        case .i64Store8Shared(let immediate): return immediate
+        case .i64Store16Shared(let immediate): return immediate
+        case .i64Store32Shared(let immediate): return immediate
         default: return nil
         }
     }
@@ -1757,6 +1826,29 @@ extension Instruction {
         case .throwRef: return 271
         case .catchHandlers: return 272
         case .catchHandlersEnd: return 273
+        case .i32LoadShared: return 274
+        case .i64LoadShared: return 275
+        case .f32LoadShared: return 276
+        case .f64LoadShared: return 277
+        case .i32Load8SShared: return 278
+        case .i32Load8UShared: return 279
+        case .i32Load16SShared: return 280
+        case .i32Load16UShared: return 281
+        case .i64Load8SShared: return 282
+        case .i64Load8UShared: return 283
+        case .i64Load16SShared: return 284
+        case .i64Load16UShared: return 285
+        case .i64Load32SShared: return 286
+        case .i64Load32UShared: return 287
+        case .i32StoreShared: return 288
+        case .i64StoreShared: return 289
+        case .f32StoreShared: return 290
+        case .f64StoreShared: return 291
+        case .i32Store8Shared: return 292
+        case .i32Store16Shared: return 293
+        case .i64Store8Shared: return 294
+        case .i64Store16Shared: return 295
+        case .i64Store32Shared: return 296
         }
     }
 }
@@ -2042,6 +2134,29 @@ extension Instruction {
         case 271: return .throwRef(Instruction.ThrowRefOperand.load(from: &pc))
         case 272: return .catchHandlers(Instruction.CatchHandlersOperand.load(from: &pc))
         case 273: return .catchHandlersEnd(Instruction.CatchHandlersEndOperand.load(from: &pc))
+        case 274: return .i32LoadShared(Instruction.LoadOperand.load(from: &pc))
+        case 275: return .i64LoadShared(Instruction.LoadOperand.load(from: &pc))
+        case 276: return .f32LoadShared(Instruction.LoadOperand.load(from: &pc))
+        case 277: return .f64LoadShared(Instruction.LoadOperand.load(from: &pc))
+        case 278: return .i32Load8SShared(Instruction.LoadOperand.load(from: &pc))
+        case 279: return .i32Load8UShared(Instruction.LoadOperand.load(from: &pc))
+        case 280: return .i32Load16SShared(Instruction.LoadOperand.load(from: &pc))
+        case 281: return .i32Load16UShared(Instruction.LoadOperand.load(from: &pc))
+        case 282: return .i64Load8SShared(Instruction.LoadOperand.load(from: &pc))
+        case 283: return .i64Load8UShared(Instruction.LoadOperand.load(from: &pc))
+        case 284: return .i64Load16SShared(Instruction.LoadOperand.load(from: &pc))
+        case 285: return .i64Load16UShared(Instruction.LoadOperand.load(from: &pc))
+        case 286: return .i64Load32SShared(Instruction.LoadOperand.load(from: &pc))
+        case 287: return .i64Load32UShared(Instruction.LoadOperand.load(from: &pc))
+        case 288: return .i32StoreShared(Instruction.StoreOperand.load(from: &pc))
+        case 289: return .i64StoreShared(Instruction.StoreOperand.load(from: &pc))
+        case 290: return .f32StoreShared(Instruction.StoreOperand.load(from: &pc))
+        case 291: return .f64StoreShared(Instruction.StoreOperand.load(from: &pc))
+        case 292: return .i32Store8Shared(Instruction.StoreOperand.load(from: &pc))
+        case 293: return .i32Store16Shared(Instruction.StoreOperand.load(from: &pc))
+        case 294: return .i64Store8Shared(Instruction.StoreOperand.load(from: &pc))
+        case 295: return .i64Store16Shared(Instruction.StoreOperand.load(from: &pc))
+        case 296: return .i64Store32Shared(Instruction.StoreOperand.load(from: &pc))
         default: fatalError("Unknown instruction opcode: \(opcode)")
         }
     }
@@ -2330,6 +2445,29 @@ extension Instruction {
         case 271: return "throwRef"
         case 272: return "catchHandlers"
         case 273: return "catchHandlersEnd"
+        case 274: return "i32LoadShared"
+        case 275: return "i64LoadShared"
+        case 276: return "f32LoadShared"
+        case 277: return "f64LoadShared"
+        case 278: return "i32Load8SShared"
+        case 279: return "i32Load8UShared"
+        case 280: return "i32Load16SShared"
+        case 281: return "i32Load16UShared"
+        case 282: return "i64Load8SShared"
+        case 283: return "i64Load8UShared"
+        case 284: return "i64Load16SShared"
+        case 285: return "i64Load16UShared"
+        case 286: return "i64Load32SShared"
+        case 287: return "i64Load32UShared"
+        case 288: return "i32StoreShared"
+        case 289: return "i64StoreShared"
+        case 290: return "f32StoreShared"
+        case 291: return "f64StoreShared"
+        case 292: return "i32Store8Shared"
+        case 293: return "i32Store16Shared"
+        case 294: return "i64Store8Shared"
+        case 295: return "i64Store16Shared"
+        case 296: return "i64Store32Shared"
         default: fatalError("Unknown instruction index: \(opcode)")
         }
     }

--- a/Sources/WasmKit/Execution/Instructions/Memory.swift
+++ b/Sources/WasmKit/Execution/Instructions/Memory.swift
@@ -10,6 +10,70 @@ extension Execution {
     @inline(never) func throwUnalignedAtomicAccess() throws -> Never {
         throw Trap(.unalignedAtomic)
     }
+
+    /// Reload the current shared memory size atomically (slow path for stale Ms).
+    /// Returns `nil` if the default memory is not shared. `@inline(never)`: this is a
+    /// cold-path helper (failed fast bounds check); keeping it out of line avoids
+    /// bloating the inlined bounds checks in the scalar shared and SIMD handlers.
+    @inline(never)
+    func reloadSharedMemorySize(sp: Sp) -> Int? {
+        guard let memory = currentInstance(sp: sp).memories.first else { return nil }
+        return memory.withValue { entity -> Int? in
+            guard let sharedStorage = entity.sharedStorage else { return nil }
+            return sharedStorage.withValue { $0.currentByteCount.load(ordering: .acquiring) }
+        }
+    }
+
+    /// Shared-memory load: a concurrent grow can leave the cached `Ms` stale, so on a
+    /// failed fast bounds check reload the authoritative committed size before trapping.
+    /// Emitted by the translator only for shared memories, so the plain `memoryLoad`
+    /// keeps `origin/main`'s leaf codegen for the common single-threaded case.
+    mutating func memoryLoadShared<T: FixedWidthInteger>(
+        sp: Sp, md: Md, ms: Ms, loadOperand: Instruction.LoadOperand, loadAs _: T.Type = T.self, castToValue: (T) -> UntypedValue
+    ) throws {
+        let length = UInt64(T.bitWidth) / 8
+        let i = sp[loadOperand.pointer].asAddressOffset()
+        let (endAddress, isEndOverflow) = i.addingReportingOverflow(length &+ loadOperand.offset)
+        let boundsOk: Bool
+        if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp), endAddress <= UInt64(freshMs) {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
+            let address = loadOperand.offset + i
+            let loaded = md.unsafelyUnwrapped.loadUnaligned(fromByteOffset: Int(address), as: T.self)
+            sp[loadOperand.result] = castToValue(loaded)
+        } else {
+            try throwOutOfBoundsMemoryAccess()
+        }
+    }
+
+    /// Shared-memory store. See `memoryLoadShared`.
+    mutating func memoryStoreShared<T: FixedWidthInteger>(sp: Sp, md: Md, ms: Ms, storeOperand: Instruction.StoreOperand, castFromValue: (UntypedValue) -> T) throws {
+        let value = sp[storeOperand.value]
+        let length = UInt64(T.bitWidth) / 8
+        let i = sp[storeOperand.pointer].asAddressOffset()
+        let address = storeOperand.offset + i
+        let (endAddress, isEndOverflow) = i.addingReportingOverflow(length &+ storeOperand.offset)
+        let boundsOk: Bool
+        if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp), endAddress <= UInt64(freshMs) {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
+            let toStore = castFromValue(value)
+            md.unsafelyUnwrapped.advanced(by: Int(address))
+                .bindMemory(to: T.self, capacity: 1).pointee = toStore.littleEndian
+        } else {
+            try throwOutOfBoundsMemoryAccess()
+        }
+    }
     mutating func memoryLoad<T: FixedWidthInteger>(
         sp: Sp, md: Md, ms: Ms, loadOperand: Instruction.LoadOperand, loadAs _: T.Type = T.self, castToValue: (T) -> UntypedValue
     ) throws {
@@ -118,7 +182,17 @@ extension Execution {
             try throwUnalignedAtomicAccess()
         }
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(length &+ loadOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let loaded: T
             switch T.bitWidth {
@@ -147,7 +221,17 @@ extension Execution {
             try throwUnalignedAtomicAccess()
         }
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(length &+ storeOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let toStore = castFromValue(value)
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             switch T.bitWidth {
@@ -180,7 +264,17 @@ extension Execution {
             try throwUnalignedAtomicAccess()
         }
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(length &+ rmwOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let value = castFromValue(sp[rmwOperand.value])
             let oldValue = atomicOp(rawPtr, value)
@@ -206,7 +300,17 @@ extension Execution {
             try throwUnalignedAtomicAccess()
         }
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(length &+ cmpxchgOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let expectedValue = castFromValue(sp[cmpxchgOperand.expected])
             let replacementValue = castFromValue(sp[cmpxchgOperand.replacement])
@@ -228,7 +332,17 @@ extension Execution {
             try throwUnalignedAtomicAccess()
         }
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(4 &+ waitOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let currentValue = wasmkit_atomic_load_32(rawPtr)
             let expectedValue = sp[waitOperand.expected].i32
@@ -241,20 +355,21 @@ extension Execution {
                 return
             }
 
-            // Value matches - wait for notification or timeout
+            // Value matches - wait for notification or timeout.
+            // Per the threads spec: timeout is a signed i64 in nanoseconds.
+            //   timeout < 0 → never expires (wait indefinitely)
+            //   timeout >= 0 → expires after `timeout` nanoseconds
             let parkingLot = store.value.atomicParkingLot
+            let timeoutSigned = Int64(bitPattern: timeout)
             let deadline: (() -> ContinuousClock.Instant)?
-            if timeout == 0 {
-                // Timeout of 0 means wait indefinitely
+            if timeoutSigned < 0 {
                 deadline = nil
             } else {
-                // Convert nanoseconds to Duration and calculate deadline
-                let timeoutDuration = Duration.nanoseconds(Int64(timeout))
+                let timeoutDuration = Duration.nanoseconds(timeoutSigned)
                 let deadlineInstant = ContinuousClock.now.advanced(by: timeoutDuration)
                 deadline = { deadlineInstant }
             }
 
-            var threadState = ThreadWaitState()
             let result = parkingLot.parkConditionally(
                 address: UInt64(address),
                 validate: {
@@ -262,8 +377,7 @@ extension Execution {
                     let currentValue = wasmkit_atomic_load_32(rawPtr)
                     return currentValue == expectedValue
                 },
-                deadline: deadline,
-                threadState: &threadState
+                deadline: deadline
             )
 
             let resultValue: Int32
@@ -287,7 +401,17 @@ extension Execution {
             try throwUnalignedAtomicAccess()
         }
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(8 &+ waitOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let currentValue = wasmkit_atomic_load_64(rawPtr)
             let expectedValue = sp[waitOperand.expected].i64
@@ -300,20 +424,21 @@ extension Execution {
                 return
             }
 
-            // Value matches - wait for notification or timeout
+            // Value matches - wait for notification or timeout.
+            // Per the threads spec: timeout is a signed i64 in nanoseconds.
+            //   timeout < 0 → never expires (wait indefinitely)
+            //   timeout >= 0 → expires after `timeout` nanoseconds
             let parkingLot = store.value.atomicParkingLot
+            let timeoutSigned = Int64(bitPattern: timeout)
             let deadline: (() -> ContinuousClock.Instant)?
-            if timeout == 0 {
-                // Timeout of 0 means wait indefinitely
+            if timeoutSigned < 0 {
                 deadline = nil
             } else {
-                // Convert nanoseconds to Duration and calculate deadline
-                let timeoutDuration = Duration.nanoseconds(Int64(timeout))
+                let timeoutDuration = Duration.nanoseconds(timeoutSigned)
                 let deadlineInstant = ContinuousClock.now.advanced(by: timeoutDuration)
                 deadline = { deadlineInstant }
             }
 
-            var threadState = ThreadWaitState()
             let result = parkingLot.parkConditionally(
                 address: UInt64(address),
                 validate: {
@@ -321,8 +446,7 @@ extension Execution {
                     let currentValue = wasmkit_atomic_load_64(rawPtr)
                     return currentValue == expectedValue
                 },
-                deadline: deadline,
-                threadState: &threadState
+                deadline: deadline
             )
 
             let resultValue: Int32
@@ -342,7 +466,17 @@ extension Execution {
         let i = sp[notifyOperand.pointer].asAddressOffset()
         let address = notifyOperand.offset + i
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(4 &+ notifyOperand.offset)
+        let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
+            boundsOk = true
+        } else if !isEndOverflow, let freshMs = reloadSharedMemorySize(sp: sp),
+            endAddress <= UInt64(freshMs)
+        {
+            boundsOk = true
+        } else {
+            boundsOk = false
+        }
+        if boundsOk {
             let count = sp[notifyOperand.count].i32
             let parkingLot = store.value.atomicParkingLot
             let wokenCount = parkingLot.unpark(address: UInt64(address), count: UInt32(bitPattern: Int32(truncatingIfNeeded: count)))

--- a/Sources/WasmKit/Execution/Instructions/Memory.swift
+++ b/Sources/WasmKit/Execution/Instructions/Memory.swift
@@ -10,6 +10,9 @@ extension Execution {
     @inline(never) func throwUnalignedAtomicAccess() throws -> Never {
         throw Trap(.unalignedAtomic)
     }
+    @inline(never) func throwAtomicWaitUnsupported() throws -> Never {
+        throw Trap(.message(.atomicWaitUnsupported))
+    }
 
     /// Reload the current shared memory size atomically (slow path for stale Ms).
     /// Returns `nil` if the default memory is not shared. `@inline(never)`: this is a
@@ -346,7 +349,6 @@ extension Execution {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let currentValue = wasmkit_atomic_load_32(rawPtr)
             let expectedValue = sp[waitOperand.expected].i32
-            let timeout = sp[waitOperand.timeout].i64
 
             // Check if value matches expected
             if currentValue != expectedValue {
@@ -359,34 +361,46 @@ extension Execution {
             // Per the threads spec: timeout is a signed i64 in nanoseconds.
             //   timeout < 0 → never expires (wait indefinitely)
             //   timeout >= 0 → expires after `timeout` nanoseconds
-            let parkingLot = store.value.atomicParkingLot
-            let timeoutSigned = Int64(bitPattern: timeout)
-            let deadline: (() -> ContinuousClock.Instant)?
-            if timeoutSigned < 0 {
-                deadline = nil
-            } else {
-                let timeoutDuration = Duration.nanoseconds(timeoutSigned)
-                let deadlineInstant = ContinuousClock.now.advanced(by: timeoutDuration)
-                deadline = { deadlineInstant }
-            }
+            #if os(Windows)
+                // Windows has no pthread blocking primitive (the parking lot is excluded,
+                // see AtomicParkingLot.swift). A zero timeout never blocks, so it still
+                // returns timed-out (2); any blocking wait is unsupported and traps.
+                if Int64(bitPattern: sp[waitOperand.timeout].i64) == 0 {
+                    sp[waitOperand.result] = .i32(2)
+                } else {
+                    try throwAtomicWaitUnsupported()
+                }
+            #else
+                let timeout = sp[waitOperand.timeout].i64
+                let parkingLot = store.value.atomicParkingLot
+                let timeoutSigned = Int64(bitPattern: timeout)
+                let deadline: (() -> ContinuousClock.Instant)?
+                if timeoutSigned < 0 {
+                    deadline = nil
+                } else {
+                    let timeoutDuration = Duration.nanoseconds(timeoutSigned)
+                    let deadlineInstant = ContinuousClock.now.advanced(by: timeoutDuration)
+                    deadline = { deadlineInstant }
+                }
 
-            let result = parkingLot.parkConditionally(
-                address: UInt64(address),
-                validate: {
-                    // Re-check the value atomically
-                    let currentValue = wasmkit_atomic_load_32(rawPtr)
-                    return currentValue == expectedValue
-                },
-                deadline: deadline
-            )
+                let result = parkingLot.parkConditionally(
+                    address: UInt64(address),
+                    validate: {
+                        // Re-check the value atomically
+                        let currentValue = wasmkit_atomic_load_32(rawPtr)
+                        return currentValue == expectedValue
+                    },
+                    deadline: deadline
+                )
 
-            let resultValue: Int32
-            switch result {
-            case .woken: resultValue = 0
-            case .mismatch: resultValue = 1
-            case .timedOut: resultValue = 2
-            }
-            sp[waitOperand.result] = .i32(UInt32(bitPattern: resultValue))
+                let resultValue: Int32
+                switch result {
+                case .woken: resultValue = 0
+                case .mismatch: resultValue = 1
+                case .timedOut: resultValue = 2
+                }
+                sp[waitOperand.result] = .i32(UInt32(bitPattern: resultValue))
+            #endif
         } else {
             try throwOutOfBoundsMemoryAccess()
         }
@@ -415,7 +429,6 @@ extension Execution {
             let rawPtr = md.unsafelyUnwrapped.advanced(by: Int(address))
             let currentValue = wasmkit_atomic_load_64(rawPtr)
             let expectedValue = sp[waitOperand.expected].i64
-            let timeout = sp[waitOperand.timeout].i64
 
             // Check if value matches expected
             if currentValue != expectedValue {
@@ -428,34 +441,46 @@ extension Execution {
             // Per the threads spec: timeout is a signed i64 in nanoseconds.
             //   timeout < 0 → never expires (wait indefinitely)
             //   timeout >= 0 → expires after `timeout` nanoseconds
-            let parkingLot = store.value.atomicParkingLot
-            let timeoutSigned = Int64(bitPattern: timeout)
-            let deadline: (() -> ContinuousClock.Instant)?
-            if timeoutSigned < 0 {
-                deadline = nil
-            } else {
-                let timeoutDuration = Duration.nanoseconds(timeoutSigned)
-                let deadlineInstant = ContinuousClock.now.advanced(by: timeoutDuration)
-                deadline = { deadlineInstant }
-            }
+            #if os(Windows)
+                // Windows has no pthread blocking primitive (the parking lot is excluded,
+                // see AtomicParkingLot.swift). A zero timeout never blocks, so it still
+                // returns timed-out (2); any blocking wait is unsupported and traps.
+                if Int64(bitPattern: sp[waitOperand.timeout].i64) == 0 {
+                    sp[waitOperand.result] = .i32(2)
+                } else {
+                    try throwAtomicWaitUnsupported()
+                }
+            #else
+                let timeout = sp[waitOperand.timeout].i64
+                let parkingLot = store.value.atomicParkingLot
+                let timeoutSigned = Int64(bitPattern: timeout)
+                let deadline: (() -> ContinuousClock.Instant)?
+                if timeoutSigned < 0 {
+                    deadline = nil
+                } else {
+                    let timeoutDuration = Duration.nanoseconds(timeoutSigned)
+                    let deadlineInstant = ContinuousClock.now.advanced(by: timeoutDuration)
+                    deadline = { deadlineInstant }
+                }
 
-            let result = parkingLot.parkConditionally(
-                address: UInt64(address),
-                validate: {
-                    // Re-check the value atomically
-                    let currentValue = wasmkit_atomic_load_64(rawPtr)
-                    return currentValue == expectedValue
-                },
-                deadline: deadline
-            )
+                let result = parkingLot.parkConditionally(
+                    address: UInt64(address),
+                    validate: {
+                        // Re-check the value atomically
+                        let currentValue = wasmkit_atomic_load_64(rawPtr)
+                        return currentValue == expectedValue
+                    },
+                    deadline: deadline
+                )
 
-            let resultValue: Int32
-            switch result {
-            case .woken: resultValue = 0
-            case .mismatch: resultValue = 1
-            case .timedOut: resultValue = 2
-            }
-            sp[waitOperand.result] = .i32(UInt32(bitPattern: resultValue))
+                let resultValue: Int32
+                switch result {
+                case .woken: resultValue = 0
+                case .mismatch: resultValue = 1
+                case .timedOut: resultValue = 2
+                }
+                sp[waitOperand.result] = .i32(UInt32(bitPattern: resultValue))
+            #endif
         } else {
             try throwOutOfBoundsMemoryAccess()
         }
@@ -464,7 +489,6 @@ extension Execution {
     /// Atomic notify - notify waiting threads
     mutating func atomicNotify(sp: Sp, md: Md, ms: Ms, notifyOperand: Instruction.AtomicNotifyOperand) throws {
         let i = sp[notifyOperand.pointer].asAddressOffset()
-        let address = notifyOperand.offset + i
         let (endAddress, isEndOverflow) = i.addingReportingOverflow(4 &+ notifyOperand.offset)
         let boundsOk: Bool
         if _fastPath(!isEndOverflow && endAddress <= ms) {
@@ -477,10 +501,17 @@ extension Execution {
             boundsOk = false
         }
         if boundsOk {
-            let count = sp[notifyOperand.count].i32
-            let parkingLot = store.value.atomicParkingLot
-            let wokenCount = parkingLot.unpark(address: UInt64(address), count: UInt32(bitPattern: Int32(truncatingIfNeeded: count)))
-            sp[notifyOperand.result] = .i32(wokenCount)
+            #if os(Windows)
+                // No parking lot on Windows (see AtomicParkingLot.swift); no waiters can
+                // ever be parked here, so there is nothing to wake.
+                sp[notifyOperand.result] = .i32(0)
+            #else
+                let address = notifyOperand.offset + i
+                let count = sp[notifyOperand.count].i32
+                let parkingLot = store.value.atomicParkingLot
+                let wokenCount = parkingLot.unpark(address: UInt64(address), count: UInt32(bitPattern: Int32(truncatingIfNeeded: count)))
+                sp[notifyOperand.result] = .i32(wokenCount)
+            #endif
         } else {
             try throwOutOfBoundsMemoryAccess()
         }

--- a/Sources/WasmKit/Execution/Instructions/SIMDMemoryAndLane.swift
+++ b/Sources/WasmKit/Execution/Instructions/SIMDMemoryAndLane.swift
@@ -2,9 +2,19 @@ import WasmTypes
 
 extension Execution {
     @inline(__always)
-    private func boundsCheck(_ start: UInt64, length: UInt64, ms: Ms) throws {
+    private func boundsCheck(_ start: UInt64, length: UInt64, ms: Ms, sp: Sp) throws {
         let (end, overflow) = start.addingReportingOverflow(length)
         if _fastPath(!overflow && end <= UInt64(ms)) { return }
+        try boundsCheckAfterSharedReload(end: end, overflow: overflow, sp: sp)
+    }
+
+    /// Cold path for a failed SIMD fast bounds check: a concurrent grow may have left
+    /// the cached `ms` stale, so reload the authoritative committed size (nil for
+    /// non-shared memory) and return if now in bounds, else trap. `@inline(never)` so the
+    /// ~19 inlined `boundsCheck` sites stay lean — a single cold call each.
+    @inline(never)
+    private func boundsCheckAfterSharedReload(end: UInt64, overflow: Bool, sp: Sp) throws {
+        if !overflow, let freshMs = reloadSharedMemorySize(sp: sp), end <= UInt64(freshMs) { return }
         try throwOutOfBoundsMemoryAccess()
     }
 
@@ -47,7 +57,7 @@ extension Execution {
         switch opcode {
         case .v128Load:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 16, ms: ms)
+            try boundsCheck(addr, length: 16, ms: ms, sp: sp)
             let lo = loadU64(md: md, address: addr)
             let hi = loadU64(md: md, address: addr &+ 8)
             sp.storeV128(V128Storage(lo: lo, hi: hi), at: immediate.result)
@@ -55,7 +65,7 @@ extension Execution {
 
         case .v128Store:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 16, ms: ms)
+            try boundsCheck(addr, length: 16, ms: ms, sp: sp)
             let v = sp.loadV128(at: immediate.input1)
             md.unsafelyUnwrapped.advanced(by: Int(addr)).bindMemory(to: UInt64.self, capacity: 1).pointee = v.lo.littleEndian
             md.unsafelyUnwrapped.advanced(by: Int(addr &+ 8)).bindMemory(to: UInt64.self, capacity: 1).pointee = v.hi.littleEndian
@@ -63,7 +73,7 @@ extension Execution {
 
         case .v128Load8X8S, .v128Load8X8U:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 8, ms: ms)
+            try boundsCheck(addr, length: 8, ms: ms, sp: sp)
             var lanes: [UInt64] = []
             lanes.reserveCapacity(8)
             for i in 0..<8 {
@@ -80,7 +90,7 @@ extension Execution {
 
         case .v128Load16X4S, .v128Load16X4U:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 8, ms: ms)
+            try boundsCheck(addr, length: 8, ms: ms, sp: sp)
             var lanes: [UInt64] = []
             lanes.reserveCapacity(4)
             for i in 0..<4 {
@@ -97,7 +107,7 @@ extension Execution {
 
         case .v128Load32X2S, .v128Load32X2U:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 8, ms: ms)
+            try boundsCheck(addr, length: 8, ms: ms, sp: sp)
             var lanes: [UInt64] = []
             lanes.reserveCapacity(2)
             for i in 0..<2 {
@@ -114,7 +124,7 @@ extension Execution {
 
         case .v128Load8Splat:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 1, ms: ms)
+            try boundsCheck(addr, length: 1, ms: ms, sp: sp)
             let b = loadU8(md: md, address: addr)
             let v = V128Lanes.pack([UInt64](repeating: UInt64(b), count: 16), widthBits: 8, laneCount: 16)
             sp.storeV128(v, at: immediate.result)
@@ -122,7 +132,7 @@ extension Execution {
 
         case .v128Load16Splat:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 2, ms: ms)
+            try boundsCheck(addr, length: 2, ms: ms, sp: sp)
             let w = loadU16(md: md, address: addr)
             let v = V128Lanes.pack([UInt64](repeating: UInt64(w), count: 8), widthBits: 16, laneCount: 8)
             sp.storeV128(v, at: immediate.result)
@@ -130,7 +140,7 @@ extension Execution {
 
         case .v128Load32Splat:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 4, ms: ms)
+            try boundsCheck(addr, length: 4, ms: ms, sp: sp)
             let d = loadU32(md: md, address: addr)
             let v = V128Lanes.pack([UInt64](repeating: UInt64(d), count: 4), widthBits: 32, laneCount: 4)
             sp.storeV128(v, at: immediate.result)
@@ -138,14 +148,14 @@ extension Execution {
 
         case .v128Load64Splat:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 8, ms: ms)
+            try boundsCheck(addr, length: 8, ms: ms, sp: sp)
             let q = loadU64(md: md, address: addr)
             sp.storeV128(V128Storage(lo: q, hi: q), at: immediate.result)
             return true
 
         case .v128Load32Zero:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 4, ms: ms)
+            try boundsCheck(addr, length: 4, ms: ms, sp: sp)
             let d = loadU32(md: md, address: addr)
             var lanes = [UInt64](repeating: 0, count: 4)
             lanes[0] = UInt64(d)
@@ -154,7 +164,7 @@ extension Execution {
 
         case .v128Load64Zero:
             let addr = sp[immediate.input0].asAddressOffset() &+ immediate.offset
-            try boundsCheck(addr, length: 8, ms: ms)
+            try boundsCheck(addr, length: 8, ms: ms, sp: sp)
             let q = loadU64(md: md, address: addr)
             sp.storeV128(V128Storage(lo: q, hi: 0), at: immediate.result)
             return true
@@ -165,22 +175,22 @@ extension Execution {
             let lane = Int(immediate.lane)
             switch opcode {
             case .v128Load8Lane:
-                try boundsCheck(addr, length: 1, ms: ms)
+                try boundsCheck(addr, length: 1, ms: ms, sp: sp)
                 var bytes = V128Lanes.extract(vec, widthBits: 8, laneCount: 16)
                 bytes[lane] = UInt64(loadU8(md: md, address: addr))
                 vec = V128Lanes.pack(bytes, widthBits: 8, laneCount: 16)
             case .v128Load16Lane:
-                try boundsCheck(addr, length: 2, ms: ms)
+                try boundsCheck(addr, length: 2, ms: ms, sp: sp)
                 var lanes = V128Lanes.extract(vec, widthBits: 16, laneCount: 8)
                 lanes[lane] = UInt64(loadU16(md: md, address: addr))
                 vec = V128Lanes.pack(lanes, widthBits: 16, laneCount: 8)
             case .v128Load32Lane:
-                try boundsCheck(addr, length: 4, ms: ms)
+                try boundsCheck(addr, length: 4, ms: ms, sp: sp)
                 var lanes = V128Lanes.extract(vec, widthBits: 32, laneCount: 4)
                 lanes[lane] = UInt64(loadU32(md: md, address: addr))
                 vec = V128Lanes.pack(lanes, widthBits: 32, laneCount: 4)
             case .v128Load64Lane:
-                try boundsCheck(addr, length: 8, ms: ms)
+                try boundsCheck(addr, length: 8, ms: ms, sp: sp)
                 var lanes = V128Lanes.extract(vec, widthBits: 64, laneCount: 2)
                 lanes[lane] = loadU64(md: md, address: addr)
                 vec = V128Lanes.pack(lanes, widthBits: 64, laneCount: 2)
@@ -196,21 +206,21 @@ extension Execution {
             let lane = Int(immediate.lane)
             switch opcode {
             case .v128Store8Lane:
-                try boundsCheck(addr, length: 1, ms: ms)
+                try boundsCheck(addr, length: 1, ms: ms, sp: sp)
                 let bytes = V128Lanes.extract(vec, widthBits: 8, laneCount: 16)
                 md.unsafelyUnwrapped.storeBytes(of: UInt8(truncatingIfNeeded: bytes[lane]), toByteOffset: Int(addr), as: UInt8.self)
             case .v128Store16Lane:
-                try boundsCheck(addr, length: 2, ms: ms)
+                try boundsCheck(addr, length: 2, ms: ms, sp: sp)
                 let lanes = V128Lanes.extract(vec, widthBits: 16, laneCount: 8)
                 let v = UInt16(truncatingIfNeeded: lanes[lane]).littleEndian
                 md.unsafelyUnwrapped.advanced(by: Int(addr)).bindMemory(to: UInt16.self, capacity: 1).pointee = v
             case .v128Store32Lane:
-                try boundsCheck(addr, length: 4, ms: ms)
+                try boundsCheck(addr, length: 4, ms: ms, sp: sp)
                 let lanes = V128Lanes.extract(vec, widthBits: 32, laneCount: 4)
                 let v = UInt32(truncatingIfNeeded: lanes[lane]).littleEndian
                 md.unsafelyUnwrapped.advanced(by: Int(addr)).bindMemory(to: UInt32.self, capacity: 1).pointee = v
             case .v128Store64Lane:
-                try boundsCheck(addr, length: 8, ms: ms)
+                try boundsCheck(addr, length: 8, ms: ms, sp: sp)
                 let lanes = V128Lanes.extract(vec, widthBits: 64, laneCount: 2)
                 let v = lanes[lane].littleEndian
                 md.unsafelyUnwrapped.advanced(by: Int(addr)).bindMemory(to: UInt64.self, capacity: 1).pointee = v

--- a/Sources/WasmKit/Execution/SharedMemoryStorage.swift
+++ b/Sources/WasmKit/Execution/SharedMemoryStorage.swift
@@ -140,10 +140,12 @@ struct SharedMemoryStorage: ~Copyable {
         }
 
         if deltaBytes > 0 {
-            #if os(Windows)
+            #if os(WASI)
+                // The whole max region is already allocated and zero-filled; nothing to commit.
+            #elseif os(Windows)
                 guard
                     VirtualAlloc(
-                        basePointer.advanced(by: oldBytes), deltaBytes,
+                        basePointer.advanced(by: oldBytes), SIZE_T(deltaBytes),
                         DWORD(MEM_COMMIT), DWORD(PAGE_READWRITE)
                     ) != nil
                 else { return -1 }
@@ -197,12 +199,20 @@ struct SharedMemoryStorage: ~Copyable {
             let ptr = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
             return ptr
         }
-        #if os(Windows)
-            guard let base = VirtualAlloc(nil, reserveBytes, DWORD(MEM_RESERVE), DWORD(PAGE_NOACCESS)) else {
+        #if os(WASI)
+            // Wasm always uses software bounds checking: no PROT_NONE reservation and no
+            // page-commit faults, so there is no mmap/mprotect dance. Allocate the whole
+            // (max-bounded) region up front, zero-filled. `reserveBytes == maxByteCount`
+            // here, and `grow` only bumps the size counters.
+            let base = UnsafeMutableRawPointer.allocate(byteCount: reserveBytes, alignment: 16)
+            base.initializeMemory(as: UInt8.self, repeating: 0, count: reserveBytes)
+            return base
+        #elseif os(Windows)
+            guard let base = VirtualAlloc(nil, SIZE_T(reserveBytes), DWORD(MEM_RESERVE), DWORD(PAGE_NOACCESS)) else {
                 throw Trap(.mmapFailed(reserveBytes: reserveBytes))
             }
             if commitBytes > 0 {
-                guard VirtualAlloc(base, commitBytes, DWORD(MEM_COMMIT), DWORD(PAGE_READWRITE)) != nil else {
+                guard VirtualAlloc(base, SIZE_T(commitBytes), DWORD(MEM_COMMIT), DWORD(PAGE_READWRITE)) != nil else {
                     VirtualFree(base, 0, DWORD(MEM_RELEASE))
                     throw Trap(.mmapFailed(reserveBytes: reserveBytes))
                 }
@@ -234,7 +244,9 @@ struct SharedMemoryStorage: ~Copyable {
             base.deallocate()
             return
         }
-        #if os(Windows)
+        #if os(WASI)
+            base.deallocate()
+        #elseif os(Windows)
             VirtualFree(base, 0, DWORD(MEM_RELEASE))
         #else
             munmap(base, byteCount)

--- a/Sources/WasmKit/Execution/SharedMemoryStorage.swift
+++ b/Sources/WasmKit/Execution/SharedMemoryStorage.swift
@@ -1,0 +1,243 @@
+import Synchronization
+import WasmParser
+@preconcurrency import _CWasmKit
+
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#elseif canImport(Musl)
+    import Musl
+#elseif os(Windows)
+    import WinSDK
+#endif
+
+/// Thread-safe backing store for a WebAssembly shared linear memory.
+///
+/// The storage pre-reserves `maxPageCount * pageSize` bytes of virtual address
+/// space using `mmap(PROT_NONE)` (POSIX) or `VirtualAlloc(MEM_RESERVE)` (Windows).
+/// Only the initially committed pages are made accessible; growth commits
+/// additional pages via `mprotect` / `VirtualAlloc(MEM_COMMIT)`.
+///
+/// The base pointer never changes, so existing references remain valid.
+///
+/// ## Thread Safety
+///
+/// - `basePointer` is stable for the lifetime of the object.
+/// - `currentByteCount` is an `Atomic<Int>` read/written with acquire/release
+///   for the Ms staleness reload path.
+/// - The C-level `wasmkit_shared_memory_guard_t` holds a spinlock (`atomic_flag`)
+///   that serializes grow with the signal handler. The signal handler acquires
+///   this spinlock when a fault lands in our reservation, checks the committed
+///   size, and either retries (grow in progress) or traps (genuine OOB).
+///
+/// ## Deregistration Invariant
+///
+/// The guard is unregistered from the global registry before deallocation.
+/// We rely on the invariant that shared memory is not deallocated while any
+/// thread is actively executing wasm on that memory.
+struct SharedMemoryStorage: ~Copyable {
+    /// The stable base pointer. Never changes after init.
+    let basePointer: UnsafeMutableRawPointer
+
+    /// The current committed size in bytes (Swift-side atomic for Ms staleness reload).
+    let currentByteCount: Atomic<Int>
+
+    /// The maximum allowed byte count (maxPages * pageSize).
+    let maxByteCount: Int
+
+    /// The total reservation size in bytes.
+    /// On mprotect platforms this covers the full wasm32 address space + offset guard;
+    /// otherwise it equals `maxByteCount`.
+    let reservationSize: Int
+
+    /// The memory type this storage was created from.
+    let memoryType: MemoryType
+
+    /// C-level guard struct registered with the signal handler.
+    /// Owns the spinlock and the canonical `current_byte_count` for the signal handler.
+    let guardPtr: UnsafeMutablePointer<wasmkit_shared_memory_guard_t>
+
+    /// The page size in bytes (64 KiB per Wasm spec).
+    static let pageSize = 65536
+
+    init(memoryType: MemoryType, engineConfiguration: EngineConfiguration, resourceLimiter: any ResourceLimiter) throws(Trap) {
+        let initialBytes = Int(memoryType.min) * Self.pageSize
+        let maxPages = memoryType.max ?? UInt64(MemoryEntity.maxPageCount(isMemory64: memoryType.isMemory64))
+        let (maxBytes, overflow) = Int(clamping: maxPages).multipliedReportingOverflow(by: Self.pageSize)
+        if overflow {
+            throw Trap(.mmapFailed(reserveBytes: Int.max))
+        }
+        do {
+            guard try resourceLimiter.limitMemoryGrowth(to: initialBytes) else {
+                throw Trap(.initialMemorySizeExceedsLimit(byteSize: initialBytes))
+            }
+        } catch let trap as Trap {
+            throw trap
+        } catch {
+            throw Trap(.initialMemorySizeExceedsLimit(byteSize: initialBytes))
+        }
+
+        // Compute reservation size: on mprotect platforms with wasm32, reserve the full
+        // 4 GiB + offset guard region so unchecked instructions fault within our mmap.
+        let reservationSize = Self.computeReservationSize(
+            maxBytes: maxBytes, memoryType: memoryType, engineConfiguration: engineConfiguration)
+
+        let base = try Self.reserveAndCommit(reserveBytes: reservationSize, commitBytes: initialBytes)
+
+        // Allocate and register the C-level guard struct for signal handler coordination.
+        // Must happen before assigning any self. properties — ~Copyable types require
+        // consistent initialization state through all code paths.
+        let gp = UnsafeMutablePointer<wasmkit_shared_memory_guard_t>.allocate(capacity: 1)
+        wasmkit_shared_memory_guard_init(gp, base, reservationSize, initialBytes)
+        guard wasmkit_shared_memory_guard_register(gp) == 0 else {
+            gp.deallocate()
+            Self.releaseReservation(base, byteCount: reservationSize)
+            throw Trap(.sharedMemoryGuardRegistryFull)
+        }
+
+        self.basePointer = base
+        self.maxByteCount = maxBytes
+        self.reservationSize = reservationSize
+        self.memoryType = memoryType
+        self.currentByteCount = Atomic(initialBytes)
+        self.guardPtr = gp
+    }
+
+    deinit {
+        wasmkit_shared_memory_guard_unregister(guardPtr)
+        guardPtr.deallocate()
+        Self.releaseReservation(basePointer, byteCount: reservationSize)
+    }
+
+    /// Grow by `deltaPages`. Returns the old page count, or -1 on failure.
+    /// Thread-safe: serialized by the C-level spinlock (same lock the signal handler acquires).
+    func grow(by deltaPages: Int, resourceLimiter: any ResourceLimiter) throws(Trap) -> Int {
+        // Block SIGSEGV/SIGBUS before acquiring the spinlock to prevent self-deadlock
+        // if a signal arrives while the lock is held (e.g., from a stray pointer during grow).
+        #if os(macOS) || os(Linux)
+            wasmkit_shared_memory_guard_lock_for_grow(guardPtr)
+            defer { wasmkit_shared_memory_guard_unlock_for_grow(guardPtr) }
+        #else
+            wasmkit_shared_memory_guard_lock(guardPtr)
+            defer { wasmkit_shared_memory_guard_unlock(guardPtr) }
+        #endif
+
+        let oldBytes = Int(wasmkit_shared_memory_guard_get_size(guardPtr))
+        let oldPages = oldBytes / Self.pageSize
+
+        // Overflow-checked arithmetic
+        let (deltaBytes, mulOverflow) = deltaPages.multipliedReportingOverflow(by: Self.pageSize)
+        guard !mulOverflow else { return -1 }
+        let (newBytes, addOverflow) = oldBytes.addingReportingOverflow(deltaBytes)
+        guard !addOverflow else { return -1 }
+        guard newBytes <= maxByteCount else { return -1 }
+
+        do {
+            guard try resourceLimiter.limitMemoryGrowth(to: newBytes) else { return -1 }
+        } catch {
+            return -1
+        }
+
+        if deltaBytes > 0 {
+            #if os(Windows)
+                guard
+                    VirtualAlloc(
+                        basePointer.advanced(by: oldBytes), deltaBytes,
+                        DWORD(MEM_COMMIT), DWORD(PAGE_READWRITE)
+                    ) != nil
+                else { return -1 }
+            #else
+                guard
+                    mprotect(
+                        basePointer.advanced(by: oldBytes), deltaBytes,
+                        PROT_READ | PROT_WRITE
+                    ) == 0
+                else { return -1 }
+            #endif
+        }
+
+        // Two-phase size update:
+        // 1. C guard size (under spinlock): the signal handler reads this value after
+        //    acquiring the per-guard spinlock. Updated first so the signal handler sees
+        //    the new size only after mprotect has committed the pages.
+        wasmkit_shared_memory_guard_set_size(guardPtr, newBytes)
+        // 2. Swift-side atomic: checked instructions read this via `reloadSharedMemorySize`.
+        //    Updated second. There is a brief window where the Swift value < C value;
+        //    this is conservative (safe) — the checked path will see the old (smaller) size,
+        //    fail the fast-path bounds check, then reload from the C guard via the slow path.
+        currentByteCount.store(newBytes, ordering: .releasing)
+
+        return oldPages
+    }
+
+    private static func computeReservationSize(
+        maxBytes: Int, memoryType: MemoryType, engineConfiguration: EngineConfiguration
+    ) -> Int {
+        #if os(macOS) || os(Linux)
+            if !memoryType.isMemory64, engineConfiguration.memoryBoundsChecking != .software {
+                return MprotectLinearMemory.wasm32ReservationSize(
+                    offsetGuardSize: engineConfiguration.memoryOffsetGuardSize)
+            }
+            return maxBytes
+        #else
+            return maxBytes
+        #endif
+    }
+
+    // MARK: - Platform Memory Management
+
+    /// Reserve `reserveBytes` of virtual address space (PROT_NONE / PAGE_NOACCESS),
+    /// then commit the first `commitBytes` as read-write.
+    private static func reserveAndCommit(
+        reserveBytes: Int, commitBytes: Int
+    ) throws(Trap) -> UnsafeMutableRawPointer {
+        guard reserveBytes > 0 else {
+            // Zero-size reservation: return a non-nil sentinel.
+            let ptr = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+            return ptr
+        }
+        #if os(Windows)
+            guard let base = VirtualAlloc(nil, reserveBytes, DWORD(MEM_RESERVE), DWORD(PAGE_NOACCESS)) else {
+                throw Trap(.mmapFailed(reserveBytes: reserveBytes))
+            }
+            if commitBytes > 0 {
+                guard VirtualAlloc(base, commitBytes, DWORD(MEM_COMMIT), DWORD(PAGE_READWRITE)) != nil else {
+                    VirtualFree(base, 0, DWORD(MEM_RELEASE))
+                    throw Trap(.mmapFailed(reserveBytes: reserveBytes))
+                }
+            }
+            return base
+        #else
+            // POSIX: Reserve entire range as PROT_NONE, then commit initial pages.
+            #if os(Linux)
+                let mapAnon = MAP_ANONYMOUS
+            #else
+                let mapAnon = MAP_ANON
+            #endif
+            let base = mmap(nil, reserveBytes, PROT_NONE, MAP_PRIVATE | mapAnon, -1, 0)
+            guard base != MAP_FAILED else {
+                throw Trap(.mmapFailed(reserveBytes: reserveBytes))
+            }
+            if commitBytes > 0 {
+                guard mprotect(base, commitBytes, PROT_READ | PROT_WRITE) == 0 else {
+                    munmap(base, reserveBytes)
+                    throw Trap(.mmapFailed(reserveBytes: reserveBytes))
+                }
+            }
+            return base!
+        #endif
+    }
+
+    private static func releaseReservation(_ base: UnsafeMutableRawPointer, byteCount: Int) {
+        guard byteCount > 0 else {
+            base.deallocate()
+            return
+        }
+        #if os(Windows)
+            VirtualFree(base, 0, DWORD(MEM_RELEASE))
+        #else
+            munmap(base, byteCount)
+        #endif
+    }
+}

--- a/Sources/WasmKit/Execution/SharedMemoryStorage.swift
+++ b/Sources/WasmKit/Execution/SharedMemoryStorage.swift
@@ -8,6 +8,8 @@ import WasmParser
     import Glibc
 #elseif canImport(Musl)
     import Musl
+#elseif canImport(Android)
+    import Android
 #elseif os(Windows)
     import WinSDK
 #endif

--- a/Sources/WasmKit/Execution/SharedMemoryStorage.swift
+++ b/Sources/WasmKit/Execution/SharedMemoryStorage.swift
@@ -228,7 +228,9 @@ struct SharedMemoryStorage: ~Copyable {
                 let mapAnon = MAP_ANON
             #endif
             let base = mmap(nil, reserveBytes, PROT_NONE, MAP_PRIVATE | mapAnon, -1, 0)
-            guard base != MAP_FAILED else {
+            // `MAP_FAILED` is `(void *)-1`; compare that sentinel directly rather than the
+            // macro, which Bionic defines as a C++ `reinterpret_cast` Swift cannot import.
+            guard base != UnsafeMutableRawPointer(bitPattern: -1) else {
                 throw Trap(.mmapFailed(reserveBytes: reserveBytes))
             }
             if commitBytes > 0 {
@@ -237,7 +239,12 @@ struct SharedMemoryStorage: ~Copyable {
                     throw Trap(.mmapFailed(reserveBytes: reserveBytes))
                 }
             }
-            return base!
+            #if canImport(Android)
+                // Bionic types `mmap` as returning a non-optional pointer.
+                return base
+            #else
+                return base!
+            #endif
         #endif
     }
 

--- a/Sources/WasmKit/Execution/Store.swift
+++ b/Sources/WasmKit/Execution/Store.swift
@@ -18,8 +18,11 @@ public final class Store {
     /// The engine associated with this store.
     public let engine: Engine
 
-    /// Parking lot for atomic wait/notify operations
-    let atomicParkingLot = AtomicParkingLot()
+    /// Parking lot for atomic wait/notify operations.
+    /// Excluded on Windows, which has no pthread blocking primitive (see AtomicParkingLot.swift).
+    #if !os(Windows)
+        let atomicParkingLot = AtomicParkingLot()
+    #endif
 
     /// Create a new store associated with the given engine.
     public init(engine: Engine) {

--- a/Sources/WasmKit/Execution/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/StoreAllocator.swift
@@ -365,6 +365,7 @@ extension StoreAllocator {
             module: module, engine: engine, resourceLimiter: resourceLimiter,
             importedFunctions: importedFunctions, importedTables: importedTables,
             importedMemories: importedMemories, importedGlobals: importedGlobals,
+            importedTags: importedTags,
             isDebuggable: isDebuggable
         )
     }
@@ -383,6 +384,7 @@ extension StoreAllocator {
         importedTables: [InternalTable],
         importedMemories: [InternalMemory],
         importedGlobals: [InternalGlobal],
+        importedTags: [InternalTag],
         isDebuggable: Bool,
         localMemoryResolver: ((_ memoryIndex: Int, _ memoryType: MemoryType) throws -> InternalMemory)? = nil
     ) throws -> InternalInstance {

--- a/Sources/WasmKit/Execution/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/StoreAllocator.swift
@@ -1,3 +1,4 @@
+import Synchronization
 import WasmParser
 
 /// A simple bump allocator for a single type.
@@ -155,50 +156,59 @@ extension ImmutableArray: Sequence {
 
 /// A type that can be interned into a unique identifier.
 /// Used for efficient equality comparison.
-protocol Internable {
+package protocol Internable {
     /// Storage representation of an interned value.
-    associatedtype Offset: UnsignedInteger
+    associatedtype Offset: UnsignedInteger & Sendable
 }
 
 /// An interned value of type `T`.
 /// Two interned values should be equal if their corresponding `T` values are equal.
-struct Interned<T: Internable>: Equatable, Hashable {
+struct Interned<T: Internable>: Equatable, Hashable, Sendable {
     let id: T.Offset
 }
 
 /// A deduplicating interner for values of type `Item`.
-class Interner<Item: Hashable & Internable> {
-    private var itemByIntern: [Item]
-    private var internByItem: [Item: Interned<Item>]
+///
+/// Thread-safe: all access is serialized by an internal `Mutex`.
+package final class Interner<Item: Hashable & Internable & Sendable>: Sendable {
+    private struct State {
+        var itemByIntern: [Item]
+        var internByItem: [Item: Interned<Item>]
+    }
+
+    private let state: Mutex<State>
 
     init() {
-        itemByIntern = []
-        internByItem = [:]
+        state = Mutex(State(itemByIntern: [], internByItem: [:]))
     }
 
     /// Interns the given `item` and returns an interned value.
     /// If the item is already interned, returns the existing interned value.
     func intern(_ item: Item) -> Interned<Item> {
-        if let interned = internByItem[item] {
-            return interned
+        state.withLock { state in
+            if let interned = state.internByItem[item] {
+                return interned
+            }
+            let id = state.itemByIntern.count
+            state.itemByIntern.append(item)
+            let newInterned = Interned<Item>(id: Item.Offset(id))
+            state.internByItem[item] = newInterned
+            return newInterned
         }
-        let id = itemByIntern.count
-        itemByIntern.append(item)
-        let newInterned = Interned<Item>(id: Item.Offset(id))
-        internByItem[item] = newInterned
-        return newInterned
     }
 
     /// Resolves the given `interned` value to the original value.
     func resolve(_ interned: Interned<Item>) -> Item {
-        return itemByIntern[Int(interned.id)]
+        state.withLock { state in
+            state.itemByIntern[Int(interned.id)]
+        }
     }
 }
 
 /// A function type is internable for efficient equality comparison.
 /// Usually used for signature checking at indirect calls.
 extension FunctionType: Internable {
-    typealias Offset = UInt32
+    package typealias Offset = UInt32
 }
 
 typealias InternedFuncType = Interned<FunctionType>
@@ -211,6 +221,7 @@ class StoreAllocator {
     private var hostFunctions: BumpAllocator<HostFunctionEntity>
     private var tables: BumpAllocator<TableEntity>
     private var memories: BumpAllocator<MemoryEntity>
+    private var sharedMemoryStorages: BumpAllocator<SharedMemoryStorage>
     private var globals: BumpAllocator<GlobalEntity>
     private var tags: BumpAllocator<TagEntity>
     private var elements: BumpAllocator<ElementSegmentEntity>
@@ -234,6 +245,7 @@ class StoreAllocator {
         codes = BumpAllocator(initialCapacity: 64)
         tables = BumpAllocator(initialCapacity: 2)
         memories = BumpAllocator(initialCapacity: 2)
+        sharedMemoryStorages = BumpAllocator(initialCapacity: 1)
         globals = BumpAllocator(initialCapacity: 256)
         tags = BumpAllocator(initialCapacity: 2)
         elements = BumpAllocator(initialCapacity: 2)
@@ -268,7 +280,6 @@ extension StoreAllocator {
     ) throws -> InternalInstance {
         // Step 1 of module allocation algorithm, according to Wasm 2.0 spec.
 
-        let types = module.types
         var importedFunctions: [InternalFunction] = []
         var importedTables: [InternalTable] = []
         var importedMemories: [InternalMemory] = []
@@ -350,6 +361,33 @@ extension StoreAllocator {
             }
         }
 
+        return try allocateCore(
+            module: module, engine: engine, resourceLimiter: resourceLimiter,
+            importedFunctions: importedFunctions, importedTables: importedTables,
+            importedMemories: importedMemories, importedGlobals: importedGlobals,
+            isDebuggable: isDebuggable
+        )
+    }
+
+    /// Shared core of module allocation: entity allocation, const eval,
+    /// element/data segments, exports, and InstanceEntity construction.
+    ///
+    /// - Parameters:
+    ///   - localMemoryResolver: Optional override for allocating each local
+    ///     memory. When `nil`, local memories are allocated fresh.
+    private func allocateCore(
+        module: Module,
+        engine: Engine,
+        resourceLimiter: any ResourceLimiter,
+        importedFunctions: [InternalFunction],
+        importedTables: [InternalTable],
+        importedMemories: [InternalMemory],
+        importedGlobals: [InternalGlobal],
+        isDebuggable: Bool,
+        localMemoryResolver: ((_ memoryIndex: Int, _ memoryType: MemoryType) throws -> InternalMemory)? = nil
+    ) throws -> InternalInstance {
+        let types = module.types
+
         func allocateEntities<EntityHandle, Internals: Collection>(
             imports: [EntityHandle],
             internals: Internals, allocateHandle: (Internals.Element, Int) throws -> EntityHandle
@@ -397,11 +435,20 @@ extension StoreAllocator {
         )
 
         // Step 4.
-        let memories = try allocateEntities(
-            imports: importedMemories,
-            internals: module.internalMemories,
-            allocateHandle: { m, _ in try allocate(memoryType: m, engineConfiguration: engine.configuration, resourceLimiter: resourceLimiter) }
-        )
+        let memories: ImmutableArray<InternalMemory>
+        if let resolver = localMemoryResolver {
+            memories = try allocateEntities(
+                imports: importedMemories,
+                internals: module.internalMemories,
+                allocateHandle: { m, absoluteIndex in try resolver(absoluteIndex, m) }
+            )
+        } else {
+            memories = try allocateEntities(
+                imports: importedMemories,
+                internals: module.internalMemories,
+                allocateHandle: { m, _ in try allocate(memoryType: m, engineConfiguration: engine.configuration, resourceLimiter: resourceLimiter) }
+            )
+        }
 
         var functionRefs: Set<InternalFunction> = []
         // Step 5.
@@ -558,7 +605,32 @@ extension StoreAllocator {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/exec/modules.html#alloc-mem>
     func allocate(memoryType: MemoryType, engineConfiguration: EngineConfiguration, resourceLimiter: any ResourceLimiter) throws -> InternalMemory {
-        let pointer = try memories.allocate(initializing: MemoryEntity(memoryType, engineConfiguration: engineConfiguration, resourceLimiter: resourceLimiter))
+        if memoryType.shared {
+            let storage = try SharedMemoryStorage(
+                memoryType: memoryType, engineConfiguration: engineConfiguration,
+                resourceLimiter: resourceLimiter)
+            let storagePointer = sharedMemoryStorages.allocate(initializing: storage)
+            let sharedHandle = SharedMemoryEntity(unsafe: storagePointer)
+            let pointer = memories.allocate(
+                initializing: MemoryEntity(memoryType, sharedStorage: sharedHandle)
+            )
+            return InternalMemory(unsafe: pointer)
+        } else {
+            let pointer = try memories.allocate(
+                initializing: MemoryEntity(memoryType, engineConfiguration: engineConfiguration, resourceLimiter: resourceLimiter)
+            )
+            return InternalMemory(unsafe: pointer)
+        }
+    }
+
+    /// Allocate a memory entity wrapping an existing shared memory storage.
+    ///
+    /// Used by `wasi_thread_spawn` to provide the same shared memory as an
+    /// import to child Store instances.
+    func allocate(memoryType: MemoryType, sharedStorage: SharedMemoryEntity) -> InternalMemory {
+        let pointer = memories.allocate(
+            initializing: MemoryEntity(memoryType, sharedStorage: sharedStorage)
+        )
         return InternalMemory(unsafe: pointer)
     }
 

--- a/Sources/WasmKit/Execution/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/StoreAllocator.swift
@@ -156,7 +156,7 @@ extension ImmutableArray: Sequence {
 
 /// A type that can be interned into a unique identifier.
 /// Used for efficient equality comparison.
-package protocol Internable {
+protocol Internable {
     /// Storage representation of an interned value.
     associatedtype Offset: UnsignedInteger & Sendable
 }
@@ -170,7 +170,7 @@ struct Interned<T: Internable>: Equatable, Hashable, Sendable {
 /// A deduplicating interner for values of type `Item`.
 ///
 /// Thread-safe: all access is serialized by an internal `Mutex`.
-package final class Interner<Item: Hashable & Internable & Sendable>: Sendable {
+final class Interner<Item: Hashable & Internable & Sendable>: Sendable {
     private struct State {
         var itemByIntern: [Item]
         var internByItem: [Item: Interned<Item>]
@@ -208,7 +208,7 @@ package final class Interner<Item: Hashable & Internable & Sendable>: Sendable {
 /// A function type is internable for efficient equality comparison.
 /// Usually used for signature checking at indirect calls.
 extension FunctionType: Internable {
-    package typealias Offset = UInt32
+    typealias Offset = UInt32
 }
 
 typealias InternedFuncType = Interned<FunctionType>

--- a/Sources/WasmKit/Module.swift
+++ b/Sources/WasmKit/Module.swift
@@ -1,6 +1,6 @@
 import WasmParser
 
-struct ModuleImports {
+struct ModuleImports: Sendable {
     let numberOfFunctions: Int
     let numberOfGlobals: Int
     let numberOfMemories: Int
@@ -53,7 +53,7 @@ struct ModuleImports {
 /// by calling either ``parseWasm(bytes:features:)`` or ``parseWasm(filePath:features:)``.
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#modules>
-public struct Module {
+public struct Module: Sendable {
     var functions: [GuestFunction]
     let elements: [ElementSegment]
     let data: [DataSegment]
@@ -194,6 +194,37 @@ public struct Module {
         // Step 12-13.
 
         // Steps 14-15.
+        try initializeActiveElementSegments(instance: instance, constEvalContext: constEvalContext)
+
+        // Step 16.
+        try initializeActiveDataSegments(instance: instance, constEvalContext: constEvalContext)
+
+        // Step 17.
+        if let startIndex = start {
+            let startFunction = try instance.functions[validating: Int(startIndex)]
+            _ = try startFunction.invoke([], store: store)
+        }
+
+        // Compile all functions eagerly if the engine is in eager compilation mode
+        if store.engine.configuration.compilationMode == .eager {
+            try instance.withValue {
+                try $0.compileAllFunctions(store: store)
+            }
+        }
+
+        return instance
+    }
+
+    /// Materialize lazily-computed elements in this module
+    @available(*, deprecated, message: "Module materialization is no longer supported. Instantiate the module explicitly instead.")
+    public mutating func materializeAll() throws {}
+
+    // MARK: - Segment Initialization Helpers
+
+    /// Initialize active element segments into instance tables.
+    private func initializeActiveElementSegments(
+        instance: InternalInstance, constEvalContext: ConstEvaluationContext
+    ) throws {
         for element in elements {
             guard case .active(let tableIndex, let offset) = element.mode else { continue }
             let table = try instance.tables[validating: Int(tableIndex)]
@@ -228,9 +259,24 @@ public struct Module {
                 )
             }
         }
+    }
 
-        // Step 16.
-        for case .active(let data) in data {
+    /// Initialize active data segments into instance memories.
+    ///
+    /// When `sharedMemories` is non-nil (child thread instantiation), active
+    /// data segments targeting shared memories are skipped — re-applying them
+    /// would overwrite memory the parent has already modified.
+    private func initializeActiveDataSegments(
+        instance: InternalInstance, constEvalContext: ConstEvaluationContext,
+        sharedMemories: [SharedMemoryEntity?]? = nil
+    ) throws {
+        for case .active(let data) in self.data {
+            // Skip data segments targeting shared memories in child threads
+            if let sharedMemories, Int(data.index) < sharedMemories.count,
+                sharedMemories[Int(data.index)] != nil
+            {
+                continue
+            }
             let memory = try instance.memories[validating: Int(data.index), MemoryEntity.createOutOfBoundsError]
             let isMemory64 = memory.withValue { $0.limit.isMemory64 }
             let offsetValue = try data.offset.evaluate(
@@ -251,26 +297,7 @@ public struct Module {
                 try memory.write(offset: Int(offset), bytes: data.initializer)
             }
         }
-
-        // Step 17.
-        if let startIndex = start {
-            let startFunction = try instance.functions[validating: Int(startIndex)]
-            _ = try startFunction.invoke([], store: store)
-        }
-
-        // Compile all functions eagerly if the engine is in eager compilation mode
-        if store.engine.configuration.compilationMode == .eager {
-            try instance.withValue {
-                try $0.compileAllFunctions(store: store)
-            }
-        }
-
-        return instance
     }
-
-    /// Materialize lazily-computed elements in this module
-    @available(*, deprecated, message: "Module materialization is no longer supported. Instantiate the module explicitly instead.")
-    public mutating func materializeAll() throws {}
 }
 
 extension Module {
@@ -309,7 +336,7 @@ typealias LabelIndex = UInt32
 /// An executable function representation in a module
 /// > Note:
 /// <https://webassembly.github.io/spec/core/syntax/modules.html#functions>
-struct GuestFunction {
+struct GuestFunction: Sendable {
     let type: FunctionType
     let code: Code
 }

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -70,6 +70,12 @@ extension InternalInstance {
         let memory = try self.memories[validating: Int(index), MemoryEntity.createOutOfBoundsError]
         return memory.withValue { $0.limit.isMemory64 }
     }
+    /// Whether the given memory is a shared (threads-proposal) memory. Used to select
+    /// the reload-capable `…Shared` load/store opcode variants at translation time.
+    func memoryIsShared(memoryIndex index: MemoryIndex) throws(WasmKitError) -> Bool {
+        let memory = try self.memories[validating: Int(index), MemoryEntity.createOutOfBoundsError]
+        return memory.withValue { $0.limit.shared }
+    }
     func isMemory64(tableIndex index: TableIndex) throws(WasmKitError) -> Bool {
         return try self.tables[validating: Int(index)].limits.isMemory64
     }
@@ -2225,11 +2231,14 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
 
     mutating func visitLoad(_ load: WasmParser.Instruction.Load, memarg: MemArg) throws(WasmKitError) {
         let instruction: (Instruction.LoadOperand) -> Instruction
+        // Shared memories use the reload-capable `…Shared` variants (paired in
+        // `memorySharedLoadStoreInsts`); non-shared memories keep the plain handlers.
+        let isShared = try module.memoryIsShared(memoryIndex: 0)
         switch load {
-        case .i32Load: instruction = Instruction.i32Load
-        case .i64Load: instruction = Instruction.i64Load
-        case .f32Load: instruction = Instruction.f32Load
-        case .f64Load: instruction = Instruction.f64Load
+        case .i32Load: instruction = isShared ? { .i32LoadShared($0) } : { .i32Load($0) }
+        case .i64Load: instruction = isShared ? { .i64LoadShared($0) } : { .i64Load($0) }
+        case .f32Load: instruction = isShared ? { .f32LoadShared($0) } : { .f32Load($0) }
+        case .f64Load: instruction = isShared ? { .f64LoadShared($0) } : { .f64Load($0) }
         case .v128Load, .v128Load8X8S, .v128Load8X8U, .v128Load16X4S, .v128Load16X4U,
             .v128Load32X2S, .v128Load32X2U, .v128Load8Splat, .v128Load16Splat, .v128Load32Splat,
             .v128Load64Splat, .v128Load32Zero, .v128Load64Zero:
@@ -2250,16 +2259,16 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
                     ))
             }
             return
-        case .i32Load8S: instruction = Instruction.i32Load8S
-        case .i32Load8U: instruction = Instruction.i32Load8U
-        case .i32Load16S: instruction = Instruction.i32Load16S
-        case .i32Load16U: instruction = Instruction.i32Load16U
-        case .i64Load8S: instruction = Instruction.i64Load8S
-        case .i64Load8U: instruction = Instruction.i64Load8U
-        case .i64Load16S: instruction = Instruction.i64Load16S
-        case .i64Load16U: instruction = Instruction.i64Load16U
-        case .i64Load32S: instruction = Instruction.i64Load32S
-        case .i64Load32U: instruction = Instruction.i64Load32U
+        case .i32Load8S: instruction = isShared ? { .i32Load8SShared($0) } : { .i32Load8S($0) }
+        case .i32Load8U: instruction = isShared ? { .i32Load8UShared($0) } : { .i32Load8U($0) }
+        case .i32Load16S: instruction = isShared ? { .i32Load16SShared($0) } : { .i32Load16S($0) }
+        case .i32Load16U: instruction = isShared ? { .i32Load16UShared($0) } : { .i32Load16U($0) }
+        case .i64Load8S: instruction = isShared ? { .i64Load8SShared($0) } : { .i64Load8S($0) }
+        case .i64Load8U: instruction = isShared ? { .i64Load8UShared($0) } : { .i64Load8U($0) }
+        case .i64Load16S: instruction = isShared ? { .i64Load16SShared($0) } : { .i64Load16S($0) }
+        case .i64Load16U: instruction = isShared ? { .i64Load16UShared($0) } : { .i64Load16U($0) }
+        case .i64Load32S: instruction = isShared ? { .i64Load32SShared($0) } : { .i64Load32S($0) }
+        case .i64Load32U: instruction = isShared ? { .i64Load32UShared($0) } : { .i64Load32U($0) }
         case .i32AtomicLoad: instruction = Instruction.i32AtomicLoad
         case .i64AtomicLoad: instruction = Instruction.i64AtomicLoad
         case .i32AtomicLoad8U: instruction = Instruction.i32AtomicLoad8U
@@ -2274,11 +2283,12 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
 
     mutating func visitStore(_ store: WasmParser.Instruction.Store, memarg: MemArg) throws(WasmKitError) {
         let instruction: (Instruction.StoreOperand) -> Instruction
+        let isShared = try module.memoryIsShared(memoryIndex: 0)
         switch store {
-        case .i32Store: instruction = Instruction.i32Store
-        case .i64Store: instruction = Instruction.i64Store
-        case .f32Store: instruction = Instruction.f32Store
-        case .f64Store: instruction = Instruction.f64Store
+        case .i32Store: instruction = isShared ? { .i32StoreShared($0) } : { .i32Store($0) }
+        case .i64Store: instruction = isShared ? { .i64StoreShared($0) } : { .i64Store($0) }
+        case .f32Store: instruction = isShared ? { .f32StoreShared($0) } : { .f32Store($0) }
+        case .f64Store: instruction = isShared ? { .f64StoreShared($0) } : { .f64Store($0) }
         case .v128Store:
             let isMemory64 = try module.isMemory64(memoryIndex: 0)
             try validator.validateMemArg(memarg, naturalAlignment: store.naturalAlignment)
@@ -2300,11 +2310,11 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
                         )))
             }
             return
-        case .i32Store8: instruction = Instruction.i32Store8
-        case .i32Store16: instruction = Instruction.i32Store16
-        case .i64Store8: instruction = Instruction.i64Store8
-        case .i64Store16: instruction = Instruction.i64Store16
-        case .i64Store32: instruction = Instruction.i64Store32
+        case .i32Store8: instruction = isShared ? { .i32Store8Shared($0) } : { .i32Store8($0) }
+        case .i32Store16: instruction = isShared ? { .i32Store16Shared($0) } : { .i32Store16($0) }
+        case .i64Store8: instruction = isShared ? { .i64Store8Shared($0) } : { .i64Store8($0) }
+        case .i64Store16: instruction = isShared ? { .i64Store16Shared($0) } : { .i64Store16($0) }
+        case .i64Store32: instruction = isShared ? { .i64Store32Shared($0) } : { .i64Store32($0) }
         case .i32AtomicStore: instruction = Instruction.i32AtomicStore
         case .i64AtomicStore: instruction = Instruction.i64AtomicStore
         case .i32AtomicStore8: instruction = Instruction.i32AtomicStore8

--- a/Sources/WasmParser/WasmTypes.swift
+++ b/Sources/WasmParser/WasmTypes.swift
@@ -193,7 +193,7 @@ public struct Global: Equatable, Sendable {
 /// Tag entry in a module
 /// > Note:
 /// <https://webassembly.github.io/exception-handling/core/syntax/modules.html#tags>
-public struct Tag: Equatable {
+public struct Tag: Equatable, Sendable {
     /// The type index of the tag's function type (parameters = exception payload, results must be empty).
     public let type: TypeIndex
 

--- a/Sources/_CWasmKit/TrapGuard.c
+++ b/Sources/_CWasmKit/TrapGuard.c
@@ -6,10 +6,13 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+// MARK: - Thread-local trap guard (non-shared memory, existing behavior)
 
 typedef struct wasmkit_trap_guard {
   sigjmp_buf env;
@@ -18,6 +21,103 @@ typedef struct wasmkit_trap_guard {
 } wasmkit_trap_guard_t;
 
 static __thread wasmkit_trap_guard_t *wasmkit_current_trap_guard = NULL;
+
+// MARK: - Shared memory guard registry
+
+#define WASMKIT_MAX_SHARED_MEMORIES 256
+
+static _Atomic(wasmkit_shared_memory_guard_t *) wasmkit_shared_guards[WASMKIT_MAX_SHARED_MEMORIES];
+static atomic_flag wasmkit_registry_lock = ATOMIC_FLAG_INIT;
+
+static void wasmkit_registry_acquire(void) {
+  while (atomic_flag_test_and_set_explicit(&wasmkit_registry_lock, memory_order_acquire)) {
+    // spin
+  }
+}
+
+static void wasmkit_registry_release(void) {
+  atomic_flag_clear_explicit(&wasmkit_registry_lock, memory_order_release);
+}
+
+int wasmkit_shared_memory_guard_register(wasmkit_shared_memory_guard_t *guard) {
+  wasmkit_registry_acquire();
+  for (int i = 0; i < WASMKIT_MAX_SHARED_MEMORIES; i++) {
+    wasmkit_shared_memory_guard_t *slot =
+        atomic_load_explicit(&wasmkit_shared_guards[i], memory_order_relaxed);
+    if (slot == NULL) {
+      atomic_store_explicit(&wasmkit_shared_guards[i], guard, memory_order_release);
+      wasmkit_registry_release();
+      return 0;
+    }
+  }
+  wasmkit_registry_release();
+  return -1;
+}
+
+void wasmkit_shared_memory_guard_unregister(wasmkit_shared_memory_guard_t *guard) {
+  wasmkit_registry_acquire();
+  for (int i = 0; i < WASMKIT_MAX_SHARED_MEMORIES; i++) {
+    wasmkit_shared_memory_guard_t *slot =
+        atomic_load_explicit(&wasmkit_shared_guards[i], memory_order_relaxed);
+    if (slot == guard) {
+      atomic_store_explicit(&wasmkit_shared_guards[i], (wasmkit_shared_memory_guard_t *)NULL,
+                            memory_order_release);
+      break;
+    }
+  }
+  wasmkit_registry_release();
+}
+
+void wasmkit_shared_memory_guard_lock(wasmkit_shared_memory_guard_t *guard) {
+  while (atomic_flag_test_and_set_explicit(&guard->spinlock, memory_order_acquire)) {
+    // spin
+  }
+}
+
+void wasmkit_shared_memory_guard_unlock(wasmkit_shared_memory_guard_t *guard) {
+  atomic_flag_clear_explicit(&guard->spinlock, memory_order_release);
+}
+
+void wasmkit_shared_memory_guard_set_size(wasmkit_shared_memory_guard_t *guard, size_t size) {
+  atomic_store_explicit(&guard->current_byte_count, size, memory_order_release);
+}
+
+size_t wasmkit_shared_memory_guard_get_size(wasmkit_shared_memory_guard_t *guard) {
+  return atomic_load_explicit(&guard->current_byte_count, memory_order_acquire);
+}
+
+void wasmkit_shared_memory_guard_init(wasmkit_shared_memory_guard_t *guard,
+                                       void *base_pointer,
+                                       size_t max_byte_count,
+                                       size_t initial_byte_count) {
+  guard->spinlock = (atomic_flag)ATOMIC_FLAG_INIT;
+  guard->base_pointer = base_pointer;
+  guard->max_byte_count = max_byte_count;
+  atomic_store_explicit(&guard->current_byte_count, initial_byte_count, memory_order_release);
+}
+
+// Saved signal mask for the grow path. Thread-local because each thread
+// may be growing a different shared memory concurrently.
+// Invariant: grow() is never recursive on the same thread.
+static __thread sigset_t wasmkit_grow_saved_mask;
+
+void wasmkit_shared_memory_guard_lock_for_grow(wasmkit_shared_memory_guard_t *guard) {
+  sigset_t block;
+  sigemptyset(&block);
+  sigaddset(&block, SIGSEGV);
+#ifdef SIGBUS
+  sigaddset(&block, SIGBUS);
+#endif
+  pthread_sigmask(SIG_BLOCK, &block, &wasmkit_grow_saved_mask);
+  wasmkit_shared_memory_guard_lock(guard);
+}
+
+void wasmkit_shared_memory_guard_unlock_for_grow(wasmkit_shared_memory_guard_t *guard) {
+  wasmkit_shared_memory_guard_unlock(guard);
+  pthread_sigmask(SIG_SETMASK, &wasmkit_grow_saved_mask, NULL);
+}
+
+// MARK: - Signal handler
 
 static struct sigaction wasmkit_prev_segv;
 static struct sigaction wasmkit_prev_bus;
@@ -62,15 +162,56 @@ static void wasmkit_chain_signal(const struct sigaction *prev, int sig,
 }
 
 static void wasmkit_signal_handler(int sig, siginfo_t *info, void *ucontext) {
-  wasmkit_trap_guard_t *guard = wasmkit_current_trap_guard;
-  if (guard && guard->md && guard->reservation_size > 0 && info && info->si_addr) {
-    uintptr_t base = (uintptr_t)guard->md;
-    uintptr_t addr = (uintptr_t)info->si_addr;
-    if (addr >= base && addr < base + (uintptr_t)guard->reservation_size) {
-      siglongjmp(guard->env, 1);
+  if (!info || !info->si_addr) goto chain;
+
+  uintptr_t addr = (uintptr_t)info->si_addr;
+
+  // Phase 1: Check shared memory registry (spinlock + retry path).
+  // Must be checked BEFORE the thread-local guard because shared memory
+  // faults may need to retry the instruction (grow in progress).
+  for (int i = 0; i < WASMKIT_MAX_SHARED_MEMORIES; i++) {
+    wasmkit_shared_memory_guard_t *guard =
+        atomic_load_explicit(&wasmkit_shared_guards[i], memory_order_acquire);
+    if (!guard) continue;
+
+    uintptr_t base = (uintptr_t)guard->base_pointer;
+    size_t max = guard->max_byte_count;
+
+    if (addr >= base && addr < base + max) {
+      // Fault is in a shared memory region. Acquire the per-guard spinlock
+      // to synchronize with grow (which holds it during mprotect + size update).
+      wasmkit_shared_memory_guard_lock(guard);
+      size_t size = atomic_load_explicit(&guard->current_byte_count, memory_order_acquire);
+      wasmkit_shared_memory_guard_unlock(guard);
+
+      if (addr < base + size) {
+        // Address is within committed region. Pages must be accessible now
+        // (grow completed mprotect before updating size, and we observed the
+        // updated size after acquiring the spinlock that grow released).
+        // Return from the signal handler to retry the faulting instruction.
+        return;
+      }
+
+      // Genuine OOB on shared memory — trap via the thread-local guard.
+      goto trap;
     }
   }
 
+  // Phase 2: Check thread-local trap guard (non-shared memory).
+  {
+    wasmkit_trap_guard_t *tl_guard = wasmkit_current_trap_guard;
+    if (tl_guard && tl_guard->md && tl_guard->reservation_size > 0) {
+      uintptr_t base = (uintptr_t)tl_guard->md;
+      if (addr >= base && addr < base + (uintptr_t)tl_guard->reservation_size) {
+        siglongjmp(tl_guard->env, 1);
+      }
+    }
+  }
+
+chain:
+  // Phase 3: Chain to the previously installed handler, preserving its
+  // semantics (including SIG_DFL restore + re-raise via
+  // wasmkit_restore_and_reraise) so non-WasmKit faults behave as expected.
   if (sig == SIGSEGV && wasmkit_has_prev_segv) {
     wasmkit_chain_signal(&wasmkit_prev_segv, sig, info, ucontext);
     return;
@@ -84,6 +225,15 @@ static void wasmkit_signal_handler(int sig, siginfo_t *info, void *ucontext) {
 
   // Preserve the conventional shell exit status for signal termination.
   _exit(128 + sig);
+
+trap:
+  {
+    wasmkit_trap_guard_t *tl_guard = wasmkit_current_trap_guard;
+    if (tl_guard) {
+      siglongjmp(tl_guard->env, 1);
+    }
+    _exit(128 + sig);
+  }
 }
 
 static void wasmkit_install_signal_handlers_once(void) {

--- a/Sources/_CWasmKit/include/DirectThreadedCode.inc
+++ b/Sources/_CWasmKit/include/DirectThreadedCode.inc
@@ -1782,6 +1782,167 @@ SWIFT_CC(swiftasync) static inline void wasmkit_tc_catchHandlersEnd(Sp sp, Pc pc
     INLINE_CALL next = wasmkit_execute_catchHandlersEnd(&sp, &pc, &md, &ms, state, &error);
     return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
 }
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32LoadShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32LoadShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32LoadShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64LoadShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64LoadShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64LoadShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_f32LoadShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_f32LoadShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_f32LoadShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_f64LoadShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_f64LoadShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_f64LoadShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32Load8SShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32Load8SShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32Load8SShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32Load8UShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32Load8UShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32Load8UShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32Load16SShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32Load16SShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32Load16SShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32Load16UShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32Load16UShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32Load16UShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Load8SShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Load8SShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Load8SShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Load8UShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Load8UShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Load8UShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Load16SShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Load16SShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Load16SShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Load16UShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Load16UShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Load16UShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Load32SShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Load32SShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Load32SShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Load32UShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Load32UShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Load32UShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32StoreShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32StoreShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32StoreShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64StoreShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64StoreShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64StoreShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_f32StoreShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_f32StoreShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_f32StoreShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_f64StoreShared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_f64StoreShared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_f64StoreShared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32Store8Shared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32Store8Shared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32Store8Shared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i32Store16Shared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i32Store16Shared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i32Store16Shared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Store8Shared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Store8Shared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Store8Shared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Store16Shared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Store16Shared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Store16Shared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_i64Store32Shared(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_i64Store32Shared(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_i64Store32Shared(&sp, &pc, &md, &ms, state, &error);
+    if (error) return wasmkit_execution_state_set_error(error, sp, state);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
 static const uintptr_t wasmkit_tc_exec_handlers[] = {
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_copyStack),
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_globalGet),
@@ -2057,4 +2218,27 @@ static const uintptr_t wasmkit_tc_exec_handlers[] = {
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_throwRef),
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_catchHandlers),
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_catchHandlersEnd),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32LoadShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64LoadShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_f32LoadShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_f64LoadShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32Load8SShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32Load8UShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32Load16SShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32Load16UShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Load8SShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Load8UShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Load16SShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Load16UShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Load32SShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Load32UShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32StoreShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64StoreShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_f32StoreShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_f64StoreShared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32Store8Shared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i32Store16Shared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Store8Shared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Store16Shared),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_i64Store32Shared),
 };

--- a/Sources/_CWasmKit/include/TrapGuard.h
+++ b/Sources/_CWasmKit/include/TrapGuard.h
@@ -3,6 +3,11 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include "Platform.h"
+
+#if WASMKIT_MPROTECT_BOUND_CHECKING
+#include <stdatomic.h>
+#endif
 
 #ifndef _Nullable
 #  ifndef __clang__
@@ -35,6 +40,86 @@ bool wasmkit_trap_guard_run(wasmkit_trap_guard_fn _Nonnull fn, void *_Nullable c
 ///
 /// Passing `reservation_size == 0` disables handling of faults for the current thread.
 void wasmkit_trap_guard_set_current_memory(void *_Nullable md, size_t reservation_size);
+
+// MARK: - Shared Memory Guard (signal handler spinlock coordination)
+
+#if WASMKIT_MPROTECT_BOUND_CHECKING
+
+/// Guard struct for coordinating shared memory grow with the signal handler.
+///
+/// The signal handler acquires the spinlock when a fault lands in
+/// [base_pointer, base_pointer + max_byte_count). If the faulting address is
+/// below current_byte_count, pages are committed and the handler returns
+/// (retrying the instruction). Otherwise it's a genuine OOB trap.
+typedef struct wasmkit_shared_memory_guard {
+    atomic_flag spinlock;
+    _Atomic(size_t) current_byte_count;
+    void *_Nonnull base_pointer;
+    size_t max_byte_count;
+} wasmkit_shared_memory_guard_t;
+
+/// Register a shared memory guard for signal handler coordination.
+/// Returns 0 on success, -1 if the registry is full.
+int wasmkit_shared_memory_guard_register(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+/// Unregister a shared memory guard. Must be called before deallocation.
+void wasmkit_shared_memory_guard_unregister(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+/// Acquire the guard's spinlock (for use by grow).
+void wasmkit_shared_memory_guard_lock(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+/// Release the guard's spinlock.
+void wasmkit_shared_memory_guard_unlock(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+/// Atomically set the committed byte count (use from Swift — Swift strips _Atomic).
+void wasmkit_shared_memory_guard_set_size(wasmkit_shared_memory_guard_t *_Nonnull guard, size_t size);
+
+/// Atomically get the committed byte count.
+size_t wasmkit_shared_memory_guard_get_size(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+/// Initialize a shared memory guard struct with the given parameters.
+void wasmkit_shared_memory_guard_init(wasmkit_shared_memory_guard_t *_Nonnull guard,
+                                       void *_Nonnull base_pointer,
+                                       size_t max_byte_count,
+                                       size_t initial_byte_count);
+
+/// Acquire the guard's spinlock for grow operations, blocking SIGSEGV/SIGBUS first.
+/// This prevents self-deadlock if a signal arrives while the lock is held.
+/// Must be paired with unlock_for_grow. Must not be called recursively.
+void wasmkit_shared_memory_guard_lock_for_grow(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+/// Release the guard's spinlock after grow, restoring the previous signal mask.
+void wasmkit_shared_memory_guard_unlock_for_grow(wasmkit_shared_memory_guard_t *_Nonnull guard);
+
+#else
+
+// Stubs when mprotect bound checking is disabled.
+typedef struct wasmkit_shared_memory_guard {
+    char spinlock;
+    size_t current_byte_count;
+    void *_Nonnull base_pointer;
+    size_t max_byte_count;
+} wasmkit_shared_memory_guard_t;
+
+static inline int wasmkit_shared_memory_guard_register(wasmkit_shared_memory_guard_t *_Nonnull g) { (void)g; return 0; }
+static inline void wasmkit_shared_memory_guard_unregister(wasmkit_shared_memory_guard_t *_Nonnull g) { (void)g; }
+static inline void wasmkit_shared_memory_guard_init(wasmkit_shared_memory_guard_t *_Nonnull g,
+                                                     void *_Nonnull base_pointer,
+                                                     size_t max_byte_count,
+                                                     size_t initial_byte_count) {
+    g->spinlock = 0;
+    g->base_pointer = base_pointer;
+    g->max_byte_count = max_byte_count;
+    g->current_byte_count = initial_byte_count;
+}
+static inline void wasmkit_shared_memory_guard_lock(wasmkit_shared_memory_guard_t *_Nonnull g) { (void)g; }
+static inline void wasmkit_shared_memory_guard_unlock(wasmkit_shared_memory_guard_t *_Nonnull g) { (void)g; }
+static inline void wasmkit_shared_memory_guard_lock_for_grow(wasmkit_shared_memory_guard_t *_Nonnull g) { (void)g; }
+static inline void wasmkit_shared_memory_guard_unlock_for_grow(wasmkit_shared_memory_guard_t *_Nonnull g) { (void)g; }
+static inline void wasmkit_shared_memory_guard_set_size(wasmkit_shared_memory_guard_t *_Nonnull g, size_t s) { g->current_byte_count = s; }
+static inline size_t wasmkit_shared_memory_guard_get_size(wasmkit_shared_memory_guard_t *_Nonnull g) { return g->current_byte_count; }
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/Tests/WasmKitTests/AtomicParkingLotTests.swift
+++ b/Tests/WasmKitTests/AtomicParkingLotTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import Synchronization
 import Testing
 
+@testable import WasmKit
+
 #if canImport(Darwin)
     import Darwin
 #elseif canImport(Musl)
@@ -11,67 +13,73 @@ import Testing
     import Glibc
 #endif
 
-@testable import WasmKit
-
 @Suite struct AtomicParkingLotTests {
     #if DEBUG
-    /// Deterministic regression for the notify/timeout race: a waiter that `unpark`
-    /// dequeues and counts must report `.woken` (0), not `.timedOut` (2).
-    ///
-    /// Ordering is forced with no reliance on wall-clock timing:
-    ///   1. the waiter registers, then blocks in `beforeSleep`;
-    ///   2. the notifier `unpark`s — removing and counting the slot — then pauses in the
-    ///      seam, before `wake()`, so `woken` stays false and the slot is already absent;
-    ///   3. the waiter resumes with a zero timeout, reads `woken == false`, and runs its
-    ///      timeout-path registry check against the now-absent slot.
-    @Test func timedOutWaiterClaimedByNotifyReportsWoken() {
-        let lot = AtomicParkingLot()
-        let address: UInt64 = 0x2000
+        /// Deterministic regression for the notify/timeout race: a waiter that `unpark`
+        /// dequeues and counts must report `.woken` (0), not `.timedOut` (2).
+        ///
+        /// Ordering is forced with no reliance on wall-clock timing:
+        ///   1. the waiter registers, then blocks in `beforeSleep`;
+        ///   2. the notifier `unpark`s — removing and counting the slot — then pauses in the
+        ///      seam, before `wake()`, so `woken` stays false and the slot is already absent;
+        ///   3. the waiter resumes with a zero timeout, reads `woken == false`, and runs its
+        ///      timeout-path registry check against the now-absent slot.
+        @Test func timedOutWaiterClaimedByNotifyReportsWoken() {
+            let lot = AtomicParkingLot()
+            let address: UInt64 = 0x2000
 
-        let registered = DispatchSemaphore(value: 0)
-        let proceedWaiter = DispatchSemaphore(value: 0)
-        let dequeued = DispatchSemaphore(value: 0)
-        let release = DispatchSemaphore(value: 0)
+            let registered = DispatchSemaphore(value: 0)
+            let proceedWaiter = DispatchSemaphore(value: 0)
+            let dequeued = DispatchSemaphore(value: 0)
+            let release = DispatchSemaphore(value: 0)
 
-        lot._afterDequeueBeforeWake.withLock { $0 = { dequeued.signal(); release.wait() } }
+            lot._afterDequeueBeforeWake.withLock {
+                $0 = {
+                    dequeued.signal()
+                    release.wait()
+                }
+            }
 
-        let outcome = Mutex<WaitOutcome?>(nil)
-        let notifyCount = Mutex<UInt32>(0)
-        let waiterDone = DispatchGroup()
-        let notifierDone = DispatchGroup()
+            let outcome = Mutex<WaitOutcome?>(nil)
+            let notifyCount = Mutex<UInt32>(0)
+            let waiterDone = DispatchGroup()
+            let notifierDone = DispatchGroup()
 
-        waiterDone.enter()
-        Thread.detachNewThread {
-            let result = lot.parkConditionally(
-                address: address,
-                validate: { true },
-                deadline: { ContinuousClock.now },  // relative timeout 0: `wait` reads `woken` immediately
-                beforeSleep: { registered.signal(); proceedWaiter.wait() }
+            waiterDone.enter()
+            Thread.detachNewThread {
+                let result = lot.parkConditionally(
+                    address: address,
+                    validate: { true },
+                    deadline: { ContinuousClock.now },  // relative timeout 0: `wait` reads `woken` immediately
+                    beforeSleep: {
+                        registered.signal()
+                        proceedWaiter.wait()
+                    }
+                )
+                outcome.withLock { $0 = result }
+                waiterDone.leave()
+            }
+
+            notifierDone.enter()
+            Thread.detachNewThread {
+                registered.wait()  // slot is queued
+                let n = lot.unpark(address: address, count: .max)  // removes+counts, then pauses in the seam
+                notifyCount.withLock { $0 = n }
+                notifierDone.leave()
+            }
+
+            dequeued.wait()  // unpark removed+counted the slot; paused before wake()
+            proceedWaiter.signal()  // waiter resumes: reads woken==false, finds its slot absent
+            waiterDone.wait()  // waiter has returned its outcome
+            release.signal()  // unpark finishes (wake() is now a no-op on the discarded slot)
+            notifierDone.wait()
+
+            #expect(notifyCount.withLock { $0 } == 1, "unpark must count the single dequeued waiter")
+            #expect(
+                outcome.withLock { $0 } == .woken,
+                "a waiter that unpark dequeued and counted must report .woken (0), not .timedOut (2)"
             )
-            outcome.withLock { $0 = result }
-            waiterDone.leave()
         }
-
-        notifierDone.enter()
-        Thread.detachNewThread {
-            registered.wait()                                   // slot is queued
-            let n = lot.unpark(address: address, count: .max)   // removes+counts, then pauses in the seam
-            notifyCount.withLock { $0 = n }
-            notifierDone.leave()
-        }
-
-        dequeued.wait()         // unpark removed+counted the slot; paused before wake()
-        proceedWaiter.signal()  // waiter resumes: reads woken==false, finds its slot absent
-        waiterDone.wait()       // waiter has returned its outcome
-        release.signal()        // unpark finishes (wake() is now a no-op on the discarded slot)
-        notifierDone.wait()
-
-        #expect(notifyCount.withLock { $0 } == 1, "unpark must count the single dequeued waiter")
-        #expect(
-            outcome.withLock { $0 } == .woken,
-            "a waiter that unpark dequeued and counted must report .woken (0), not .timedOut (2)"
-        )
-    }
     #endif
 
     /// Contention breadth: across a run using only `unpark`, the sum of `unpark`
@@ -115,7 +123,10 @@ import Testing
                         continue
                     }
                 }
-                totals.withLock { $0.woken += woken; $0.timedOut += timedOut }
+                totals.withLock {
+                    $0.woken += woken
+                    $0.timedOut += timedOut
+                }
                 waiters.leave()
             }
         }

--- a/Tests/WasmKitTests/AtomicParkingLotTests.swift
+++ b/Tests/WasmKitTests/AtomicParkingLotTests.swift
@@ -18,161 +18,161 @@ import Testing
 // (see AtomicParkingLot.swift), and `swift test` there must not compile this suite.
 #if canImport(Darwin) || canImport(Musl) || canImport(Glibc)
 
-@Suite struct AtomicParkingLotTests {
-    #if DEBUG
-        /// Deterministic regression for the notify/timeout race: a waiter that `unpark`
-        /// dequeues and counts must report `.woken` (0), not `.timedOut` (2).
-        ///
-        /// Ordering is forced with no reliance on wall-clock timing:
-        ///   1. the waiter registers, then blocks in `beforeSleep`;
-        ///   2. the notifier `unpark`s — removing and counting the slot — then pauses in the
-        ///      seam, before `wake()`, so `woken` stays false and the slot is already absent;
-        ///   3. the waiter resumes with a zero timeout, reads `woken == false`, and runs its
-        ///      timeout-path registry check against the now-absent slot.
-        @Test func timedOutWaiterClaimedByNotifyReportsWoken() {
-            let lot = AtomicParkingLot()
-            let address: UInt64 = 0x2000
+    @Suite struct AtomicParkingLotTests {
+        #if DEBUG
+            /// Deterministic regression for the notify/timeout race: a waiter that `unpark`
+            /// dequeues and counts must report `.woken` (0), not `.timedOut` (2).
+            ///
+            /// Ordering is forced with no reliance on wall-clock timing:
+            ///   1. the waiter registers, then blocks in `beforeSleep`;
+            ///   2. the notifier `unpark`s — removing and counting the slot — then pauses in the
+            ///      seam, before `wake()`, so `woken` stays false and the slot is already absent;
+            ///   3. the waiter resumes with a zero timeout, reads `woken == false`, and runs its
+            ///      timeout-path registry check against the now-absent slot.
+            @Test func timedOutWaiterClaimedByNotifyReportsWoken() {
+                let lot = AtomicParkingLot()
+                let address: UInt64 = 0x2000
 
-            let registered = DispatchSemaphore(value: 0)
-            let proceedWaiter = DispatchSemaphore(value: 0)
-            let dequeued = DispatchSemaphore(value: 0)
-            let release = DispatchSemaphore(value: 0)
+                let registered = DispatchSemaphore(value: 0)
+                let proceedWaiter = DispatchSemaphore(value: 0)
+                let dequeued = DispatchSemaphore(value: 0)
+                let release = DispatchSemaphore(value: 0)
 
-            lot._afterDequeueBeforeWake.withLock {
-                $0 = {
-                    dequeued.signal()
-                    release.wait()
-                }
-            }
-
-            let outcome = Mutex<WaitOutcome?>(nil)
-            let notifyCount = Mutex<UInt32>(0)
-            let waiterDone = DispatchGroup()
-            let notifierDone = DispatchGroup()
-
-            waiterDone.enter()
-            Thread.detachNewThread {
-                let result = lot.parkConditionally(
-                    address: address,
-                    validate: { true },
-                    deadline: { ContinuousClock.now },  // relative timeout 0: `wait` reads `woken` immediately
-                    beforeSleep: {
-                        registered.signal()
-                        proceedWaiter.wait()
+                lot._afterDequeueBeforeWake.withLock {
+                    $0 = {
+                        dequeued.signal()
+                        release.wait()
                     }
-                )
-                outcome.withLock { $0 = result }
-                waiterDone.leave()
-            }
+                }
 
-            notifierDone.enter()
-            Thread.detachNewThread {
-                registered.wait()  // slot is queued
-                let n = lot.unpark(address: address, count: .max)  // removes+counts, then pauses in the seam
-                notifyCount.withLock { $0 = n }
-                notifierDone.leave()
-            }
+                let outcome = Mutex<WaitOutcome?>(nil)
+                let notifyCount = Mutex<UInt32>(0)
+                let waiterDone = DispatchGroup()
+                let notifierDone = DispatchGroup()
 
-            dequeued.wait()  // unpark removed+counted the slot; paused before wake()
-            proceedWaiter.signal()  // waiter resumes: reads woken==false, finds its slot absent
-            waiterDone.wait()  // waiter has returned its outcome
-            release.signal()  // unpark finishes (wake() is now a no-op on the discarded slot)
-            notifierDone.wait()
-
-            #expect(notifyCount.withLock { $0 } == 1, "unpark must count the single dequeued waiter")
-            #expect(
-                outcome.withLock { $0 } == .woken,
-                "a waiter that unpark dequeued and counted must report .woken (0), not .timedOut (2)"
-            )
-        }
-    #endif
-
-    /// Contention breadth: across a run using only `unpark`, the sum of `unpark`
-    /// return values must equal the number of `parkConditionally` calls returning
-    /// `.woken` (exact post-fix; see the plan's Correctness argument). Waiters use a
-    /// short positive timeout so they block in `pthread_cond_timedwait`, the
-    /// production `memory.atomic.wait` path.
-    @Test func notifyCountMatchesObservedWakeupsUnderContention() {
-        let lot = AtomicParkingLot()
-        let address: UInt64 = 0x1000
-
-        let cores = ProcessInfo.processInfo.activeProcessorCount
-        let waiterCount = max(4, cores)
-        let notifierCount = max(2, cores / 2)
-        let runDuration: Duration = .milliseconds(750)
-        let waitTimeout: Duration = .microseconds(200)
-
-        let totals = Mutex<(notify: Int, woken: Int, timedOut: Int)>((0, 0, 0))
-        let stop = Atomic<Bool>(false)
-        let waiters = DispatchGroup()
-        let notifiers = DispatchGroup()
-        let stopAt = ContinuousClock.now.advanced(by: runDuration)
-
-        for _ in 0..<waiterCount {
-            waiters.enter()
-            Thread.detachNewThread {
-                var woken = 0
-                var timedOut = 0
-                while ContinuousClock.now < stopAt {
-                    switch lot.parkConditionally(
+                waiterDone.enter()
+                Thread.detachNewThread {
+                    let result = lot.parkConditionally(
                         address: address,
                         validate: { true },
-                        deadline: { ContinuousClock.now.advanced(by: waitTimeout) }
-                    ) {
-                    case .woken: woken += 1
-                    case .timedOut: timedOut += 1
-                    case .mismatch:
-                        // Unreachable here: `validate` is constant-true, so the slot is always
-                        // appended and the wait runs. `continue` (not `break`) makes the intent
-                        // explicit — a bare `break` would exit only the switch, not the loop.
-                        continue
+                        deadline: { ContinuousClock.now },  // relative timeout 0: `wait` reads `woken` immediately
+                        beforeSleep: {
+                            registered.signal()
+                            proceedWaiter.wait()
+                        }
+                    )
+                    outcome.withLock { $0 = result }
+                    waiterDone.leave()
+                }
+
+                notifierDone.enter()
+                Thread.detachNewThread {
+                    registered.wait()  // slot is queued
+                    let n = lot.unpark(address: address, count: .max)  // removes+counts, then pauses in the seam
+                    notifyCount.withLock { $0 = n }
+                    notifierDone.leave()
+                }
+
+                dequeued.wait()  // unpark removed+counted the slot; paused before wake()
+                proceedWaiter.signal()  // waiter resumes: reads woken==false, finds its slot absent
+                waiterDone.wait()  // waiter has returned its outcome
+                release.signal()  // unpark finishes (wake() is now a no-op on the discarded slot)
+                notifierDone.wait()
+
+                #expect(notifyCount.withLock { $0 } == 1, "unpark must count the single dequeued waiter")
+                #expect(
+                    outcome.withLock { $0 } == .woken,
+                    "a waiter that unpark dequeued and counted must report .woken (0), not .timedOut (2)"
+                )
+            }
+        #endif
+
+        /// Contention breadth: across a run using only `unpark`, the sum of `unpark`
+        /// return values must equal the number of `parkConditionally` calls returning
+        /// `.woken` (exact post-fix; see the plan's Correctness argument). Waiters use a
+        /// short positive timeout so they block in `pthread_cond_timedwait`, the
+        /// production `memory.atomic.wait` path.
+        @Test func notifyCountMatchesObservedWakeupsUnderContention() {
+            let lot = AtomicParkingLot()
+            let address: UInt64 = 0x1000
+
+            let cores = ProcessInfo.processInfo.activeProcessorCount
+            let waiterCount = max(4, cores)
+            let notifierCount = max(2, cores / 2)
+            let runDuration: Duration = .milliseconds(750)
+            let waitTimeout: Duration = .microseconds(200)
+
+            let totals = Mutex<(notify: Int, woken: Int, timedOut: Int)>((0, 0, 0))
+            let stop = Atomic<Bool>(false)
+            let waiters = DispatchGroup()
+            let notifiers = DispatchGroup()
+            let stopAt = ContinuousClock.now.advanced(by: runDuration)
+
+            for _ in 0..<waiterCount {
+                waiters.enter()
+                Thread.detachNewThread {
+                    var woken = 0
+                    var timedOut = 0
+                    while ContinuousClock.now < stopAt {
+                        switch lot.parkConditionally(
+                            address: address,
+                            validate: { true },
+                            deadline: { ContinuousClock.now.advanced(by: waitTimeout) }
+                        ) {
+                        case .woken: woken += 1
+                        case .timedOut: timedOut += 1
+                        case .mismatch:
+                            // Unreachable here: `validate` is constant-true, so the slot is always
+                            // appended and the wait runs. `continue` (not `break`) makes the intent
+                            // explicit — a bare `break` would exit only the switch, not the loop.
+                            continue
+                        }
                     }
+                    totals.withLock {
+                        $0.woken += woken
+                        $0.timedOut += timedOut
+                    }
+                    waiters.leave()
                 }
-                totals.withLock {
-                    $0.woken += woken
-                    $0.timedOut += timedOut
-                }
-                waiters.leave()
             }
-        }
 
-        for _ in 0..<notifierCount {
-            notifiers.enter()
-            Thread.detachNewThread {
-                var notified = 0
-                while !stop.load(ordering: .acquiring) {
-                    notified += Int(lot.unpark(address: address, count: .max))
-                    // Yield each iteration so the tight notify loop does not starve the
-                    // waiter threads of CPU on low-core hosts: waiters must get scheduled
-                    // long enough to actually park for a notify to reach them, which keeps
-                    // the `woken > 0` non-vacuity guard robust without lengthening the
-                    // waiters' timeout (which would stop exercising the timeout path).
-                    sched_yield()
+            for _ in 0..<notifierCount {
+                notifiers.enter()
+                Thread.detachNewThread {
+                    var notified = 0
+                    while !stop.load(ordering: .acquiring) {
+                        notified += Int(lot.unpark(address: address, count: .max))
+                        // Yield each iteration so the tight notify loop does not starve the
+                        // waiter threads of CPU on low-core hosts: waiters must get scheduled
+                        // long enough to actually park for a notify to reach them, which keeps
+                        // the `woken > 0` non-vacuity guard robust without lengthening the
+                        // waiters' timeout (which would stop exercising the timeout path).
+                        sched_yield()
+                    }
+                    totals.withLock { $0.notify += notified }
+                    notifiers.leave()
                 }
-                totals.withLock { $0.notify += notified }
-                notifiers.leave()
             }
-        }
 
-        waiters.wait()
-        stop.store(true, ordering: .releasing)
-        notifiers.wait()
+            waiters.wait()
+            stop.store(true, ordering: .releasing)
+            notifiers.wait()
 
-        // `waiters.wait()`/`notifiers.wait()` establish happens-before for every per-thread
-        // `totals` write, so this final read observes all of them.
-        totals.withLock { t in
-            #expect(
-                t.notify == t.woken,
-                "notify count (\(t.notify)) must equal observed wakeups (\(t.woken))"
-            )
-            // Non-vacuity: confirm notifies actually woke some waiters this run (else
-            // 0 == 0 is meaningless). This proves notify reached waiters; it does NOT by
-            // itself prove the timeout/notify overlap window was hit — that race is what
-            // `timedOutWaiterClaimedByNotifyReportsWoken` covers deterministically.
-            // A failure here means too little contention: raise runDuration / counts.
-            #expect(t.woken > 0, "no waiter was woken by a notify (raise contention/runDuration)")
+            // `waiters.wait()`/`notifiers.wait()` establish happens-before for every per-thread
+            // `totals` write, so this final read observes all of them.
+            totals.withLock { t in
+                #expect(
+                    t.notify == t.woken,
+                    "notify count (\(t.notify)) must equal observed wakeups (\(t.woken))"
+                )
+                // Non-vacuity: confirm notifies actually woke some waiters this run (else
+                // 0 == 0 is meaningless). This proves notify reached waiters; it does NOT by
+                // itself prove the timeout/notify overlap window was hit — that race is what
+                // `timedOutWaiterClaimedByNotifyReportsWoken` covers deterministically.
+                // A failure here means too little contention: raise runDuration / counts.
+                #expect(t.woken > 0, "no waiter was woken by a notify (raise contention/runDuration)")
+            }
         }
     }
-}
 
 #endif

--- a/Tests/WasmKitTests/AtomicParkingLotTests.swift
+++ b/Tests/WasmKitTests/AtomicParkingLotTests.swift
@@ -13,6 +13,11 @@ import Testing
     import Glibc
 #endif
 
+// These tests drive real cross-thread park/unpark blocking, so they only apply where
+// `AtomicParkingLot` has a pthread-backed implementation. On Windows/WASI it is a stub
+// (see AtomicParkingLot.swift), and `swift test` there must not compile this suite.
+#if canImport(Darwin) || canImport(Musl) || canImport(Glibc)
+
 @Suite struct AtomicParkingLotTests {
     #if DEBUG
         /// Deterministic regression for the notify/timeout race: a waiter that `unpark`
@@ -169,3 +174,5 @@ import Testing
         }
     }
 }
+
+#endif

--- a/Tests/WasmKitTests/AtomicParkingLotTests.swift
+++ b/Tests/WasmKitTests/AtomicParkingLotTests.swift
@@ -1,0 +1,160 @@
+import Dispatch
+import Foundation
+import Synchronization
+import Testing
+
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
+@testable import WasmKit
+
+@Suite struct AtomicParkingLotTests {
+    #if DEBUG
+    /// Deterministic regression for the notify/timeout race: a waiter that `unpark`
+    /// dequeues and counts must report `.woken` (0), not `.timedOut` (2).
+    ///
+    /// Ordering is forced with no reliance on wall-clock timing:
+    ///   1. the waiter registers, then blocks in `beforeSleep`;
+    ///   2. the notifier `unpark`s — removing and counting the slot — then pauses in the
+    ///      seam, before `wake()`, so `woken` stays false and the slot is already absent;
+    ///   3. the waiter resumes with a zero timeout, reads `woken == false`, and runs its
+    ///      timeout-path registry check against the now-absent slot.
+    @Test func timedOutWaiterClaimedByNotifyReportsWoken() {
+        let lot = AtomicParkingLot()
+        let address: UInt64 = 0x2000
+
+        let registered = DispatchSemaphore(value: 0)
+        let proceedWaiter = DispatchSemaphore(value: 0)
+        let dequeued = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+
+        lot._afterDequeueBeforeWake.withLock { $0 = { dequeued.signal(); release.wait() } }
+
+        let outcome = Mutex<WaitOutcome?>(nil)
+        let notifyCount = Mutex<UInt32>(0)
+        let waiterDone = DispatchGroup()
+        let notifierDone = DispatchGroup()
+
+        waiterDone.enter()
+        Thread.detachNewThread {
+            let result = lot.parkConditionally(
+                address: address,
+                validate: { true },
+                deadline: { ContinuousClock.now },  // relative timeout 0: `wait` reads `woken` immediately
+                beforeSleep: { registered.signal(); proceedWaiter.wait() }
+            )
+            outcome.withLock { $0 = result }
+            waiterDone.leave()
+        }
+
+        notifierDone.enter()
+        Thread.detachNewThread {
+            registered.wait()                                   // slot is queued
+            let n = lot.unpark(address: address, count: .max)   // removes+counts, then pauses in the seam
+            notifyCount.withLock { $0 = n }
+            notifierDone.leave()
+        }
+
+        dequeued.wait()         // unpark removed+counted the slot; paused before wake()
+        proceedWaiter.signal()  // waiter resumes: reads woken==false, finds its slot absent
+        waiterDone.wait()       // waiter has returned its outcome
+        release.signal()        // unpark finishes (wake() is now a no-op on the discarded slot)
+        notifierDone.wait()
+
+        #expect(notifyCount.withLock { $0 } == 1, "unpark must count the single dequeued waiter")
+        #expect(
+            outcome.withLock { $0 } == .woken,
+            "a waiter that unpark dequeued and counted must report .woken (0), not .timedOut (2)"
+        )
+    }
+    #endif
+
+    /// Contention breadth: across a run using only `unpark`, the sum of `unpark`
+    /// return values must equal the number of `parkConditionally` calls returning
+    /// `.woken` (exact post-fix; see the plan's Correctness argument). Waiters use a
+    /// short positive timeout so they block in `pthread_cond_timedwait`, the
+    /// production `memory.atomic.wait` path.
+    @Test func notifyCountMatchesObservedWakeupsUnderContention() {
+        let lot = AtomicParkingLot()
+        let address: UInt64 = 0x1000
+
+        let cores = ProcessInfo.processInfo.activeProcessorCount
+        let waiterCount = max(4, cores)
+        let notifierCount = max(2, cores / 2)
+        let runDuration: Duration = .milliseconds(750)
+        let waitTimeout: Duration = .microseconds(200)
+
+        let totals = Mutex<(notify: Int, woken: Int, timedOut: Int)>((0, 0, 0))
+        let stop = Atomic<Bool>(false)
+        let waiters = DispatchGroup()
+        let notifiers = DispatchGroup()
+        let stopAt = ContinuousClock.now.advanced(by: runDuration)
+
+        for _ in 0..<waiterCount {
+            waiters.enter()
+            Thread.detachNewThread {
+                var woken = 0
+                var timedOut = 0
+                while ContinuousClock.now < stopAt {
+                    switch lot.parkConditionally(
+                        address: address,
+                        validate: { true },
+                        deadline: { ContinuousClock.now.advanced(by: waitTimeout) }
+                    ) {
+                    case .woken: woken += 1
+                    case .timedOut: timedOut += 1
+                    case .mismatch:
+                        // Unreachable here: `validate` is constant-true, so the slot is always
+                        // appended and the wait runs. `continue` (not `break`) makes the intent
+                        // explicit — a bare `break` would exit only the switch, not the loop.
+                        continue
+                    }
+                }
+                totals.withLock { $0.woken += woken; $0.timedOut += timedOut }
+                waiters.leave()
+            }
+        }
+
+        for _ in 0..<notifierCount {
+            notifiers.enter()
+            Thread.detachNewThread {
+                var notified = 0
+                while !stop.load(ordering: .acquiring) {
+                    notified += Int(lot.unpark(address: address, count: .max))
+                    // Yield each iteration so the tight notify loop does not starve the
+                    // waiter threads of CPU on low-core hosts: waiters must get scheduled
+                    // long enough to actually park for a notify to reach them, which keeps
+                    // the `woken > 0` non-vacuity guard robust without lengthening the
+                    // waiters' timeout (which would stop exercising the timeout path).
+                    sched_yield()
+                }
+                totals.withLock { $0.notify += notified }
+                notifiers.leave()
+            }
+        }
+
+        waiters.wait()
+        stop.store(true, ordering: .releasing)
+        notifiers.wait()
+
+        // `waiters.wait()`/`notifiers.wait()` establish happens-before for every per-thread
+        // `totals` write, so this final read observes all of them.
+        totals.withLock { t in
+            #expect(
+                t.notify == t.woken,
+                "notify count (\(t.notify)) must equal observed wakeups (\(t.woken))"
+            )
+            // Non-vacuity: confirm notifies actually woke some waiters this run (else
+            // 0 == 0 is meaningless). This proves notify reached waiters; it does NOT by
+            // itself prove the timeout/notify overlap window was hit — that race is what
+            // `timedOutWaiterClaimedByNotifyReportsWoken` covers deterministically.
+            // A failure here means too little contention: raise runDuration / counts.
+            #expect(t.woken > 0, "no waiter was woken by a notify (raise contention/runDuration)")
+        }
+    }
+}

--- a/Tests/WasmKitTests/SharedMemoryStorageTests.swift
+++ b/Tests/WasmKitTests/SharedMemoryStorageTests.swift
@@ -1,0 +1,846 @@
+import Synchronization
+import Testing
+import WAT
+
+@_spi(Fuzzing) @_spi(OnlyForCLI) @testable import WasmKit
+
+@Suite struct SharedMemoryStorageTests {
+    /// Asserts `body` throws a `Trap` whose `reason` equals `expected`, without relying on
+    /// `Trap: Equatable`. Closure-based counterpart to `ExecutionTests.expectTrap` (which runs
+    /// a WAT module); both capture the trap and assert on its reason rather than comparing
+    /// whole `Trap` values, so the per-run backtrace never participates in the check.
+    func expectTrap(
+        _ expected: TrapReason,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ body: () throws -> Void
+    ) {
+        do {
+            try body()
+            Issue.record("expected a trap (\(expected)), but no error was thrown", sourceLocation: sourceLocation)
+        } catch let trap as Trap {
+            #expect(trap.reason == expected, sourceLocation: sourceLocation)
+        } catch {
+            Issue.record("expected a trap (\(expected)), but caught: \(error)", sourceLocation: sourceLocation)
+        }
+    }
+
+    // MARK: - Unit tests (SharedMemoryStorage directly)
+
+    @Test func initSharedMemory_correctInitialState() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 2, max: 10, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            let shared = entity.sharedStorage!
+            shared.withValue { storage in
+                #expect(storage.currentByteCount.load(ordering: .acquiring) == 2 * 65536)
+                #expect(storage.maxByteCount == 10 * 65536)
+                // On mprotect platforms, reservation covers full wasm32 range (4 GiB+)
+                #if os(macOS) || os(Linux)
+                    #expect(storage.reservationSize >= (1 << 32))
+                #else
+                    #expect(storage.reservationSize == 10 * 65536)
+                #endif
+                // Verify initial region is zero-filled
+                let firstByte = storage.basePointer.load(as: UInt8.self)
+                #expect(firstByte == 0)
+                let lastByte = storage.basePointer.load(fromByteOffset: 2 * 65536 - 1, as: UInt8.self)
+                #expect(lastByte == 0)
+            }
+        }
+    }
+
+    @Test func growSharedMemory_basePointerStable() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 4, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        let baseBefore = memory.handle.withValue { $0.baseAddress }
+        // Grow by 2 pages
+        memory.handle.withValue { entity in
+            let result = try! entity.grow(by: 2, resourceLimiter: store.resourceLimiter)
+            #expect(result == .i32(1))  // old page count was 1
+        }
+        let baseAfter = memory.handle.withValue { $0.baseAddress }
+        #expect(baseBefore == baseAfter, "Base pointer must not change on shared memory grow")
+        #expect(memory.handle.withValue({ $0.byteCount }) == 3 * 65536)
+    }
+
+    @Test func growSharedMemory_returnsPreviousPageCount() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 4, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            let result1 = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+            #expect(result1 == .i32(1))  // was 1 page
+            let result2 = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+            #expect(result2 == .i32(2))  // was 2 pages
+        }
+    }
+
+    @Test func growSharedMemory_exceedsMax_returnsNegative() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 2, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            // Grow by 2 would bring total to 3, exceeding max of 2
+            let result = try! entity.grow(by: 2, resourceLimiter: store.resourceLimiter)
+            #expect(result == .i32(UInt32(bitPattern: -1)))
+            // Size unchanged
+            #expect(entity.byteCount == 1 * 65536)
+        }
+    }
+
+    @Test func growSharedMemory_zeroFillsNewPages() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 3, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            // Write a non-zero byte at the end of page 1
+            entity.baseAddress!.storeBytes(of: UInt8(0xFF), toByteOffset: 65535, as: UInt8.self)
+
+            let _ = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+
+            // Spot-check new page is zero-filled at start, middle, and end
+            let newPageStart = entity.baseAddress!.load(fromByteOffset: 65536, as: UInt8.self)
+            let newPageMiddle = entity.baseAddress!.load(fromByteOffset: 65536 + 32768, as: UInt8.self)
+            let newPageEnd = entity.baseAddress!.load(fromByteOffset: 2 * 65536 - 1, as: UInt8.self)
+            #expect(newPageStart == 0)
+            #expect(newPageMiddle == 0)
+            #expect(newPageEnd == 0)
+
+            // Verify the old data is still intact
+            let preserved = entity.baseAddress!.load(fromByteOffset: 65535, as: UInt8.self)
+            #expect(preserved == 0xFF)
+        }
+    }
+
+    // MARK: - WAT-based integration tests
+
+    @Test func sharedMemory_growAndAccess() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 4 shared)
+                    (func (export "grow") (result i32)
+                        (memory.grow (i32.const 1))
+                    )
+                    (func (export "store-and-load") (param $addr i32) (param $val i32) (result i32)
+                        (i32.store (local.get $addr) (local.get $val))
+                        (i32.load (local.get $addr))
+                    )
+                    (func (export "size") (result i32)
+                        (memory.size)
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let grow = try #require(instance.exports[function: "grow"])
+        let storeAndLoad = try #require(instance.exports[function: "store-and-load"])
+        let size = try #require(instance.exports[function: "size"])
+
+        // Initial size is 1 page
+        #expect(try size() == [.i32(1)])
+
+        // Store and load within initial page
+        #expect(try storeAndLoad([.i32(0), .i32(42)]) == [.i32(42)])
+
+        // Grow by 1
+        #expect(try grow() == [.i32(1)])  // old page count
+
+        // Size should be 2
+        #expect(try size() == [.i32(2)])
+
+        // Store and load in the new page
+        #expect(try storeAndLoad([.i32(65536), .i32(99)]) == [.i32(99)])
+    }
+
+    @Test func sharedMemory_sizeReflectsHostGrow() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (import "env" "mem") 1 4 shared)
+                    (func (export "size") (result i32)
+                        (memory.size)
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+
+        // Create shared memory and import it
+        let sharedMem = try Memory(store: store, type: MemoryType(min: 1, max: 4, shared: true))
+        let imports: Imports = ["env": ["mem": sharedMem]]
+        let instance = try module.instantiate(store: store, imports: imports)
+        let size = try #require(instance.exports[function: "size"])
+
+        #expect(try size() == [.i32(1)])
+
+        // Grow from the host side (bypassing wasm memory.grow instruction)
+        sharedMem.handle.withValue { entity in
+            let _ = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+        }
+
+        // memory.size should see the updated value (reads atomically from SharedMemoryStorage)
+        #expect(try size() == [.i32(2)])
+    }
+
+    // MARK: - Bounds checking and signal handler tests
+
+    @Test func growSharedMemory_byZero_returnsCurrentPageCount() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 2, max: 4, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            let result = try! entity.grow(by: 0, resourceLimiter: store.resourceLimiter)
+            #expect(result == .i32(2))  // returns current page count, not -1
+            #expect(entity.byteCount == 2 * 65536)  // size unchanged
+        }
+    }
+
+    @Test func growSharedMemory_toExactMax_succeeds() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 3, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            // Grow to exactly max (1 + 2 = 3)
+            let result = try! entity.grow(by: 2, resourceLimiter: store.resourceLimiter)
+            #expect(result == .i32(1))
+            #expect(entity.byteCount == 3 * 65536)
+
+            // One more page should fail
+            let fail = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+            #expect(fail == .i32(UInt32(bitPattern: -1)))
+            #expect(entity.byteCount == 3 * 65536)  // unchanged
+        }
+    }
+
+    @Test func growSharedMemory_overflowChecked() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 10, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            // Grow by a huge number that would overflow Int multiplication
+            let result = try! entity.grow(by: Int.max / 65536 + 1, resourceLimiter: store.resourceLimiter)
+            #expect(result == .i32(UInt32(bitPattern: -1)))
+            #expect(entity.byteCount == 1 * 65536)  // unchanged
+        }
+    }
+
+    @Test func sharedMemory_oobBoundary() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "load8") (param $addr i32) (result i32)
+                        (i32.load8_u (local.get $addr))
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let load8 = try #require(instance.exports[function: "load8"])
+
+        // Last byte of page 1: should succeed
+        #expect(try load8([.i32(65535)]) == [.i32(0)])
+
+        // First byte beyond committed region: should trap
+        expectTrap(.memoryOutOfBounds) {
+            _ = try load8([.i32(65536)])
+        }
+    }
+
+    @Test func sharedMemory_bulkOps() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "fill") (param $dst i32) (param $val i32) (param $len i32)
+                        (memory.fill (local.get $dst) (local.get $val) (local.get $len))
+                    )
+                    (func (export "copy") (param $dst i32) (param $src i32) (param $len i32)
+                        (memory.copy (local.get $dst) (local.get $src) (local.get $len))
+                    )
+                    (func (export "load8") (param $addr i32) (result i32)
+                        (i32.load8_u (local.get $addr))
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let fill = try #require(instance.exports[function: "fill"])
+        let copy = try #require(instance.exports[function: "copy"])
+        let load8 = try #require(instance.exports[function: "load8"])
+
+        // Fill 4 bytes at offset 0 with value 0xAB
+        _ = try fill([.i32(0), .i32(0xAB), .i32(4)])
+        #expect(try load8([.i32(0)]) == [.i32(0xAB)])
+        #expect(try load8([.i32(3)]) == [.i32(0xAB)])
+        #expect(try load8([.i32(4)]) == [.i32(0)])
+
+        // Copy 4 bytes from offset 0 to offset 10
+        _ = try copy([.i32(10), .i32(0), .i32(4)])
+        #expect(try load8([.i32(10)]) == [.i32(0xAB)])
+        #expect(try load8([.i32(13)]) == [.i32(0xAB)])
+    }
+
+    @Test func sharedMemory_growViaWasm_failAtMax() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "grow1") (result i32)
+                        (memory.grow (i32.const 1))
+                    )
+                    (func (export "size") (result i32)
+                        (memory.size)
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let grow1 = try #require(instance.exports[function: "grow1"])
+        let size = try #require(instance.exports[function: "size"])
+
+        #expect(try size() == [.i32(1)])
+
+        // Grow to max (2 pages)
+        #expect(try grow1() == [.i32(1)])
+        #expect(try size() == [.i32(2)])
+
+        // One more should fail
+        #expect(try grow1() == [.i32(UInt32(bitPattern: -1))])
+        #expect(try size() == [.i32(2)])
+    }
+
+    @Test func sharedMemory_accessAfterGrowInNewRegion() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 4 shared)
+                    (func (export "grow1") (result i32)
+                        (memory.grow (i32.const 1))
+                    )
+                    (func (export "store-load") (param $addr i32) (param $val i32) (result i32)
+                        (i32.store (local.get $addr) (local.get $val))
+                        (i32.load (local.get $addr))
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let grow1 = try #require(instance.exports[function: "grow1"])
+        let storeLoad = try #require(instance.exports[function: "store-load"])
+
+        // Grow into page 2
+        #expect(try grow1() == [.i32(1)])
+
+        // Access the newly grown page
+        #expect(try storeLoad([.i32(65536), .i32(12345)]) == [.i32(12345)])
+
+        // Grow again, access page 3
+        #expect(try grow1() == [.i32(2)])
+        #expect(try storeLoad([.i32(131072), .i32(99999)]) == [.i32(99999)])
+    }
+
+    @Test func sharedMemory_uncheckedOobTraps() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 2, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        // Verify trapGuardReservationSize is nonzero (meaning unchecked instructions will be used)
+        memory.handle.withValue { entity in
+            #expect(entity.trapGuardReservationSize > 0, "Shared memory must report reservation size for unchecked instructions")
+        }
+
+        // Run a module that does an OOB access -- must trap, not silently succeed
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (import "env" "mem") 1 2 shared)
+                    (func (export "oob_load") (result i32)
+                        (i32.load (i32.const 65536))
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let imports: Imports = ["env": ["mem": memory]]
+        let instance = try module.instantiate(store: store, imports: imports)
+        let oobLoad = try #require(instance.exports[function: "oob_load"])
+
+        expectTrap(.memoryOutOfBounds) {
+            _ = try oobLoad()
+        }
+    }
+
+    // MARK: - Step 1: Large OOB address must trap, not crash
+
+    @Test func sharedMemory_largeOobTraps() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 1, max: 2, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (import "env" "mem") 1 2 shared)
+                    (func (export "oob") (param $addr i32) (result i32)
+                        (i32.load (local.get $addr))
+                    )
+                )
+                """,
+                features: [.threads]),
+            features: [.threads])
+        let instance = try module.instantiate(store: store, imports: ["env": ["mem": memory]])
+        let oob = try #require(instance.exports[function: "oob"])
+
+        // Address 999999 is way beyond 2 pages (131072). Must trap, not crash.
+        expectTrap(.memoryOutOfBounds) {
+            _ = try oob([.i32(999999)])
+        }
+    }
+
+    // MARK: - Step 6: Ms staleness reload path tests
+
+    @Test func sharedMemory_stalenessReloadPath_software() throws {
+        // Shared memory always uses software bounds checking. After a host grow, the
+        // running frame's cached `ms` is stale, so this exercises the shared load
+        // variant's reload (reloadSharedMemorySize) before it would otherwise trap.
+        let engine = Engine(
+            configuration: .init(
+                features: [.threads],
+                memoryBoundsChecking: .software
+            ))
+        let store = Store(engine: engine)
+
+        let sharedMem = try Memory(store: store, type: MemoryType(min: 1, max: 4, shared: true))
+
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (import "test" "memory" (memory 1 4 shared))
+                    (import "test" "grow" (func $grow))
+                    (func (export "test_staleness") (result i32)
+                        ;; Call host to grow by 1 page. After returning, the cached ms
+                        ;; (memory size) is stale -- it still reflects the pre-grow size.
+                        call $grow
+                        ;; Access the first byte of the newly grown page. With software
+                        ;; bounds checking, this exercises the boundsOk slow path which
+                        ;; calls reloadSharedMemorySize to get the fresh size.
+                        (i32.load (i32.const 65536))
+                    )
+                )
+                """,
+                features: [.threads]),
+            features: [.threads])
+
+        let growCalled = Atomic<Bool>(false)
+        let sharedStorage = sharedMem.handle.withValue { $0.sharedStorage! }
+        let limiter = store.resourceLimiter
+        let growFunc = Function(store: store, type: FunctionType(parameters: [], results: [])) { _, _ in
+            sharedStorage.withValue { storage in
+                _ = try! storage.grow(by: 1, resourceLimiter: limiter)
+            }
+            growCalled.store(true, ordering: .releasing)
+            return []
+        }
+
+        let imports: Imports = ["test": ["memory": sharedMem, "grow": growFunc]]
+        let instance = try module.instantiate(store: store, imports: imports)
+        let testStaleness = try #require(instance.exports[function: "test_staleness"])
+
+        // The load should succeed (reading from the grown page, which is zero-initialized)
+        let result = try testStaleness()
+        #expect(result == [.i32(0)])
+        let didGrow = growCalled.load(ordering: .acquiring)
+        #expect(didGrow, "Host grow function must have been called")
+    }
+
+    @Test func sharedMemory_stalenessReloadPath_atomic() throws {
+        // Use default engine config (mprotect bounds checking). i32.atomic.load always
+        // uses the checked path (atomics have no unchecked variants), so this exercises
+        // the boundsOk slow path via the atomic load instruction.
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+
+        let sharedMem = try Memory(store: store, type: MemoryType(min: 1, max: 4, shared: true))
+
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (import "test" "memory" (memory 1 4 shared))
+                    (import "test" "grow" (func $grow))
+                    (func (export "test_staleness") (result i32)
+                        call $grow
+                        ;; i32.atomic.load always takes the checked path (no unchecked
+                        ;; atomic variants). Exercises atomicLoad boundsOk slow path
+                        ;; when ms is stale after host grow.
+                        (i32.atomic.load (i32.const 65536))
+                    )
+                )
+                """,
+                features: [.threads]),
+            features: [.threads])
+
+        let growCalled = Atomic<Bool>(false)
+        let sharedStorage = sharedMem.handle.withValue { $0.sharedStorage! }
+        let limiter = store.resourceLimiter
+        let growFunc = Function(store: store, type: FunctionType(parameters: [], results: [])) { _, _ in
+            sharedStorage.withValue { storage in
+                _ = try! storage.grow(by: 1, resourceLimiter: limiter)
+            }
+            growCalled.store(true, ordering: .releasing)
+            return []
+        }
+
+        let imports: Imports = ["test": ["memory": sharedMem, "grow": growFunc]]
+        let instance = try module.instantiate(store: store, imports: imports)
+        let testStaleness = try #require(instance.exports[function: "test_staleness"])
+
+        let result = try testStaleness()
+        #expect(result == [.i32(0)])
+        let didGrow = growCalled.load(ordering: .acquiring)
+        #expect(didGrow, "Host grow function must have been called")
+    }
+
+    // MARK: - Step 7: Additional coverage tests
+
+    @Test func sharedMemory_boundaryAfterGrow() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "grow1") (result i32)
+                        (memory.grow (i32.const 1))
+                    )
+                    (func (export "load8") (param $addr i32) (result i32)
+                        (i32.load8_u (local.get $addr))
+                    )
+                )
+                """,
+                features: [.threads]),
+            features: [.threads])
+        let instance = try module.instantiate(store: store)
+        let grow1 = try #require(instance.exports[function: "grow1"])
+        let load8 = try #require(instance.exports[function: "load8"])
+
+        // Grow from 1 to 2 pages
+        #expect(try grow1() == [.i32(1)])
+
+        // Last byte of page 2: should succeed
+        #expect(try load8([.i32(131071)]) == [.i32(0)])
+
+        // First byte beyond 2 pages: should trap
+        expectTrap(.memoryOutOfBounds) {
+            _ = try load8([.i32(131072)])
+        }
+    }
+
+    @Test func sharedMemory_dataIntegrityAcrossGrow() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 4 shared)
+                    (func (export "grow1") (result i32)
+                        (memory.grow (i32.const 1))
+                    )
+                    (func (export "store32") (param $addr i32) (param $val i32)
+                        (i32.store (local.get $addr) (local.get $val))
+                    )
+                    (func (export "load32") (param $addr i32) (result i32)
+                        (i32.load (local.get $addr))
+                    )
+                )
+                """,
+                features: [.threads]),
+            features: [.threads])
+        let instance = try module.instantiate(store: store)
+        let grow1 = try #require(instance.exports[function: "grow1"])
+        let store32 = try #require(instance.exports[function: "store32"])
+        let load32 = try #require(instance.exports[function: "load32"])
+
+        // Store value in page 1
+        _ = try store32([.i32(100), .i32(42)])
+
+        // Grow and store in page 2
+        #expect(try grow1() == [.i32(1)])
+        _ = try store32([.i32(65636), .i32(99)])
+
+        // Read back both values — data in page 1 must survive grow
+        #expect(try load32([.i32(100)]) == [.i32(42)])
+        #expect(try load32([.i32(65636)]) == [.i32(99)])
+    }
+
+    @Test func sharedMemory_minZero() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 0, max: 2, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        #expect(memory.byteCount == 0)
+
+        // Grow by 1 page
+        memory.handle.withValue { entity in
+            let result = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+            #expect(result == .i32(0))  // old page count was 0
+            #expect(entity.byteCount == 65536)
+        }
+    }
+
+    @Test func sharedMemory_minEqualsMax() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let memType = MemoryType(min: 2, max: 2, shared: true)
+        let memory = try Memory(store: store, type: memType)
+
+        memory.handle.withValue { entity in
+            // Grow by 0 returns current page count
+            let result0 = try! entity.grow(by: 0, resourceLimiter: store.resourceLimiter)
+            #expect(result0 == .i32(2))
+
+            // Grow by 1 must fail (already at max)
+            let result1 = try! entity.grow(by: 1, resourceLimiter: store.resourceLimiter)
+            #expect(result1 == .i32(UInt32(bitPattern: -1)))
+
+            // Size unchanged
+            #expect(entity.byteCount == 2 * 65536)
+        }
+    }
+
+    // Regression: per the threads spec, `memory.atomic.wait` timeout is a
+    // signed i64; `timeout >= 0` expires after that many nanoseconds, and
+    // a zero timeout must return immediately with code 2 (timed-out) when
+    // the value matches. The original implementation incorrectly treated
+    // `timeout == 0` as "wait indefinitely".
+    @Test func atomicWait32_zeroTimeoutReturnsImmediately() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "wait_zero") (result i32)
+                        i32.const 0       ;; address
+                        i32.const 0       ;; expected value (matches initial 0)
+                        i64.const 0       ;; timeout = 0 ns (immediate)
+                        memory.atomic.wait32
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let waitZero = try #require(instance.exports[function: "wait_zero"])
+        // Spec result codes: 0 = ok, 1 = not-equal, 2 = timed-out.
+        #expect(try waitZero([]) == [.i32(2)])
+    }
+
+    // Regression: per the threads spec, `memory.atomic.wait` timeout is a
+    // signed i64; `timeout < 0` means never expires. The original
+    // implementation crashed on negative timeouts because it converted the
+    // raw UInt64 via `Int64(timeout)`, which traps on values > Int64.max.
+    // Use a value-mismatch path so the wait returns immediately with code 1
+    // and we don't actually have to wait forever to prove there's no crash.
+    @Test func atomicWait32_negativeTimeoutDoesNotCrash() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "wait_mismatch") (result i32)
+                        i32.const 0       ;; address
+                        i32.const 999     ;; expected value (mismatches initial 0)
+                        i64.const -1      ;; timeout < 0 (would be infinite if reached)
+                        memory.atomic.wait32
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let waitMismatch = try #require(instance.exports[function: "wait_mismatch"])
+        // Value mismatch returns code 1 (not-equal) without entering the wait,
+        // but the timeout argument is decoded before the mismatch check in
+        // some implementations — this still proves the bit-pattern conversion
+        // doesn't crash.
+        #expect(try waitMismatch([]) == [.i32(1)])
+    }
+
+    // Regression: same fix verified for the i64 variant.
+    @Test func atomicWait64_zeroTimeoutReturnsImmediately() throws {
+        let engine = Engine(configuration: .init(features: [.threads]))
+        let store = Store(engine: engine)
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (memory (export "mem") 1 2 shared)
+                    (func (export "wait_zero") (result i32)
+                        i32.const 0       ;; address
+                        i64.const 0       ;; expected value (matches initial 0)
+                        i64.const 0       ;; timeout = 0 ns (immediate)
+                        memory.atomic.wait64
+                    )
+                )
+                """,
+                features: [.threads]
+            ),
+            features: [.threads]
+        )
+        let instance = try module.instantiate(store: store)
+        let waitZero = try #require(instance.exports[function: "wait_zero"])
+        #expect(try waitZero([]) == [.i32(2)])
+    }
+
+    // Directly verifies translation-time handler selection: shared-memory scalar
+    // loads/stores route to the reload-capable `…Shared` opcode variants, and
+    // non-shared memory to the plain `origin/main` handlers. Guards the per-case
+    // ternaries in Translator.visitLoad/visitStore against drift.
+    @Test func loadStoreOpcodeSelection_byMemoryShared() throws {
+        func dumpLoadStore(shared: Bool) throws -> String {
+            let memoryDecl = shared ? "(memory 1 1 shared)" : "(memory 1)"
+            let module = try parseWasm(
+                bytes: try wat2wasm(
+                    """
+                    (module
+                        \(memoryDecl)
+                        (func (export "ld") (param i32) (result i32) (i32.load (local.get 0)))
+                        (func (export "st") (param i32 i32) (i32.store (local.get 0) (local.get 1)))
+                    )
+                    """,
+                    features: shared ? [.threads] : []
+                ),
+                features: shared ? [.threads] : []
+            )
+            // dumpFunctions requires the token threading model.
+            let engine = Engine(configuration: .init(threadingModel: .token, features: shared ? [.threads] : []))
+            let store = Store(engine: engine)
+            let instance = try module.instantiate(store: store)
+            var out = ""
+            try instance.dumpFunctions(to: &out, module: module)
+            return out
+        }
+
+        let plain = try dumpLoadStore(shared: false)
+        #expect(plain.contains("i32.load"))
+        #expect(plain.contains("i32.store"))
+        #expect(!plain.contains("Shared"))
+
+        let shared = try dumpLoadStore(shared: true)
+        #expect(shared.contains("i32LoadShared"))
+        #expect(shared.contains("i32StoreShared"))
+    }
+
+    // SIMD (v128) loads on shared memory must tolerate a stale cached size after a
+    // concurrent grow, consistent with scalar loads. After a host grow, the v128.load
+    // into the freshly-grown page must succeed (zero-filled), not trap.
+    @Test func sharedMemory_stalenessReloadPath_simd() throws {
+        let engine = Engine(configuration: .init(features: [.threads, .simd]))
+        let store = Store(engine: engine)
+        let sharedMem = try Memory(store: store, type: MemoryType(min: 1, max: 4, shared: true))
+        let module = try parseWasm(
+            bytes: try wat2wasm(
+                """
+                (module
+                    (import "test" "memory" (memory 1 4 shared))
+                    (import "test" "grow" (func $grow))
+                    (func (export "test_staleness") (result i32)
+                        call $grow
+                        (i32x4.extract_lane 0 (v128.load (i32.const 65536)))
+                    )
+                )
+                """,
+                features: [.threads, .simd]),
+            features: [.threads, .simd])
+        let growCalled = Atomic<Bool>(false)
+        let sharedStorage = sharedMem.handle.withValue { $0.sharedStorage! }
+        let limiter = store.resourceLimiter
+        let growFunc = Function(store: store, type: FunctionType(parameters: [], results: [])) { _, _ in
+            sharedStorage.withValue { storage in
+                _ = try! storage.grow(by: 1, resourceLimiter: limiter)
+            }
+            growCalled.store(true, ordering: .releasing)
+            return []
+        }
+        let imports: Imports = ["test": ["memory": sharedMem, "grow": growFunc]]
+        let instance = try module.instantiate(store: store, imports: imports)
+        let testStaleness = try #require(instance.exports[function: "test_staleness"])
+        let result = try testStaleness()
+        #expect(result == [.i32(0)])
+        let didGrow = growCalled.load(ordering: .acquiring)
+        #expect(didGrow, "Host grow function must have been called")
+    }
+}

--- a/Tests/WasmKitTests/SharedMemoryStorageTests.swift
+++ b/Tests/WasmKitTests/SharedMemoryStorageTests.swift
@@ -37,9 +37,16 @@ import WAT
             shared.withValue { storage in
                 #expect(storage.currentByteCount.load(ordering: .acquiring) == 2 * 65536)
                 #expect(storage.maxByteCount == 10 * 65536)
-                // On mprotect platforms, reservation covers full wasm32 range (4 GiB+)
+                // The full wasm32 reservation (4 GiB+) is only taken when the engine
+                // actually resolved to mprotect bounds checking. Under AddressSanitizer or
+                // token threading the engine downgrades to software checks (see Engine.init),
+                // where the reservation is just maxByteCount.
                 #if os(macOS) || os(Linux)
-                    #expect(storage.reservationSize >= (1 << 32))
+                    if engine.configuration.memoryBoundsChecking == .mprotect {
+                        #expect(storage.reservationSize >= (1 << 32))
+                    } else {
+                        #expect(storage.reservationSize == 10 * 65536)
+                    }
                 #else
                     #expect(storage.reservationSize == 10 * 65536)
                 #endif

--- a/Utilities/Sources/VMGen.swift
+++ b/Utilities/Sources/VMGen.swift
@@ -85,6 +85,17 @@ enum VMGen {
             """
         }
 
+        for op in memoryLoadOps {
+            inlineImpls[op.sharedInstruction.name] = """
+            try memoryLoadShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: \(op.loadAs).self, castToValue: { \(op.castToValue) })
+            """
+        }
+        for op in memoryStoreOps {
+            inlineImpls[op.sharedInstruction.name] = """
+            try memoryStoreShared(sp: sp.pointee, md: md.pointee, ms: ms.pointee, storeOperand: immediate, castFromValue: { \(op.castFromValue) })
+            """
+        }
+
         for op in memoryAtomicLoadOps {
             inlineImpls[op.atomicInstruction.name] = """
             try atomicLoad(sp: sp.pointee, md: md.pointee, ms: ms.pointee, loadOperand: immediate, loadAs: \(op.loadAs).self, castToValue: { \(op.castToValue) })

--- a/Utilities/Sources/VMSpec/Instruction.swift
+++ b/Utilities/Sources/VMSpec/Instruction.swift
@@ -363,6 +363,10 @@ extension VMGen {
             Instruction(name: "\(type)Atomic\(op)", documentation: "WebAssembly Core Instruction `\(type).atomic.\(VMGen.snakeCase(pascalCase: op))`",
                         mayThrow: true, useCurrentMemory: .read, immediateLayout: .load)
         }
+        var sharedInstruction: Instruction {
+            Instruction(name: "\(type)\(op)Shared", documentation: "WebAssembly Core Instruction `\(type).\(VMGen.snakeCase(pascalCase: op))` on shared memory",
+                        mayThrow: true, useCurrentMemory: .read, immediateLayout: .load)
+        }
     }
 
     static let memoryLoadOps: [LoadOpInfo] = [
@@ -399,6 +403,10 @@ extension VMGen {
             Instruction(name: "\(type)Atomic\(op)", documentation: "WebAssembly Core Instruction `\(type).atomic.\(VMGen.snakeCase(pascalCase: op))`",
                         mayThrow: true, useCurrentMemory: .read, immediateLayout: .store)
         }
+        var sharedInstruction: Instruction {
+            Instruction(name: "\(type)\(op)Shared", documentation: "WebAssembly Core Instruction `\(type).\(VMGen.snakeCase(pascalCase: op))` on shared memory",
+                        mayThrow: true, useCurrentMemory: .read, immediateLayout: .store)
+        }
     }
     static let memoryStoreOps: [StoreOpInfo] = [
         ("i32", "Store", "$0.i32", false),
@@ -415,6 +423,7 @@ extension VMGen {
     }
     static let memoryAtomicStoreOps = memoryStoreOps.filter { !$0.isFloatingPoint }
     static let memoryLoadStoreInsts: [Instruction] = memoryLoadOps.map(\.instruction) + memoryStoreOps.map(\.instruction)
+    static let memorySharedLoadStoreInsts: [Instruction] = memoryLoadOps.map(\.sharedInstruction) + memoryStoreOps.map(\.sharedInstruction)
     static let memoryAtomicInsts: [Instruction] = memoryAtomicLoadOps.map(\.atomicInstruction) + memoryAtomicStoreOps.map(\.atomicInstruction)
 
     // MARK: - Atomic RMW Operations
@@ -775,6 +784,7 @@ extension VMGen {
         instructions += atomicWaitNotifyInsts
         // Exception handling
         instructions += exceptionHandlingInsts
+        instructions += memorySharedLoadStoreInsts
         return instructions
     }
 


### PR DESCRIPTION
Added corresponding shared memory load/instructions that call `reloadSharedMemorySize`, updated atomic instructions to do the same.