### PR TITLE
WasmParser: Add `FileSystem` trait to allow omitting file system helpers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           ./Vendor/checkout-dependency --category component-model
 
           swift --version
-          swift test --sanitize address --traits ComponentModel,WasmDebuggingSupport ${{ matrix.test-args }}
+          swift test --sanitize address --traits FileSystem,ComponentModel,WasmDebuggingSupport ${{ matrix.test-args }}
           swift build --package-path Benchmarks
 
   build-macos:
@@ -71,7 +71,7 @@ jobs:
           # Swift 6.3.2
           - os: macos-26
             xcode: Xcode_26.5
-            test-args: "--sanitize address --traits ComponentModel,WasmDebuggingSupport"
+            test-args: "--sanitize address --traits FileSystem,ComponentModel,WasmDebuggingSupport"
 
     runs-on: ${{ matrix.os }}
     name: "build-macos (${{ matrix.xcode }})"
@@ -132,15 +132,15 @@ jobs:
       matrix:
         include:
           - swift: "swift:6.3-noble"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport --enable-code-coverage"
+            test-args: "--traits FileSystem,ComponentModel,WasmDebuggingSupport --enable-code-coverage"
             build-benchmarks: true
             run-benchmarks: true
             build-dev-dashboard: true
           - swift: "swiftlang/swift:nightly-6.4.x-noble"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport"
+            test-args: "--traits FileSystem,ComponentModel,WasmDebuggingSupport"
             build-benchmarks: true
           - swift: "swiftlang/swift:nightly-main-noble"
-            test-args: "--traits ComponentModel,WasmDebuggingSupport"
+            test-args: "--traits FileSystem,ComponentModel,WasmDebuggingSupport"
             build-benchmarks: true
 
     runs-on: ubuntu-24.04
@@ -234,9 +234,9 @@ jobs:
         run: ./build-exec swift sdk install "${{ matrix.musl-swift-sdk-download }}" --checksum "${{ matrix.musl-swift-sdk-checksum }}"
 
       - name: Build (x86_64-swift-linux-musl)
-        run: ./build-exec swift build --swift-sdk x86_64-swift-linux-musl --traits ComponentModel,WasmDebuggingSupport --explicit-target-dependency-import-check error
+        run: ./build-exec swift build --swift-sdk x86_64-swift-linux-musl --traits FileSystem,ComponentModel,WasmDebuggingSupport --explicit-target-dependency-import-check error
       - name: Build (aarch64-swift-linux-musl)
-        run: ./build-exec swift build --swift-sdk aarch64-swift-linux-musl --traits ComponentModel,WasmDebuggingSupport --explicit-target-dependency-import-check error
+        run: ./build-exec swift build --swift-sdk aarch64-swift-linux-musl --traits FileSystem,ComponentModel,WasmDebuggingSupport --explicit-target-dependency-import-check error
 
   build-android:
     runs-on: ubuntu-24.04
@@ -297,4 +297,4 @@ jobs:
       - name: Install Swift SDK
         run: swift sdk install https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz --checksum a61f0584c93283589f8b2f42db05c1f9a182b506c2957271402992655591dd7c
       - name: Build with the Swift SDK
-        run: swift build --swift-sdk "$(swiftc -print-target-info | jq -r '.swiftCompilerTag')_wasm" --traits ComponentModel --explicit-target-dependency-import-check error --product wasmkit-cli
+        run: swift build --swift-sdk "$(swiftc -print-target-info | jq -r '.swiftCompilerTag')_wasm" --traits FileSystem,ComponentModel --explicit-target-dependency-import-check error --product wasmkit-cli

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ add_compile_definitions(
 include(FetchContent)
 
 option(WASMKIT_BUILD_CLI "Build wasmkit-cli" ON)
+option(WASMKIT_ENABLE_FILESYSTEM "Enable FileSystem support" ON)
 
 if(WASMKIT_BUILD_CLI)
   set(BUILD_TESTING OFF) # disable ArgumentParser tests

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,8 @@ let package = Package(
         .library(name: "_CabiShims", targets: ["_CabiShims"]),
     ],
     traits: [
-        .default(enabledTraits: []),
+        .default(enabledTraits: ["FileSystem"]),
+        "FileSystem",
         "ComponentModel",
         "WasmDebuggingSupport",
     ],
@@ -112,7 +113,10 @@ let package = Package(
             name: "WasmParser",
             dependencies: [
                 "WasmTypes",
-                .product(name: "SystemPackage", package: "swift-system"),
+                .product(
+                    name: "SystemPackage", package: "swift-system",
+                    condition: .when(traits: ["FileSystem"])
+                ),
                 .target(
                     name: "ComponentModel",
                     condition: .when(traits: ["ComponentModel"])

--- a/Sources/WasmKit/CMakeLists.txt
+++ b/Sources/WasmKit/CMakeLists.txt
@@ -3,6 +3,7 @@ add_wasmkit_library(WasmKit
   Imports.swift
   Module.swift
   ModuleParser.swift
+  ModuleParser+FileSystem.swift
   SIMDOpcode.swift
   Translator.swift
   Validator.swift
@@ -46,6 +47,11 @@ add_wasmkit_library(WasmKit
   Execution/Value.swift
   Execution/V128Storage.swift
 )
+
+if(WASMKIT_ENABLE_FILESYSTEM)
+  target_compile_options(WasmKit PRIVATE
+    $<$<COMPILE_LANGUAGE:Swift>:-D;FileSystem>)
+endif()
 
 target_link_wasmkit_libraries(WasmKit PUBLIC
   _CWasmKit WasmParser SystemExtras WasmTypes SystemPackage)

--- a/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
+++ b/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
@@ -1,21 +1,8 @@
 #if ComponentModel
     import ComponentModel
-    import SystemPackage
     import WasmParser
 
     // MARK: - Component Parsing
-
-    /// Parse a component binary file from a caller-owned file descriptor.
-    ///
-    /// The descriptor is consumed from its current offset and is not closed by
-    /// this function.
-    public func parseComponent(
-        fileHandle: FileDescriptor,
-        features: WasmFeatureSet = .default
-    ) throws -> ParsedComponent {
-        let stream = try FileHandleStream(fileHandle: fileHandle)
-        return try parseComponent(stream: stream, features: features)
-    }
 
     /// Parse a component binary into a `ParsedComponent` ready for instantiation.
     ///
@@ -608,4 +595,20 @@
         let options: [CanonicalOption]
     }
 
+#endif
+
+#if ComponentModel && FileSystem
+    import struct SystemPackage.FileDescriptor
+
+    /// Parse a component binary file from a caller-owned file descriptor.
+    ///
+    /// The descriptor is consumed from its current offset and is not closed by
+    /// this function.
+    public func parseComponent(
+        fileHandle: FileDescriptor,
+        features: WasmFeatureSet = .default
+    ) throws -> ParsedComponent {
+        let stream = try FileHandleStream(fileHandle: fileHandle)
+        return try parseComponent(stream: stream, features: features)
+    }
 #endif

--- a/Sources/WasmKit/ModuleParser+FileSystem.swift
+++ b/Sources/WasmKit/ModuleParser+FileSystem.swift
@@ -1,0 +1,38 @@
+#if FileSystem
+    import WasmParser
+    import SystemExtras
+    import SystemPackage
+
+    #if os(Windows)
+        import ucrt
+    #endif
+
+    /// Parse a given file as a WebAssembly binary format file
+    /// > Note: <https://webassembly.github.io/spec/core/binary/index.html>
+    public func parseWasm(filePath: FilePath, features: WasmFeatureSet = .default) throws -> Module {
+        #if os(Windows)
+            // TODO: Upstream `O_BINARY` to `SystemPackage
+            let accessMode = FileDescriptor.AccessMode(
+                rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
+            )
+        #else
+            let accessMode: FileDescriptor.AccessMode = .readOnly
+        #endif
+        let fileHandle = try FileDescriptor.open(filePath, accessMode)
+        return try withThrowing {
+            try parseWasm(fileHandle: fileHandle, features: features)
+        } defer: {
+            try fileHandle.close()
+        }
+    }
+
+    /// Parse a WebAssembly binary file from a caller-owned file descriptor.
+    ///
+    /// The descriptor is consumed from its current offset and is not closed by
+    /// this function.
+    public func parseWasm(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws -> Module {
+        let stream = try FileHandleStream(fileHandle: fileHandle)
+        let module = try parseModule(stream: stream, features: features)
+        return module
+    }
+#endif

--- a/Sources/WasmKit/ModuleParser.swift
+++ b/Sources/WasmKit/ModuleParser.swift
@@ -1,39 +1,4 @@
-import SystemExtras
-import SystemPackage
 import WasmParser
-
-#if os(Windows)
-    import ucrt
-#endif
-
-/// Parse a given file as a WebAssembly binary format file
-/// > Note: <https://webassembly.github.io/spec/core/binary/index.html>
-public func parseWasm(filePath: FilePath, features: WasmFeatureSet = .default) throws -> Module {
-    #if os(Windows)
-        // TODO: Upstream `O_BINARY` to `SystemPackage
-        let accessMode = FileDescriptor.AccessMode(
-            rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
-        )
-    #else
-        let accessMode: FileDescriptor.AccessMode = .readOnly
-    #endif
-    let fileHandle = try FileDescriptor.open(filePath, accessMode)
-    return try withThrowing {
-        try parseWasm(fileHandle: fileHandle, features: features)
-    } defer: {
-        try fileHandle.close()
-    }
-}
-
-/// Parse a WebAssembly binary file from a caller-owned file descriptor.
-///
-/// The descriptor is consumed from its current offset and is not closed by
-/// this function.
-public func parseWasm(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws -> Module {
-    let stream = try FileHandleStream(fileHandle: fileHandle)
-    let module = try parseModule(stream: stream, features: features)
-    return module
-}
 
 /// Parse a given byte array as a WebAssembly binary format file
 /// > Note: <https://webassembly.github.io/spec/core/binary/index.html>

--- a/Sources/WasmParser/CMakeLists.txt
+++ b/Sources/WasmParser/CMakeLists.txt
@@ -11,4 +11,12 @@ add_wasmkit_library(WasmParser
 )
 
 target_link_wasmkit_libraries(WasmParser PUBLIC
-  SystemExtras WasmTypes SystemPackage)
+  WasmTypes)
+
+if(WASMKIT_ENABLE_FILESYSTEM)
+  target_compile_options(WasmParser PRIVATE
+    $<$<COMPILE_LANGUAGE:Swift>:-D;FileSystem>)
+  target_link_wasmkit_libraries(WasmParser PUBLIC
+    SystemPackage)
+endif()
+

--- a/Sources/WasmParser/Stream/FileHandleStream.swift
+++ b/Sources/WasmParser/Stream/FileHandleStream.swift
@@ -1,92 +1,132 @@
-import struct SystemPackage.FileDescriptor
+// "FileSystem" trait can be turned off to support embedded platforms
+#if FileSystem
 
-public final class FileHandleStream: ByteStream {
-    private(set) public var currentIndex: Int = 0
+    import struct SystemPackage.FileDescriptor
+    import struct SystemPackage.FilePath
 
-    private let fileHandle: FileDescriptor
-    private let bufferLength: Int
+    #if os(Windows)
+        import ucrt
+    #endif
 
-    private var endOffset: Int = 0
-    private var startOffset: Int = 0
-    private var bytes: [UInt8] = []
+    extension Parser where Stream == FileHandleStream {
 
-    public init(fileHandle: FileDescriptor, bufferLength: Int = 1024 * 8) throws {
-        self.fileHandle = fileHandle
-        self.bufferLength = bufferLength
-
-        try readMoreIfNeeded()
-    }
-
-    private func readMoreIfNeeded() throws(WasmParserError) {
-        guard Int(endOffset) == currentIndex else { return }
-        startOffset = currentIndex
-
-        do {
-            let data = try fileHandle.read(upToCount: bufferLength)
-
-            bytes = [UInt8](data)
-        } catch {
-            throw WasmParserError("I/O error: \(error)", offset: currentIndex)
+        /// Initialize a new parser with the given file handle
+        ///
+        /// - Parameters:
+        ///   - fileHandle: The file handle to the WebAssembly binary file to parse
+        ///   - features: Enabled WebAssembly features for parsing
+        public init(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws {
+            self.init(stream: try FileHandleStream(fileHandle: fileHandle), features: features)
         }
-        endOffset = startOffset + bytes.count
-    }
 
-    @discardableResult
-    public func consumeAny() throws(WasmParserError) -> UInt8 {
-        guard let consumed = try peek() else {
-            throw WasmParserError(message: .unexpectedEnd, offset: currentIndex)
+        /// Initialize a new parser with the given file path
+        ///
+        /// - Parameters:
+        ///   - filePath: The file path to the WebAssembly binary file to parse
+        ///   - features: Enabled WebAssembly features for parsing
+        public init(filePath: FilePath, features: WasmFeatureSet = .default) throws {
+            #if os(Windows)
+                // TODO: Upstream `O_BINARY` to `SystemPackage
+                let accessMode = FileDescriptor.AccessMode(
+                    rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
+                )
+            #else
+                let accessMode: FileDescriptor.AccessMode = .readOnly
+            #endif
+            let fileHandle = try FileDescriptor.open(filePath, accessMode)
+            self.init(stream: try FileHandleStream(fileHandle: fileHandle), features: features)
         }
-        currentIndex = bytes.index(after: currentIndex)
-        return consumed
     }
 
-    public func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8> {
-        let bytesToRead = currentIndex + count - endOffset
+    public final class FileHandleStream: ByteStream {
+        private(set) public var currentIndex: Int = 0
 
-        guard bytesToRead > 0 else {
+        private let fileHandle: FileDescriptor
+        private let bufferLength: Int
+
+        private var endOffset: Int = 0
+        private var startOffset: Int = 0
+        private var bytes: [UInt8] = []
+
+        public init(fileHandle: FileDescriptor, bufferLength: Int = 1024 * 8) throws {
+            self.fileHandle = fileHandle
+            self.bufferLength = bufferLength
+
+            try readMoreIfNeeded()
+        }
+
+        private func readMoreIfNeeded() throws(WasmParserError) {
+            guard Int(endOffset) == currentIndex else { return }
+            startOffset = currentIndex
+
+            do {
+                let data = try fileHandle.read(upToCount: bufferLength)
+
+                bytes = [UInt8](data)
+            } catch {
+                throw WasmParserError("I/O error: \(error)", offset: currentIndex)
+            }
+            endOffset = startOffset + bytes.count
+        }
+
+        @discardableResult
+        public func consumeAny() throws(WasmParserError) -> UInt8 {
+            guard let consumed = try peek() else {
+                throw WasmParserError(message: .unexpectedEnd, offset: currentIndex)
+            }
+            currentIndex = bytes.index(after: currentIndex)
+            return consumed
+        }
+
+        public func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8> {
+            let bytesToRead = currentIndex + count - endOffset
+
+            guard bytesToRead > 0 else {
+                let bytesIndex = currentIndex - startOffset
+                let result = bytes[bytesIndex..<bytesIndex + count]
+                currentIndex = currentIndex + count
+                return result
+            }
+
+            let data: [UInt8]
+            do {
+                data = try fileHandle.read(upToCount: bytesToRead)
+            } catch {
+                throw WasmParserError("I/O error: \(error)", offset: currentIndex)
+            }
+            guard data.count == bytesToRead else {
+                throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: currentIndex)
+            }
+
+            bytes.append(contentsOf: [UInt8](data))
+            endOffset = endOffset + data.count
+
             let bytesIndex = currentIndex - startOffset
             let result = bytes[bytesIndex..<bytesIndex + count]
-            currentIndex = currentIndex + count
+
+            currentIndex = endOffset
+
             return result
         }
 
-        let data: [UInt8]
-        do {
-            data = try fileHandle.read(upToCount: bytesToRead)
-        } catch {
-            throw WasmParserError("I/O error: \(error)", offset: currentIndex)
-        }
-        guard data.count == bytesToRead else {
-            throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: currentIndex)
-        }
+        public func peek() throws(WasmParserError) -> UInt8? {
+            try readMoreIfNeeded()
 
-        bytes.append(contentsOf: [UInt8](data))
-        endOffset = endOffset + data.count
+            let index = currentIndex - startOffset
+            guard bytes.indices.contains(index) else {
+                return nil
+            }
 
-        let bytesIndex = currentIndex - startOffset
-        let result = bytes[bytesIndex..<bytesIndex + count]
-
-        currentIndex = endOffset
-
-        return result
-    }
-
-    public func peek() throws(WasmParserError) -> UInt8? {
-        try readMoreIfNeeded()
-
-        let index = currentIndex - startOffset
-        guard bytes.indices.contains(index) else {
-            return nil
-        }
-
-        return bytes[index]
-    }
-}
-
-extension FileDescriptor {
-    fileprivate func read(upToCount maxLength: Int) throws -> [UInt8] {
-        try [UInt8](unsafeUninitializedCapacity: maxLength) { buffer, outCount in
-            outCount = try read(into: UnsafeMutableRawBufferPointer(buffer))
+            return bytes[index]
         }
     }
-}
+
+    extension FileDescriptor {
+        fileprivate func read(upToCount maxLength: Int) throws -> [UInt8] {
+            try [UInt8](unsafeUninitializedCapacity: maxLength) { buffer, outCount in
+                outCount = try read(into: UnsafeMutableRawBufferPointer(buffer))
+            }
+        }
+    }
+
+#endif

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -1,12 +1,5 @@
 import WasmTypes
 
-import struct SystemPackage.FileDescriptor
-import struct SystemPackage.FilePath
-
-#if os(Windows)
-    import ucrt
-#endif
-
 /// A streaming parser for WebAssembly binary format.
 ///
 /// The parser is designed to be used to incrementally parse a WebAssembly binary bytestream.
@@ -51,36 +44,6 @@ extension Parser where Stream == StaticByteStream {
     ///   - features: Enabled WebAssembly features for parsing
     public init(bytes: [UInt8], features: WasmFeatureSet = .default) {
         self.init(stream: StaticByteStream(bytes: bytes), features: features)
-    }
-}
-
-extension Parser where Stream == FileHandleStream {
-
-    /// Initialize a new parser with the given file handle
-    ///
-    /// - Parameters:
-    ///   - fileHandle: The file handle to the WebAssembly binary file to parse
-    ///   - features: Enabled WebAssembly features for parsing
-    public init(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws {
-        self.init(stream: try FileHandleStream(fileHandle: fileHandle), features: features)
-    }
-
-    /// Initialize a new parser with the given file path
-    ///
-    /// - Parameters:
-    ///   - filePath: The file path to the WebAssembly binary file to parse
-    ///   - features: Enabled WebAssembly features for parsing
-    public init(filePath: FilePath, features: WasmFeatureSet = .default) throws {
-        #if os(Windows)
-            // TODO: Upstream `O_BINARY` to `SystemPackage
-            let accessMode = FileDescriptor.AccessMode(
-                rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
-            )
-        #else
-            let accessMode: FileDescriptor.AccessMode = .readOnly
-        #endif
-        let fileHandle = try FileDescriptor.open(filePath, accessMode)
-        self.init(stream: try FileHandleStream(fileHandle: fileHandle), features: features)
     }
 }
 


### PR DESCRIPTION
Extracted from https://github.com/swiftwasm/WasmKit/pull/357