### PR TITLE
Upgrade `swift-system` dependency version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(NOT SwiftSystem_FOUND)
   message("-- Vending SwiftSystem")
   FetchContent_Declare(SwiftSystem
     GIT_REPOSITORY https://github.com/apple/swift-system
-    GIT_TAG 1.5.0
+    GIT_TAG 1.7.2
   )
   FetchContent_MakeAvailable(SwiftSystem)
 endif()

--- a/Package.swift
+++ b/Package.swift
@@ -287,11 +287,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.1"),
-        // Upper-bounded: swift-system 1.7.0 moved the `stat` members into `CSystem`,
-        // which breaks swift-nio's `_NIOFileSystem` (a test/benchmark dependency) on
-        // Linux/Swift 6.2 under `MemberImportVisibility`. Drop the bound once swift-nio
-        // builds against swift-system 1.7.0.
-        .package(url: "https://github.com/apple/swift-system", "1.5.0"..<"1.7.0"),
+        .package(url: "https://github.com/apple/swift-system", from: "1.7.2"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.90.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.7.1"),
     ]


### PR DESCRIPTION
`swift-system` was capped below 1.7.0 because 1.7.0 and 1.7.1 broke the `_NIOFileSystem` target in `swift-nio` on Linux under `MemberImportVisibility`. `swift-system` 1.7.2 fixed that regression.