### PR TITLE
WasmParser: Remove `consume(_ expected: Set<UInt8>)` from `ByteStream`

### DIFF
--- a/Sources/WasmParser/Stream/ByteStream.swift
+++ b/Sources/WasmParser/Stream/ByteStream.swift
@@ -2,17 +2,12 @@ public protocol ByteStream: ~Copyable {
     var currentIndex: Int { get }
 
     func consumeAny() throws(WasmParserError) -> UInt8
-    func consume(_ expected: Set<UInt8>) throws(WasmParserError) -> UInt8
     func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8>
 
     func peek() throws(WasmParserError) -> UInt8?
 }
 
 extension ByteStream {
-    func consume(_ expected: UInt8) throws(WasmParserError) -> UInt8 {
-        try consume(Set([expected]))
-    }
-
     @usableFromInline
     func hasReachedEnd() throws(WasmParserError) -> Bool {
         try peek() == nil
@@ -39,25 +34,6 @@ public final class StaticByteStream: ByteStream {
         }
 
         let consumed = bytes[currentIndex]
-        currentIndex = bytes.index(after: currentIndex)
-        return consumed
-    }
-
-    @discardableResult
-    public func consume(_ expected: Set<UInt8>) throws(WasmParserError) -> UInt8 {
-        guard bytes.indices.contains(currentIndex) else {
-            throw WasmParserError(kind: .parserUnexpectedEnd(expected: Set(expected)), offset: currentIndex)
-        }
-
-        let consumed = bytes[currentIndex]
-        guard expected.contains(consumed) else {
-            throw WasmParserError(
-                kind: .parserUnexpectedByte(
-                    consumed,
-                    expected: Set(expected)
-                ), offset: currentIndex)
-        }
-
         currentIndex = bytes.index(after: currentIndex)
         return consumed
     }

--- a/Sources/WasmParser/Stream/FileHandleStream.swift
+++ b/Sources/WasmParser/Stream/FileHandleStream.swift
@@ -40,22 +40,6 @@ public final class FileHandleStream: ByteStream {
         return consumed
     }
 
-    @discardableResult
-    public func consume(_ expected: Set<UInt8>) throws(WasmParserError) -> UInt8 {
-        guard let consumed = try peek() else {
-            throw WasmParserError(kind: .parserUnexpectedEnd(expected: Set(expected)), offset: currentIndex)
-        }
-        guard expected.contains(consumed) else {
-            throw WasmParserError(
-                kind: .parserUnexpectedByte(
-                    consumed,
-                    expected: Set(expected)
-                ), offset: currentIndex)
-        }
-        currentIndex = bytes.index(after: currentIndex)
-        return consumed
-    }
-
     public func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8> {
         let bytesToRead = currentIndex + count - endOffset
 

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -824,19 +824,19 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-importdesc>
     func parseImportDescriptor() throws(WasmParserError) -> ImportDescriptor {
-        let maxKind: UInt8 = features.contains(.exceptionHandling) ? 0x04 : 0x03
-        let b = try stream.consume(Set(0x00...maxKind))
+        let descriptorOffset = stream.currentIndex
+        let b = try stream.consumeAny()
         switch b {
         case 0x00: return try .function(parseUnsigned())
         case 0x01: return try .table(parseTableType())
         case 0x02: return try .memory(parseMemoryType())
         case 0x03: return try .global(parseGlobalType())
-        case 0x04:
+        case 0x04 where features.contains(.exceptionHandling):
             let attribute: UInt8 = try parseUnsigned()
             guard attribute == 0 else { throw makeError(.invalidTagAttribute(attribute)) }
             return try .tag(parseUnsigned())
         default:
-            preconditionFailure("should never reach here")
+            throw WasmParserError(kind: .parserUnexpectedByte(b, expected: nil), offset: descriptorOffset)
         }
     }
 
@@ -898,16 +898,16 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-exportdesc>
     func parseExportDescriptor() throws(WasmParserError) -> ExportDescriptor {
-        let maxKind: UInt8 = features.contains(.exceptionHandling) ? 0x04 : 0x03
-        let b = try stream.consume(Set(0x00...maxKind))
+        let descriptorOffset = stream.currentIndex
+        let b = try stream.consumeAny()
         switch b {
         case 0x00: return try .function(parseUnsigned())
         case 0x01: return try .table(parseUnsigned())
         case 0x02: return try .memory(parseUnsigned())
         case 0x03: return try .global(parseUnsigned())
-        case 0x04: return try .tag(parseUnsigned())
+        case 0x04 where features.contains(.exceptionHandling): return try .tag(parseUnsigned())
         default:
-            preconditionFailure("should never reach here")
+            throw WasmParserError(kind: .parserUnexpectedByte(b, expected: nil), offset: descriptorOffset)
         }
     }
 


### PR DESCRIPTION
We don't need `Set` allocation, and ByteStream should not be responsible for validation.