### PR TITLE
WasmParser: Stop taking `FilePath` in `detectWasmFileType`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -111,7 +111,6 @@ let package = Package(
         .target(
             name: "WasmParser",
             dependencies: [
-                "SystemExtras",
                 "WasmTypes",
                 .product(name: "SystemPackage", package: "swift-system"),
                 .target(

--- a/Sources/CLICommands/CMakeLists.txt
+++ b/Sources/CLICommands/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_wasmkit_library(CLICommands
     Explore.swift
+    Platform.swift
     Run.swift
     Wat2wasm.swift
 )

--- a/Sources/CLICommands/Platform.swift
+++ b/Sources/CLICommands/Platform.swift
@@ -1,0 +1,20 @@
+import struct SystemPackage.FileDescriptor
+
+#if os(Windows)
+    import ucrt
+#endif
+
+enum Platform {
+    #if os(Windows)
+        // TODO: Upstream `O_BINARY` to `SystemPackage
+        static let readOnlyBinaryAccessMode = FileDescriptor.AccessMode(
+            rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
+        )
+        static let readOnlyTextAccessMode = FileDescriptor.AccessMode(
+            rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_TEXT
+        )
+    #else
+        static let readOnlyBinaryAccessMode: FileDescriptor.AccessMode = .readOnly
+        static let readOnlyTextAccessMode: FileDescriptor.AccessMode = .readOnly
+    #endif
+}

--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -159,27 +159,70 @@ package struct Run: AsyncParsableCommand {
 
         log("Started parsing module", verbose: true)
 
-        // Detect file type (component vs module)
         let filePath = FilePath(path)
-        let fileType = try detectWasmFileType(filePath: filePath)
-
-        #if ComponentModel
-            if fileType == .component {
-                try runComponent(filePath: filePath)
-                return
-            }
-        #endif
-
-        // Regular module execution
         let module: Module
-        if verbose, #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
-            let (parsedModule, parseTime) = try measure {
-                try parseWasm(filePath: filePath)
+
+        if filePath.extension == "wat" {
+            let fileHandle: FileDescriptor = try FileDescriptor.open(filePath, Platform.readOnlyTextAccessMode)
+            module = try withThrowing {
+                let size = try fileHandle.seek(offset: 0, from: .end)
+                _ = try fileHandle.seek(offset: 0, from: .start)
+                let wat = try String(unsafeUninitializedCapacity: Int(size)) {
+                    try fileHandle.read(into: UnsafeMutableRawBufferPointer($0))
+                }
+                return try WasmKit.parseWasm(bytes: wat2wasm(wat))
+            } defer: {
+                try fileHandle.close()
             }
-            log("Finished parsing module: \(parseTime)", verbose: true)
-            module = parsedModule
         } else {
-            module = try parseWasm(filePath: filePath)
+            let fileHandle: FileDescriptor = try FileDescriptor.open(filePath, Platform.readOnlyBinaryAccessMode)
+            #if ComponentModel
+                var parsedComponent: ParsedComponent?
+            #endif
+            let parsedModule: Module? = try withThrowing { () throws -> Module? in
+                var magic: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (0, 0, 0, 0, 0, 0, 0, 0)
+                let bytesRead = try withUnsafeMutableBytes(of: &magic) { buffer in
+                    try fileHandle.read(into: buffer)
+                }
+
+                // Detect file type (component vs module)
+                let fileType: WasmFileType
+                if bytesRead == MemoryLayout.size(ofValue: magic) {
+                    fileType = detectWasmFileType(magic)
+                } else {
+                    fileType = .unknown
+                }
+
+                #if ComponentModel
+                    if fileType == .component {
+                        log("Detected component binary, parsing component...", verbose: true)
+                        _ = try fileHandle.seek(offset: 0, from: .start)
+                        parsedComponent = try parseComponent(fileHandle: fileHandle)
+                        return nil
+                    }
+                #endif
+
+                guard fileType == .coreModule else {
+                    fatalError("Unsupported WebAssembly file type: \(fileType)")
+                }
+
+                _ = try fileHandle.seek(offset: 0, from: .start)
+                let (parsedModule, parseTime) = try measure {
+                    try WasmKit.parseWasm(fileHandle: fileHandle)
+                }
+                log("Finished parsing module: \(parseTime)", verbose: true)
+                return parsedModule
+            } defer: {
+                try fileHandle.close()
+            }
+            #if ComponentModel
+                if let parsedComponent {
+                    try runComponent(component: parsedComponent)
+                    return
+                }
+            #endif
+            guard let parsedModule else { return }
+            module = parsedModule
         }
 
         let (interceptor, finalize) = try deriveInterceptor()
@@ -205,11 +248,7 @@ package struct Run: AsyncParsableCommand {
 
     #if ComponentModel
         /// Run a WebAssembly component.
-        func runComponent(filePath: FilePath) throws {
-            log("Detected component binary, parsing component...", verbose: true)
-
-            let component = try parseComponent(filePath: filePath)
-
+        func runComponent(component: ParsedComponent) throws {
             let engine = Engine(configuration: deriveRuntimeConfiguration())
             let store = Store(engine: engine)
             let loader = ComponentLoader(store: store)
@@ -347,25 +386,6 @@ package struct Run: AsyncParsableCommand {
         if !verbose || self.verbose {
             try! FileDescriptor.standardError.writeAll((message + "\n").utf8)
         }
-    }
-}
-
-/// Parses a `.wasm` or `.wat` module.
-func parseWasm(filePath: FilePath) throws -> Module {
-    if filePath.extension == "wat", #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, visionOS 1.0, watchOS 7.0, *) {
-        let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-        return try withThrowing {
-            let size = try fileHandle.seek(offset: 0, from: .end)
-
-            let wat = try String(unsafeUninitializedCapacity: Int(size)) {
-                try fileHandle.read(fromAbsoluteOffset: 0, into: .init($0))
-            }
-            return try WasmKit.parseWasm(bytes: wat2wasm(wat))
-        } defer: {
-            try fileHandle.close()
-        }
-    } else {
-        return try WasmKit.parseWasm(filePath: filePath)
     }
 }
 

--- a/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
+++ b/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
@@ -1,31 +1,20 @@
 #if ComponentModel
     import ComponentModel
-    import SystemExtras
     import SystemPackage
     import WasmParser
 
     // MARK: - Component Parsing
 
-    /// Parse a component binary file into a `ParsedComponent` ready for instantiation.
+    /// Parse a component binary file from a caller-owned file descriptor.
     ///
-    /// This function reads the component from a file using streaming I/O for efficiency.
-    ///
-    /// - Parameters:
-    ///   - filePath: Path to the WebAssembly component binary file
-    ///   - features: Enabled WebAssembly features for parsing
-    /// - Returns: A `ParsedComponent` ready for instantiation
-    /// - Throws: `WasmKitError` if parsing fails, `ComponentParseError` for semantic errors
+    /// The descriptor is consumed from its current offset and is not closed by
+    /// this function.
     public func parseComponent(
-        filePath: FilePath,
+        fileHandle: FileDescriptor,
         features: WasmFeatureSet = .default
     ) throws -> ParsedComponent {
-        let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-        return try withThrowing {
-            let stream = try FileHandleStream(fileHandle: fileHandle)
-            return try parseComponent(stream: stream, features: features)
-        } defer: {
-            try fileHandle.close()
-        }
+        let stream = try FileHandleStream(fileHandle: fileHandle)
+        return try parseComponent(stream: stream, features: features)
     }
 
     /// Parse a component binary into a `ParsedComponent` ready for instantiation.

--- a/Sources/WasmKit/ModuleParser.swift
+++ b/Sources/WasmKit/ModuleParser.swift
@@ -19,12 +19,20 @@ public func parseWasm(filePath: FilePath, features: WasmFeatureSet = .default) t
     #endif
     let fileHandle = try FileDescriptor.open(filePath, accessMode)
     return try withThrowing {
-        let stream = try FileHandleStream(fileHandle: fileHandle)
-        let module = try parseModule(stream: stream, features: features)
-        return module
+        try parseWasm(fileHandle: fileHandle, features: features)
     } defer: {
         try fileHandle.close()
     }
+}
+
+/// Parse a WebAssembly binary file from a caller-owned file descriptor.
+///
+/// The descriptor is consumed from its current offset and is not closed by
+/// this function.
+public func parseWasm(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws -> Module {
+    let stream = try FileHandleStream(fileHandle: fileHandle)
+    let module = try parseModule(stream: stream, features: features)
+    return module
 }
 
 /// Parse a given byte array as a WebAssembly binary format file

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -1,4 +1,3 @@
-import SystemExtras
 import WasmTypes
 
 import struct SystemPackage.FileDescriptor
@@ -1333,50 +1332,31 @@ public enum WasmFileType: Equatable, Sendable {
     case unknown
 }
 
-/// Detect the type of a WebAssembly binary file by reading its header.
+/// Detect the type of a WebAssembly binary file from its header.
 ///
-/// This function reads the 8-byte WebAssembly header to determine whether
-/// the file contains a core module or a component. Uses stack allocation
-/// only (no heap allocation for the header bytes).
+/// This function classifies the 8-byte WebAssembly header to determine
+/// whether it identifies a core module or a component.
 ///
-/// - Parameter filePath: Path to the WebAssembly binary file
+/// - Parameter header: The first 8 bytes of the WebAssembly binary file.
 /// - Returns: The detected file type
-/// - Throws: If the file cannot be opened or read
-public func detectWasmFileType(filePath: FilePath) throws -> WasmFileType {
-    let fileHandle = try FileDescriptor.open(filePath, .readOnly)
-    return try withThrowing {
-        // Use a tuple to avoid heap allocation - 8 bytes on stack
-        // TODO: needs a `SmallArray` abstraction until `InlineArray` becomes available after dropping support for macOS 15.
-        var header: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (0, 0, 0, 0, 0, 0, 0, 0)
-        let bytesRead = try withUnsafeMutableBytes(of: &header) { buffer in
-            try fileHandle.read(into: buffer)
-        }
+public func detectWasmFileType(_ header: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> WasmFileType {
+    // Check magic number: \0asm (uses WASM_MAGIC as source of truth)
+    guard
+        header.0 == WASM_MAGIC[0] && header.1 == WASM_MAGIC[1]
+            && header.2 == WASM_MAGIC[2] && header.3 == WASM_MAGIC[3]
+    else {
+        return .unknown
+    }
 
-        // Need at least 8 bytes for a valid header
-        guard bytesRead >= 8 else {
-            return .unknown
-        }
-
-        // Check magic number: \0asm (uses WASM_MAGIC as source of truth)
-        guard
-            header.0 == WASM_MAGIC[0] && header.1 == WASM_MAGIC[1]
-                && header.2 == WASM_MAGIC[2] && header.3 == WASM_MAGIC[3]
-        else {
-            return .unknown
-        }
-
-        // Check version and layer bytes:
-        // - Core module: version=0x01, 0x00 and layer=0x00, 0x00
-        // - Component:   version=0x0d, 0x00 and layer=0x01, 0x00
-        switch (header.4, header.5, header.6, header.7) {
-        case (0x01, 0x00, 0x00, 0x00):
-            return .coreModule
-        case (0x0d, 0x00, 0x01, 0x00):
-            return .component
-        default:
-            return .unknown
-        }
-    } defer: {
-        try fileHandle.close()
+    // Check version and layer bytes:
+    // - Core module: version=0x01, 0x00 and layer=0x00, 0x00
+    // - Component:   version=0x0d, 0x00 and layer=0x01, 0x00
+    switch (header.4, header.5, header.6, header.7) {
+    case (0x01, 0x00, 0x00, 0x00):
+        return .coreModule
+    case (0x0d, 0x00, 0x01, 0x00):
+        return .component
+    default:
+        return .unknown
     }
 }

--- a/Tests/WasmParserTests/WasmFileTypeTests.swift
+++ b/Tests/WasmParserTests/WasmFileTypeTests.swift
@@ -1,0 +1,37 @@
+import Testing
+
+@testable import WasmParser
+
+@Suite struct WasmFileTypeTests {
+    @Test func detectsCoreModuleHeader() {
+        let header: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
+            0x00, 0x61, 0x73, 0x6d,
+            0x01, 0x00, 0x00, 0x00
+        )
+
+        #expect(detectWasmFileType(header) == .coreModule)
+    }
+
+    @Test func detectsComponentHeader() {
+        let header: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
+            0x00, 0x61, 0x73, 0x6d,
+            0x0d, 0x00, 0x01, 0x00
+        )
+
+        #expect(detectWasmFileType(header) == .component)
+    }
+
+    @Test func rejectsUnknownHeaders() {
+        let invalidMagic: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
+            0x00, 0x61, 0x73, 0x78,
+            0x01, 0x00, 0x00, 0x00
+        )
+        let invalidVersion: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
+            0x00, 0x61, 0x73, 0x6d,
+            0x02, 0x00, 0x00, 0x00
+        )
+
+        #expect(detectWasmFileType(invalidMagic) == .unknown)
+        #expect(detectWasmFileType(invalidVersion) == .unknown)
+    }
+}


### PR DESCRIPTION
The caller usually uses a `FileDescriptor` to parse the file after detecting the file type, so opening fd inside the detection function is wasteful. We can instead move the fd opening to the caller. Also this reduces system dependencies in the `WasmParser` module.