### PR TITLE
WASI: Fix fd leak in `fd_readdir`

### DIFF
--- a/Sources/SystemExtras/FileOperations.swift
+++ b/Sources/SystemExtras/FileOperations.swift
@@ -571,6 +571,10 @@ extension FileDescriptor {
       self.rawValue = rawValue
     }
 
+    public func close() {
+      _ = system_closedir(rawValue)
+    }
+
     public func next() -> Result<DirectoryEntry, Errno>? {
       // https://man7.org/linux/man-pages/man3/readdir.3.html#RETURN_VALUE
       // > If the end of the directory stream is reached, NULL is returned

--- a/Sources/SystemExtras/Syscalls.swift
+++ b/Sources/SystemExtras/Syscalls.swift
@@ -145,6 +145,11 @@ internal func system_fdopendir(_ fd: Int32) -> CInterop.DirP? {
 internal func system_readdir(_ dirp: CInterop.DirP) -> UnsafeMutablePointer<dirent>? {
   return readdir(dirp)
 }
+
+// closedir
+internal func system_closedir(_ dirp: CInterop.DirP) -> CInt {
+  return closedir(dirp)
+}
 #endif
 
 #if os(Windows)

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -54,6 +54,7 @@ protocol WASIFile: WASIEntry {
 
 protocol WASIDir: WASIEntry {
     typealias ReaddirElement = (dirent: WASIAbi.Dirent, name: String)
+    associatedtype ReadEntriesResult: WASIReaddirIterator where ReadEntriesResult.Element == ReaddirElement
 
     var preopenPath: String? { get }
 
@@ -72,13 +73,22 @@ protocol WASIDir: WASIEntry {
     func removeFile(atPath path: String) throws
     func symlink(from sourcePath: String, to destPath: String) throws
     func rename(from sourcePath: String, toDir newDir: any WASIDir, to destPath: String) throws
-    func readEntries(cookie: WASIAbi.DirCookie) throws -> AnyIterator<Result<ReaddirElement, any Error>>
+    func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat
     func setFilestatTimes(
         path: String,
         atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags, symlinkFollow: Bool
     ) throws
+}
+
+protocol WASIReaddirIterator {
+    associatedtype Element
+    mutating func next() -> Result<Element, any Error>?
+    /// Closes the iterator and releases any owned resources.
+    ///
+    /// Callers must invoke this exactly once after iteration completes.
+    mutating func close()
 }
 
 enum FdEntry {

--- a/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
@@ -3,6 +3,45 @@ import SystemPackage
 
 /// A WASIDir implementation backed by an in-memory directory node.
 struct MemoryDirEntry: WASIDir {
+    struct ReadEntriesResult: WASIReaddirIterator {
+        let children: [String]
+        let fileSystem: MemoryFileSystem
+        let basePath: String
+        var nextIndex: Int
+
+        mutating func next() -> Result<ReaddirElement, any Error>? {
+            guard nextIndex < children.count else { return nil }
+            let index = nextIndex
+            let name = children[index]
+            nextIndex += 1
+            return Result(catching: {
+                let childPath = MemoryFileSystem.joinGuestPath(basePath, name)
+                guard let childNode = fileSystem.lookup(at: childPath) else {
+                    throw WASIAbi.Errno.ENOENT
+                }
+
+                let fileType: WASIAbi.FileType
+                switch childNode.type {
+                case .directory: fileType = .DIRECTORY
+                case .file: fileType = .REGULAR_FILE
+                case .characterDevice: fileType = .CHARACTER_DEVICE
+                }
+
+                let dirent = WASIAbi.Dirent(
+                    dNext: WASIAbi.DirCookie(index + 1),
+                    dIno: 0,
+                    dirNameLen: WASIAbi.DirNameLen(name.utf8.count),
+                    dType: fileType
+                )
+
+                return (dirent, name)
+            })
+        }
+
+        mutating func close() {
+        }
+    }
+
     let preopenPath: String?
     let dirNode: MemoryDirectoryNode
     let path: String
@@ -106,41 +145,13 @@ struct MemoryDirEntry: WASIDir {
         )
     }
 
-    func readEntries(cookie: WASIAbi.DirCookie) throws -> AnyIterator<Result<ReaddirElement, any Error>> {
-        let children = dirNode.listChildren()
-
-        let fs = self.fileSystem
-        let basePath = self.path
-
-        let iterator = children.enumerated()
-            .dropFirst(Int(cookie))
-            .map { (index, name) -> Result<ReaddirElement, any Error> in
-                return Result(catching: {
-                    let childPath = MemoryFileSystem.joinGuestPath(basePath, name)
-                    guard let childNode = fs.lookup(at: childPath) else {
-                        throw WASIAbi.Errno.ENOENT
-                    }
-
-                    let fileType: WASIAbi.FileType
-                    switch childNode.type {
-                    case .directory: fileType = .DIRECTORY
-                    case .file: fileType = .REGULAR_FILE
-                    case .characterDevice: fileType = .CHARACTER_DEVICE
-                    }
-
-                    let dirent = WASIAbi.Dirent(
-                        dNext: WASIAbi.DirCookie(index + 1),
-                        dIno: 0,
-                        dirNameLen: WASIAbi.DirNameLen(name.utf8.count),
-                        dType: fileType
-                    )
-
-                    return (dirent, name)
-                })
-            }
-            .makeIterator()
-
-        return AnyIterator(iterator)
+    func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult {
+        ReadEntriesResult(
+            children: dirNode.listChildren(),
+            fileSystem: fileSystem,
+            basePath: path,
+            nextIndex: Int(cookie)
+        )
     }
 
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat {

--- a/Sources/WASI/Platform/Directory.swift
+++ b/Sources/WASI/Platform/Directory.swift
@@ -178,22 +178,56 @@ extension DirEntry: WASIDir, FdWASIEntry {
         #endif
     }
 
-    func readEntries(
-        cookie: WASIAbi.DirCookie
-    ) throws -> AnyIterator<Result<ReaddirElement, any Error>> {
-        #if os(Windows)
-            throw WASIAbi.Errno.ENOSYS
-        #else
-            // Duplicate fd because readdir takes the ownership of
-            // the given fd and closedir also close the underlying fd
-            let newFd = try WASIAbi.Errno.translatingPlatformErrno {
-                try fd.open(at: ".", .readOnly, options: [])
+    #if os(Windows)
+        struct ReadEntriesResult: WASIReaddirIterator {
+            init(fd: FileDescriptor, cookie: WASIAbi.DirCookie) throws {
+                throw WASIAbi.Errno.ENOSYS
             }
-            let iterator = try WASIAbi.Errno.translatingPlatformErrno {
-                try newFd.contentsOfDirectory()
+
+            mutating func next() -> Result<ReaddirElement, any Error>? {
+                return nil
             }
-            .lazy.enumerated()
-            .map { (entryIndex, entry) in
+
+            mutating func close() {}
+        }
+    #else
+        struct ReadEntriesResult: WASIReaddirIterator {
+            let fd: FileDescriptor
+            let stream: FileDescriptor.DirectoryStream
+            var entryIndex: Int
+
+            init(
+                fd: FileDescriptor,
+                cookie: WASIAbi.DirCookie
+            ) throws {
+                // Duplicate fd because readdir takes the ownership of
+                // the given fd and closedir also close the underlying fd
+                let newFd = try WASIAbi.Errno.translatingPlatformErrno {
+                    try fd.open(at: ".", .readOnly, options: [])
+                }
+                let stream: FileDescriptor.DirectoryStream
+                do {
+                    stream = try newFd.contentsOfDirectory()
+                } catch let errno as Errno {
+                    throw try WASIAbi.Errno(platformErrno: errno)
+                }
+
+                self.fd = fd
+                self.entryIndex = 0
+                self.stream = stream
+
+                let skippedCount = Int(cookie)
+                while entryIndex < skippedCount {
+                    guard let entry = next() else { break }
+                    _ = try entry.get()
+                }
+            }
+
+            mutating func next() -> Result<ReaddirElement, any Error>? {
+                guard let entry = stream.next() else {
+                    return nil
+                }
+                defer { entryIndex += 1 }
                 return Result(catching: { () -> ReaddirElement in
                     let entry = try entry.get()
                     let name = entry.name
@@ -212,10 +246,16 @@ extension DirEntry: WASIDir, FdWASIEntry {
                     return (dirent, name)
                 })
             }
-            .dropFirst(Int(cookie))
-            .makeIterator()
-            return AnyIterator(iterator)
-        #endif
+
+            mutating func close() {
+                stream.close()
+            }
+        }
+    #endif
+    func readEntries(
+        cookie: WASIAbi.DirCookie
+    ) throws -> ReadEntriesResult {
+        return try ReadEntriesResult(fd: fd, cookie: cookie)
     }
 
     func createDirectory(atPath path: String) throws {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1702,54 +1702,60 @@ final class WASIImplementation: Sendable {
         cookie: WASIAbi.DirCookie,
         memory: M
     ) throws -> WASIAbi.Size {
+        func readDirectoryEntries<D: WASIDir>(
+            from dirEntry: D
+        ) throws -> WASIAbi.Size {
+            var entries = try dirEntry.readEntries(cookie: cookie)
+            defer { entries.close() }
+            var bufferUsed: WASIAbi.Size = 0
+            let totalBufferSize = buffer.count
+            while let result = entries.next() {
+                var (entry, name) = try result.get()
+                do {
+                    // 1. Copy dirent to the buffer
+                    // Copy dirent as much as possible even though the buffer doesn't have enough remaining space
+                    let copyingBytes = min(WASIAbi.Dirent.sizeInGuest, totalBufferSize - bufferUsed)
+                    let rangeStart = buffer.baseAddress.raw.advanced(by: bufferUsed)
+                    let rangeEnd = rangeStart.advanced(by: copyingBytes)
+                    WASIAbi.Dirent.writeToGuest(unalignedAt: rangeStart, end: rangeEnd, in: memory, value: entry)
+                    bufferUsed += copyingBytes
+
+                    // bail out if the remaining buffer space is not enough
+                    if copyingBytes < WASIAbi.Dirent.sizeInGuest {
+                        return totalBufferSize
+                    }
+                }
+
+                do {
+                    // 2. Copy name string to the buffer
+                    // Same truncation rule applied as above
+                    let copyingBytes = min(entry.dirNameLen, totalBufferSize - bufferUsed)
+                    let rangeStart = buffer.baseAddress.raw.advanced(by: bufferUsed)
+                    name.withUTF8 { bytes in
+                        rangeStart.withHostPointer(in: memory, count: Int(copyingBytes)) { hostBuffer in
+                            hostBuffer.copyMemory(
+                                from: UnsafeRawBufferPointer(start: bytes.baseAddress, count: Int(copyingBytes))
+                            )
+                        }
+                    }
+                    bufferUsed += copyingBytes
+
+                    // bail out if the remaining buffer space is not enough
+                    if copyingBytes < entry.dirNameLen {
+                        return totalBufferSize
+                    }
+                }
+            }
+            return bufferUsed
+        }
+
         let dirEntry = try fdTable.withLock { table -> any WASIDir in
             guard case .directory(let dirEntry) = table[fd] else {
                 throw WASIAbi.Errno.EBADF
             }
             return dirEntry
         }
-
-        let entries = try dirEntry.readEntries(cookie: cookie)
-        var bufferUsed: WASIAbi.Size = 0
-        let totalBufferSize = buffer.count
-        while let result = entries.next() {
-            var (entry, name) = try result.get()
-            do {
-                // 1. Copy dirent to the buffer
-                // Copy dirent as much as possible even though the buffer doesn't have enough remaining space
-                let copyingBytes = min(WASIAbi.Dirent.sizeInGuest, totalBufferSize - bufferUsed)
-                let rangeStart = buffer.baseAddress.raw.advanced(by: bufferUsed)
-                let rangeEnd = rangeStart.advanced(by: copyingBytes)
-                WASIAbi.Dirent.writeToGuest(unalignedAt: rangeStart, end: rangeEnd, in: memory, value: entry)
-                bufferUsed += copyingBytes
-
-                // bail out if the remaining buffer space is not enough
-                if copyingBytes < WASIAbi.Dirent.sizeInGuest {
-                    return totalBufferSize
-                }
-            }
-
-            do {
-                // 2. Copy name string to the buffer
-                // Same truncation rule applied as above
-                let copyingBytes = min(entry.dirNameLen, totalBufferSize - bufferUsed)
-                let rangeStart = buffer.baseAddress.raw.advanced(by: bufferUsed)
-                name.withUTF8 { bytes in
-                    rangeStart.withHostPointer(in: memory, count: Int(copyingBytes)) { hostBuffer in
-                        hostBuffer.copyMemory(
-                            from: UnsafeRawBufferPointer(start: bytes.baseAddress, count: Int(copyingBytes))
-                        )
-                    }
-                }
-                bufferUsed += copyingBytes
-
-                // bail out if the remaining buffer space is not enough
-                if copyingBytes < entry.dirNameLen {
-                    return totalBufferSize
-                }
-            }
-        }
-        return bufferUsed
+        return try readDirectoryEntries(from: dirEntry)
     }
 
     /// Atomically replace a file descriptor by renumbering another file descriptor.

--- a/Tests/WASITests/WASITests.swift
+++ b/Tests/WASITests/WASITests.swift
@@ -1,8 +1,54 @@
+import Foundation
 import Testing
 import WasmKit
 import WasmTypes
 
 @testable import WASI
+
+#if os(macOS)
+    import Darwin
+#elseif os(Linux)
+    import Glibc
+#endif
+
+#if os(macOS) || os(Linux)
+    private func currentOpenFileDescriptorCount() throws -> Int {
+        #if os(macOS)
+            let fdDirectory = "/dev/fd"
+        #else
+            let fdDirectory = "/proc/self/fd"
+        #endif
+        return try FileManager.default.contentsOfDirectory(atPath: fdDirectory).count
+    }
+
+    private func withReducedOpenFileLimit<Result>(
+        extraDescriptors: Int,
+        _ body: () throws -> Result
+    ) throws -> Result {
+        #if os(macOS)
+            let nofileResource = RLIMIT_NOFILE
+        #else
+            let nofileResource = __rlimit_resource_t(RLIMIT_NOFILE.rawValue)
+        #endif
+        var original = rlimit()
+        guard getrlimit(nofileResource, &original) == 0 else {
+            throw TestSupport.Error(errno: errno)
+        }
+
+        let currentOpen = try currentOpenFileDescriptorCount()
+        let desiredSoft = rlim_t(currentOpen + extraDescriptors)
+        var reduced = original
+        reduced.rlim_cur = min(original.rlim_cur, desiredSoft)
+        guard setrlimit(nofileResource, &reduced) == 0 else {
+            throw TestSupport.Error(errno: errno)
+        }
+        defer {
+            var original = original
+            _ = setrlimit(nofileResource, &original)
+        }
+        return try body()
+    }
+#endif
 
 @Suite
 struct WASITests {
@@ -1615,6 +1661,42 @@ struct WASITests {
 
                     try wasi.path_create_directory(dirFd: dir1Fd, path: "foo/bar")
                     try wasi.path_remove_directory(dirFd: dir1Fd, path: "foo/bar")
+                }
+            }
+        }
+
+        // https://github.com/swiftwasm/WasmKit/issues/362
+        @Test
+        func fdReaddirDoesNotLeakFileDescriptors() throws {
+            let t = try TestSupport.TemporaryDirectory()
+            try t.createDir(at: "dir")
+            try t.createFile(at: "dir/a.txt", contents: "a")
+            try t.createFile(at: "dir/b.txt", contents: "b")
+
+            let bridge = try WASIBridgeToHost(
+                fileSystem: .host().withPreopens([
+                    .init(guestPath: "/dir", hostPath: t.url.appending(component: "dir").path)
+                ])
+            )
+            try bridge.runAndClose { _ in
+                let wasi = bridge.underlying
+                let dirFd: WASIAbi.Fd = 3
+                let memory = TestSupport.TestGuestMemory()
+                let buffer = UnsafeGuestBufferPointer<UInt8>(
+                    baseAddress: UnsafeGuestPointer<UInt8>(offset: 0),
+                    count: 4096
+                )
+
+                try withReducedOpenFileLimit(extraDescriptors: 32) {
+                    for _ in 0..<512 {
+                        let bytesRead = try wasi.fd_readdir(
+                            fd: dirFd,
+                            buffer: buffer,
+                            cookie: 0,
+                            memory: memory
+                        )
+                        #expect(bytesRead > 0)
+                    }
                 }
             }
         }


### PR DESCRIPTION
We didn't call `closedir` corresponding to the `fdopendir` call, which caused file descriptor leaks when `fd_readdir` was called.

Close https://github.com/swiftwasm/WasmKit/issues/362

<details>
<summary>Investigation notes</summary>

1. Reproduced the failure locally by lowering the per-process fd limit.
2. Let agent instrument WasmKit to trace:
   - WASI syscall entry/exit for `path_open` and `fd_close`
   - host-side open/close points
3. Ran the failing swift-syntax test with tracing enabled and compared open/close counts.
4. Observed that:
   - guest `path_open` and `fd_close` were balanced
   - repeated `fd_readdir` calls caused host-side duplicated directory handles
   - those handles were not being closed
5. Followed the trace to the `fdopendir` path and identified the missing `closedir` as the leak point.
</details>