### PR TITLE
Fuzzing: Guarantee that module instantiation will finish eventually

### DIFF
--- a/FuzzTesting/Sources/WasmKitFuzzing/WasmKitFuzzing.swift
+++ b/FuzzTesting/Sources/WasmKitFuzzing/WasmKitFuzzing.swift
@@ -18,7 +18,10 @@ public struct FuzzerResourceLimiter: ResourceLimiter {
 ///
 /// - Parameter bytes: The bytes of the Wasm module.
 public func fuzzInstantiation(bytes: [UInt8]) throws {
-    let module = try WasmKit.parseWasm(bytes: bytes)
+    var module = try WasmKit.parseWasm(bytes: bytes)
+    // To ensure that the module instantiation will stop eventually.
+    module.dropStartFunction()
+
     let engine = Engine(configuration: EngineConfiguration(compilationMode: .eager))
     let store = Store(engine: engine)
     store.resourceLimiter = FuzzerResourceLimiter()

--- a/Sources/WasmKit/Module.swift
+++ b/Sources/WasmKit/Module.swift
@@ -57,7 +57,7 @@ public struct Module {
     var functions: [GuestFunction]
     let elements: [ElementSegment]
     let data: [DataSegment]
-    let start: FunctionIndex?
+    private(set) var start: FunctionIndex?
     let globals: [WasmParser.Global]
     let tags: [WasmParser.Tag]
     public let imports: [Import]
@@ -140,6 +140,15 @@ public struct Module {
             )
         }
         return functions[Int(index) - self.moduleImports.numberOfFunctions].type
+    }
+
+    /// Drop the start section information from this module.
+    ///
+    /// This is useful to guarantee that "instantiation" of a module
+    /// will eventually halt.
+    @_spi(Fuzzing)
+    public mutating func dropStartFunction() {
+        self.start = nil
     }
 
     /// Instantiate this module in the given imports.


### PR DESCRIPTION
FuzzTranslator detected false positives in fuzzing due to a infinite-looping start function of a given Wasm module being executed during instantiation.

https://github.com/swiftwasm/WasmKit/actions/runs/27900404518/job/82559564897

```
==100== ERROR: libFuzzer: timeout after 27 seconds
    #0 0x55fd0d3e8eb8 in __sanitizer_print_stack_trace /home/build-user/llvm-project/compiler-rt/lib/asan/asan_stack.cpp:87:3
    #1 0x55fd0d42c258 in fuzzer::PrintStackTrace() /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
    #2 0x55fd0d412a37 in fuzzer::Fuzzer::AlarmCallback() /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:304:5
    #3 0x7fa57e2f332f  (/lib/x86_64-linux-gnu/libc.so.6+0x4532f) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #4 0x55fd0df45e48 in $sSv13loadUnaligned14fromByteOffset2asxSi_xmtlFxSryxGXEfU_ /<compiler-generated>
    #5 0x55fd0df2a61b in $sSv13loadUnaligned14fromByteOffset2asxSi_xmtlF /<compiler-generated>
    #6 0x55fd0df29ad9 in $s7WasmKit9ExecutionV10memoryLoad2sp2md2ms11loadOperand0I2As11castToValueySpys6UInt64VG_SvSgSiAA11InstructionO0eJ0VxmAA07UntypedN0VxXEtKs17FixedWidthIntegerRzlF /src/wasmkit/Sources/WasmKit/Execution/Instructions/Memory.swift:21:47
    #7 0x55fd0dce5aa1 in wasmkit_execute_i64Load32S /src/wasmkit/Sources/WasmKit/Execution/DispatchInstruction.swift:524:13
    #8 0x55fd0dce5aa1 in wasmkit_tc_i64Load32S /src/wasmkit/Sources/_CWasmKit/include/DirectThreadedCode.inc:209:24
    #9 0x55fd0df4d339 in wasmkit_tc_start /src/wasmkit/Sources/_CWasmKit/include/_CWasmKit.h:93:3
    #10 0x55fd0df4c998 in $s7WasmKit40wasmkit_direct_threaded_trap_guard_entryyySvSgXCvpfiyACcfU_ /src/wasmkit/Sources/WasmKit/Execution/MprotectTrapGuard.swift:28:9
    #11 0x55fd0df4cbe8 in $s7WasmKit40wasmkit_direct_threaded_trap_guard_entryyySvSgXCvpfiyACcfU_To /<compiler-generated>
    #12 0x55fd0dfce569 in wasmkit_trap_guard_run /src/wasmkit/Sources/_CWasmKit/TrapGuard.c:119:5
    #13 0x55fd0dd413fe in $s7WasmKit9ExecutionV17runDirectThreaded2sp2pc2md2msySpys6UInt64VG_AKSvSgSitKFySpyACGKXEfU_SbyXEfU_ /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:532:36
    #14 0x55fd0dd40b52 in $s7WasmKit9ExecutionV17runDirectThreaded2sp2pc2md2msySpys6UInt64VG_AKSvSgSitKFySpyACGKXEfU_ /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:522:45
    #15 0x55fd0dd44dd6 in $s7WasmKit9ExecutionV17runDirectThreaded2sp2pc2md2msySpys6UInt64VG_AKSvSgSitKFySpyACGKXEfU_TA /<compiler-generated>
    #16 0x55fd0d65ea70 in $ss24withUnsafeMutablePointer2to_q0_xz_q0_SpyxGq_YKXEtq_YKs5ErrorR_Ri_zRi_0_r1_lF /<compiler-generated>
    #17 0x55fd0dd3f451 in $s7WasmKit9ExecutionV17runDirectThreaded2sp2pc2md2msySpys6UInt64VG_AKSvSgSitKF /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:520:21
    #18 0x55fd0dd3badd in $s7WasmKit9ExecutionV7execute2sp2pc6handle4typeySpys6UInt64VG_AkA16InternalFunctionV0A5Types0K4TypeVtKF /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:495:21
    #19 0x55fd0dd3b2ff in $s7WasmKit07executeA05store8function4type9argumentsSay0A5Types5ValueOGAA5StoreC_AA16InternalFunctionVAG0L4TypeVAJtKFAjA9ExecutionVz_Spys6UInt64VGtKXEfU_ySryATGKXEfU_ /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:363:23
    #20 0x55fd0dd3ab81 in $s7WasmKit07executeA05store8function4type9argumentsSay0A5Types5ValueOGAA5StoreC_AA16InternalFunctionVAG0L4TypeVAJtKFAjA9ExecutionVz_Spys6UInt64VGtKXEfU_ /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:359:13
    #21 0x55fd0dd44c04 in $s7WasmKit07executeA05store8function4type9argumentsSay0A5Types5ValueOGAA5StoreC_AA16InternalFunctionVAG0L4TypeVAJtKFAjA9ExecutionVz_Spys6UInt64VGtKXEfU_TA /<compiler-generated>
    #22 0x55fd0dd1ea28 in $s7WasmKit9ExecutionV4with5store4bodyxAA8StoreRefV_xACz_Spys6UInt64VGtKXEtKlFZ /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:57:20
    #23 0x55fd0dd39db9 in $s7WasmKit07executeA05store8function4type9argumentsSay0A5Types5ValueOGAA5StoreC_AA16InternalFunctionVAG0L4TypeVAJtKF /src/wasmkit/Sources/WasmKit/Execution/Execution.swift:346:26
    #24 0x55fd0d6ab1ff in $s7WasmKit16InternalFunctionV6invoke_5storeSay0A5Types5ValueOGAI_AA5StoreCtKF /src/wasmkit/Sources/WasmKit/Execution/Function.swift:174:24
    #25 0x55fd0d74704f in $s7WasmKit6ModuleV17instantiateHandle33_9D7B6AF9E60BD2C9958AA3A316E12A98LL5store7imports12isDebuggableAA06EntityE0VyAA08InstanceT0VGAA5StoreC_AA7ImportsVSbtKF /src/wasmkit/Sources/WasmKit/Module.swift:258:35
    #26 0x55fd0d7451a0 in $s7WasmKit6ModuleV11instantiate5store7importsAA8InstanceVAA5StoreC_AA7ImportsVtKF /src/wasmkit/Sources/WasmKit/Module.swift:152:35
    #27 0x55fd0d4fe17b in $s14WasmKitFuzzing17fuzzInstantiation5bytesySays5UInt8VG_tKF /src/wasmkit/FuzzTesting/Sources/WasmKitFuzzing/WasmKitFuzzing.swift:57:20
    #28 0x55fd0d4f8f86 in $s14FuzzTranslator0A5Checkys5Int32VSPys5UInt8VG_SitF /src/wasmkit/FuzzTesting/Sources/FuzzTranslator/FuzzTranslator.swift:8:13
    #29 0x55fd0d4f8d40 in LLVMFuzzerTestOneInput /<compiler-generated>
    #30 0x55fd0d413ffb in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
    #31 0x55fd0d413615 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:516:7
    #32 0x55fd0d414f79 in fuzzer::Fuzzer::MutateAndTestOne() /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:765:19
    #33 0x55fd0d415a45 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:910:5
    #34 0x55fd0d402bb5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:917:6
    #35 0x55fd0d42cd82 in main /home/build-user/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #36 0x7fa57e2d81c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #37 0x7fa57e2d828a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #38 0x55fd0d3f7414 in _start (build-out/FuzzTranslator+0x445414) (BuildId: bfed40a1f758dc65695648aa240b4af8bc49b6a2)
```