### PR TITLE
Benchmark with `native` build system in dev snapshot builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,9 +140,6 @@ jobs:
             build-benchmarks: true
           - swift: "swiftlang/swift:nightly-main-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport"
-            build-benchmarks: false
-          - swift: "swiftlang/swift:nightly-main-noble"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport --build-system native"
             build-benchmarks: true
 
     runs-on: ubuntu-24.04
@@ -184,7 +181,7 @@ jobs:
         run: |
           ./build-exec apt-get update
           ./build-exec apt-get install -y libjemalloc-dev
-          ./build-exec swift package --package-path Benchmarks benchmark
+          ./build-exec swift package --build-system native --package-path Benchmarks benchmark
 
       - if: matrix.build-dev-dashboard
         run: ./build-exec ./CI/build-dev-dashboard.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,9 @@ jobs:
           - swift: "swiftlang/swift:nightly-main-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport"
             build-benchmarks: true
+          - swift: "swiftlang/swift:nightly-main-noble"
+            test-args: "--traits ComponentModel,WasmDebuggingSupport --build-system native"
+            build-benchmarks: true
 
     runs-on: ubuntu-24.04
     name: "build-linux (${{ matrix.swift }}${{ matrix.label }})"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
             build-benchmarks: true
           - swift: "swiftlang/swift:nightly-main-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport"
-            build-benchmarks: true
+            build-benchmarks: false
           - swift: "swiftlang/swift:nightly-main-noble"
             test-args: "--traits ComponentModel,WasmDebuggingSupport --build-system native"
             build-benchmarks: true


### PR DESCRIPTION
This provides a baseline against SwiftBuild, which became the default since Swift 6.4