### PR TITLE
Bump Amazon Linux version to 2023 in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ targets: [
 
 ## Supported Platforms
 
-WasmKit engine works on all major platforms supported by Swift. It is continuously tested on macOS, Ubuntu, Amazon Linux 2, Android, and Windows,
+WasmKit engine works on all major platforms supported by Swift. It is continuously tested on macOS, Ubuntu, Amazon Linux 2023, Android, and Windows,
 and should work on the following platforms:
 
 - macOS 10.13+, iOS 12.0+, tvOS 12.0+, watchOS 6.0+


### PR DESCRIPTION
Amazon Linux 2 is no longer supported by Swift 6.4 and later: https://forums.swift.org/t/dropping-support-for-amazon-linux-2/87920