### PR TITLE
Move byte-stream offset control out of the I/O sources

### DIFF
--- a/Sources/WasmKit/Execution/NameRegistry.swift
+++ b/Sources/WasmKit/Execution/NameRegistry.swift
@@ -1,7 +1,7 @@
 import struct WasmParser.CustomSection
 import struct WasmParser.NameMap
 import struct WasmParser.NameSectionParser
-import class WasmParser.StaticByteStream
+import class WasmParser.StaticByteStreamSource
 
 struct NameRegistry {
     private var functionNames: [InternalFunction: String] = [:]
@@ -11,8 +11,8 @@ struct NameRegistry {
 
     mutating func register(instance: InternalInstance, nameSection: CustomSection) throws {
         materializers.append { registry in
-            let stream = StaticByteStream(bytes: Array(nameSection.bytes))
-            let parser = NameSectionParser(stream: stream)
+            let stream = StaticByteStreamSource(bytes: Array(nameSection.bytes))
+            var parser = NameSectionParser(stream: stream)
             for result in try parser.parseAll() {
                 switch result {
                 case .functions(let nameMap):

--- a/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
+++ b/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
@@ -18,7 +18,7 @@
         bytes: [UInt8],
         features: WasmFeatureSet = .default
     ) throws -> ParsedComponent {
-        let stream = StaticByteStream(bytes: bytes)
+        let stream = StaticByteStreamSource(bytes: bytes)
         return try parseComponent(stream: stream, features: features)
     }
 
@@ -35,13 +35,13 @@
         bytes: ArraySlice<UInt8>,
         features: WasmFeatureSet = .default
     ) throws -> ParsedComponent {
-        let stream = StaticByteStream(bytes: bytes)
+        let stream = StaticByteStreamSource(bytes: bytes)
         return try parseComponent(stream: stream, features: features)
     }
 
     /// Internal implementation that parses from any ByteStream.
-    private func parseComponent<Stream: ByteStream>(
-        stream: Stream,
+    private func parseComponent<Source: ByteStreamSource>(
+        stream: Source,
         features: WasmFeatureSet
     ) throws -> ParsedComponent {
         var parser = WasmParser.ComponentParser(stream: stream, features: features)
@@ -608,7 +608,7 @@
         fileHandle: FileDescriptor,
         features: WasmFeatureSet = .default
     ) throws -> ParsedComponent {
-        let stream = try FileHandleStream(fileHandle: fileHandle)
+        let stream = try FileHandleStreamSource(fileHandle: fileHandle)
         return try parseComponent(stream: stream, features: features)
     }
 #endif

--- a/Sources/WasmKit/ModuleParser+FileSystem.swift
+++ b/Sources/WasmKit/ModuleParser+FileSystem.swift
@@ -31,8 +31,8 @@
     /// The descriptor is consumed from its current offset and is not closed by
     /// this function.
     public func parseWasm(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws -> Module {
-        let stream = try FileHandleStream(fileHandle: fileHandle)
-        let module = try parseModule(stream: stream, features: features)
+        let parser = try WasmParser.Parser(fileHandle: fileHandle, features: features)
+        let module = try parseModule(parser: parser, features: features)
         return module
     }
 #endif

--- a/Sources/WasmKit/ModuleParser.swift
+++ b/Sources/WasmKit/ModuleParser.swift
@@ -3,22 +3,22 @@ import WasmParser
 /// Parse a given byte array as a WebAssembly binary format file
 /// > Note: <https://webassembly.github.io/spec/core/binary/index.html>
 public func parseWasm(bytes: [UInt8], features: WasmFeatureSet = .default) throws(WasmKitError) -> Module {
-    let stream = StaticByteStream(bytes: bytes)
-    let module = try parseModule(stream: stream, features: features)
+    let parser = Parser(bytes: bytes, features: features)
+    let module = try parseModule(parser: parser, features: features)
     return module
 }
 
 /// Parse a given byte slice as a WebAssembly binary format file
 /// > Note: <https://webassembly.github.io/spec/core/binary/index.html>
 public func parseWasm(bytes: ArraySlice<UInt8>, features: WasmFeatureSet = .default) throws -> Module {
-    let stream = StaticByteStream(bytes: bytes)
-    let module = try parseModule(stream: stream, features: features)
+    let parser = Parser(bytes: bytes, features: features)
+    let module = try parseModule(parser: parser, features: features)
     return module
 }
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-module>
-func parseModule<Stream: ByteStream>(stream: Stream, features: WasmFeatureSet = .default) throws(WasmKitError) -> Module {
+func parseModule<Source: ByteStreamSource>(parser: consuming WasmParser.Parser<Source>, features: WasmFeatureSet = .default) throws(WasmKitError) -> Module {
     var types: [FunctionType] = []
     var typeIndices: [TypeIndex] = []
     var codes: [Code] = []
@@ -33,10 +33,6 @@ func parseModule<Stream: ByteStream>(stream: Stream, features: WasmFeatureSet = 
     var exports: [Export] = []
     var customSections: [CustomSection] = []
     var dataCount: UInt32?
-
-    var parser = WasmParser.Parser<Stream>(
-        stream: stream, features: features
-    )
 
     while let payload = try WasmKitError.wrap({ () throws(WasmParserError) in try parser.parseNext() }) {
         switch payload {

--- a/Sources/WasmParser/BinaryInstructionDecoder.swift
+++ b/Sources/WasmParser/BinaryInstructionDecoder.swift
@@ -10,7 +10,7 @@ protocol BinaryInstructionDecoder {
     var offset: Int { get }
 
     /// Claim the next byte to be decoded
-    @inlinable func claimNextByte() throws(WasmParserError) -> UInt8
+    @inlinable mutating func claimNextByte() throws(WasmParserError) -> UInt8
 
     /// Throw an error due to unknown opcode.
     func throwUnknown(_ opcode: [UInt8]) throws(WasmParserError) -> Never

--- a/Sources/WasmParser/ComponentParser.swift
+++ b/Sources/WasmParser/ComponentParser.swift
@@ -4,9 +4,9 @@
 
     /// A streaming parser for WebAssembly Component Model binary format.
     /// For proposed production rules refer to https://github.com/WebAssembly/component-model/blob/7479890cb506d0f8f687595a4d41361ff8a2a194/design/mvp/Binary.md
-    public struct ComponentParser<Stream: ByteStream> {
+    public struct ComponentParser<Source: ByteStreamSource> {
         @usableFromInline
-        let stream: Stream
+        var stream: ByteStream<Source>
         @usableFromInline
         let features: WasmFeatureSet
 
@@ -22,8 +22,8 @@
             return stream.currentIndex
         }
 
-        public init(stream: Stream, features: WasmFeatureSet = .default) {
-            self.stream = stream
+        public init(stream: Source, features: WasmFeatureSet = .default) {
+            self.stream = ByteStream(stream)
             self.features = features
             self.nextParseTarget = .header
         }
@@ -34,14 +34,14 @@
         }
     }
 
-    extension ComponentParser where Stream == StaticByteStream {
+    extension ComponentParser where Source == StaticByteStreamSource {
         /// Initialize a new parser with the given bytes
         ///
         /// - Parameters:
         ///   - bytes: The bytes of the WebAssembly component binary file to parse
         ///   - features: Enabled WebAssembly features for parsing
         public init(bytes: [UInt8], features: WasmFeatureSet = .default) {
-            self.init(stream: StaticByteStream(bytes: bytes), features: features)
+            self.init(stream: StaticByteStreamSource(bytes: bytes), features: features)
         }
     }
 
@@ -172,7 +172,7 @@
     extension ComponentParser {
         /// Parse the component magic number and version.
         @usableFromInline
-        func parsePreamble() throws(WasmParserError) -> [UInt8] {
+        mutating func parsePreamble() throws(WasmParserError) -> [UInt8] {
             // Magic number: 0x00 0x61 0x73 0x6D (same as core wasm)
             let magic = try stream.consume(count: 4)
             guard magic.elementsEqual(WASM_MAGIC) else {
@@ -190,16 +190,23 @@
         }
 
         @inlinable
-        func parseUnsigned<T: RawUnsignedInteger>(_: T.Type = T.self) throws(WasmParserError) -> T {
+        mutating func parseUnsigned<T: RawUnsignedInteger>(_: T.Type = T.self) throws(WasmParserError) -> T {
             try stream.parseUnsigned(T.self)
         }
 
         @inlinable
-        func parseVector<Content>(content parser: () throws(WasmParserError) -> Content) throws(WasmParserError) -> [Content] {
-            try stream.parseVector(content: parser)
+        mutating func parseVector<Content>(
+            content parser: (inout ComponentParser) throws(WasmParserError) -> Content
+        ) throws(WasmParserError) -> [Content] {
+            var contents = [Content]()
+            let count: UInt32 = try parseUnsigned()
+            for _ in 0..<count {
+                try contents.append(parser(&self))
+            }
+            return contents
         }
 
-        func parseCoreSort() throws(WasmParserError) -> CoreDefSort {
+        mutating func parseCoreSort() throws(WasmParserError) -> CoreDefSort {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00: return .func
@@ -214,7 +221,7 @@
             }
         }
 
-        func parseSort() throws(WasmParserError) -> ComponentDefSort {
+        mutating func parseSort() throws(WasmParserError) -> ComponentDefSort {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00:
@@ -230,41 +237,41 @@
             }
         }
 
-        func parseSortIdx() throws(WasmParserError) -> (sort: ComponentDefSort, index: UInt32) {
+        mutating func parseSortIdx() throws(WasmParserError) -> (sort: ComponentDefSort, index: UInt32) {
             let sort = try parseSort()
             let index: UInt32 = try parseUnsigned()
             return (sort, index)
         }
 
-        func parseCanonicalOptions() throws(WasmParserError) -> [CanonicalOption] {
-            try parseVector { () throws(WasmParserError) -> CanonicalOption in
-                let byte = try stream.consumeAny()
+        mutating func parseCanonicalOptions() throws(WasmParserError) -> [CanonicalOption] {
+            try parseVector { p throws(WasmParserError) -> CanonicalOption in
+                let byte = try p.stream.consumeAny()
                 guard let tag = CanonOptionTag(rawValue: byte) else {
-                    throw makeError(.unknownCanonOptionTag(byte))
+                    throw p.makeError(.unknownCanonOptionTag(byte))
                 }
                 switch tag {
                 case .stringEncodingUtf8: return .utf8
                 case .stringEncodingUtf16: return .utf16
                 case .stringEncodingLatin1Utf16: return .latin1UTF16
                 case .memory:
-                    let idx: UInt32 = try parseUnsigned()
+                    let idx: UInt32 = try p.parseUnsigned()
                     return .memory(memoryIndex: idx)
                 case .realloc:
-                    let idx: UInt32 = try parseUnsigned()
+                    let idx: UInt32 = try p.parseUnsigned()
                     return .realloc(funcIndex: idx)
                 case .postReturn:
-                    let idx: UInt32 = try parseUnsigned()
+                    let idx: UInt32 = try p.parseUnsigned()
                     return .postReturn(funcIndex: idx)
                 case .async: return .async
                 case .callback:
-                    let idx: UInt32 = try parseUnsigned()
+                    let idx: UInt32 = try p.parseUnsigned()
                     return .callback(funcIndex: idx)
                 }
             }
         }
 
         /// Parse a value type (primitive or type index).
-        func parseValType() throws(WasmParserError) -> ComponentDefValType {
+        mutating func parseValType() throws(WasmParserError) -> ComponentDefValType {
             let byte = try stream.peek() ?? 0
             // Check if it's a type index (non-negative SLEB128)
             if byte < 0x64 {
@@ -277,7 +284,7 @@
         }
 
         /// Parse an optional value type.
-        func parseOptionalValType() throws(WasmParserError) -> ComponentValType? {
+        mutating func parseOptionalValType() throws(WasmParserError) -> ComponentValType? {
             let present = try stream.consumeAny()
             if present == 0x00 {
                 return nil
@@ -288,7 +295,7 @@
         }
 
         /// Parse a defined value type.
-        func parseDefValType() throws(WasmParserError) -> ComponentDefValType {
+        mutating func parseDefValType() throws(WasmParserError) -> ComponentDefValType {
             let byte = try stream.peek() ?? 0
 
             // Check for type index first
@@ -309,18 +316,18 @@
             }
             switch compositeType {
             case .record:
-                let fields = try parseVector { () throws(WasmParserError) -> ComponentRecordField in
-                    let name = try stream.parseName()
-                    let typeIdx: UInt32 = try parseUnsigned()
+                let fields = try parseVector { p throws(WasmParserError) -> ComponentRecordField in
+                    let name = try p.stream.parseName()
+                    let typeIdx: UInt32 = try p.parseUnsigned()
                     return ComponentRecordField(name: name, type: .index(ComponentTypeIndex(rawValue: Int(typeIdx))))
                 }
                 return .record(fields)
 
             case .variant:
-                let cases = try parseVector { () throws(WasmParserError) -> ComponentCaseField in
-                    let name = try stream.parseName()
-                    let typeIdx = try parseOptionalValType()
-                    _ = try stream.consumeAny()  // consume 0x00 terminator
+                let cases = try parseVector { p throws(WasmParserError) -> ComponentCaseField in
+                    let name = try p.stream.parseName()
+                    let typeIdx = try p.parseOptionalValType()
+                    _ = try p.stream.consumeAny()  // consume 0x00 terminator
                     return ComponentCaseField(name: name, type: typeIdx)
                 }
                 return .variant(cases)
@@ -330,15 +337,15 @@
                 return .list(.index(ComponentTypeIndex(rawValue: Int(elemIdx))))
 
             case .tuple:
-                let typeIndices: [UInt32] = try parseVector { () throws(WasmParserError) -> UInt32 in try parseUnsigned() }
+                let typeIndices: [UInt32] = try parseVector { p throws(WasmParserError) -> UInt32 in try p.parseUnsigned() }
                 return .tuple(typeIndices.map { .index(ComponentTypeIndex(rawValue: Int($0))) })
 
             case .flags:
-                let labels = try parseVector { () throws(WasmParserError) -> String in try stream.parseName() }
+                let labels = try parseVector { p throws(WasmParserError) -> String in try p.stream.parseName() }
                 return .flags(labels)
 
             case .enum:
-                let labels = try parseVector { () throws(WasmParserError) -> String in try stream.parseName() }
+                let labels = try parseVector { p throws(WasmParserError) -> String in try p.stream.parseName() }
                 return .enum(labels)
 
             case .option:
@@ -388,7 +395,7 @@
         }
 
         /// Parse an extern descriptor.
-        func parseExternDesc() throws(WasmParserError) -> ComponentExternDesc {
+        mutating func parseExternDesc() throws(WasmParserError) -> ComponentExternDesc {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00:
@@ -419,7 +426,7 @@
         }
 
         /// Parse a value bound.
-        func parseValueBound() throws(WasmParserError) -> ComponentValueBound {
+        mutating func parseValueBound() throws(WasmParserError) -> ComponentValueBound {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00:
@@ -434,7 +441,7 @@
         }
 
         /// Parse a type bound.
-        func parseTypeBound() throws(WasmParserError) -> ComponentTypeBound {
+        mutating func parseTypeBound() throws(WasmParserError) -> ComponentTypeBound {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00:
@@ -448,7 +455,7 @@
         }
 
         /// Parse an import/export name with optional version suffix.
-        func parseImportExportName() throws(WasmParserError) -> String {
+        mutating func parseImportExportName() throws(WasmParserError) -> String {
             let prefix = try stream.consumeAny()
             let len: UInt32 = try parseUnsigned()
             let nameBytes = try stream.consume(count: Int(len))
@@ -479,7 +486,7 @@
 
     extension ComponentParser {
         /// Parse a custom section.
-        func parseCustomSection(size: UInt32) throws(WasmParserError) -> CustomSection {
+        mutating func parseCustomSection(size: UInt32) throws(WasmParserError) -> CustomSection {
             let preNameIndex = stream.currentIndex
             let name = try stream.parseName()
             let nameSize = stream.currentIndex - preNameIndex
@@ -494,97 +501,97 @@
         }
 
         /// Parse core instance section (section 2).
-        func parseCoreInstanceSection() throws(WasmParserError) -> [CoreInstanceDefinition] {
-            try parseVector { () throws(WasmParserError) -> CoreInstanceDefinition in
-                let kind = try stream.consumeAny()
+        mutating func parseCoreInstanceSection() throws(WasmParserError) -> [CoreInstanceDefinition] {
+            try parseVector { p throws(WasmParserError) -> CoreInstanceDefinition in
+                let kind = try p.stream.consumeAny()
                 switch kind {
                 case 0x00:
-                    let moduleIdx: UInt32 = try parseUnsigned()
-                    let args = try parseVector { () throws(WasmParserError) -> CoreInstantiateArg in
-                        let name = try stream.parseName()
-                        let marker = try stream.consumeAny()
+                    let moduleIdx: UInt32 = try p.parseUnsigned()
+                    let args = try p.parseVector { q throws(WasmParserError) -> CoreInstantiateArg in
+                        let name = try q.stream.parseName()
+                        let marker = try q.stream.consumeAny()
                         guard marker == 0x12 else {
-                            throw makeError(.malformedSectionID(marker))
+                            throw q.makeError(.malformedSectionID(marker))
                         }
-                        let instanceIdx: UInt32 = try parseUnsigned()
+                        let instanceIdx: UInt32 = try q.parseUnsigned()
                         return CoreInstantiateArg(name: name, instanceIndex: instanceIdx)
                     }
                     return .instantiate(moduleIndex: moduleIdx, args: args)
                 case 0x01:
-                    let exports = try parseVector { () throws(WasmParserError) -> CoreInlineExport in
-                        let name = try stream.parseName()
-                        let sort = try parseCoreSort()
-                        let idx: UInt32 = try parseUnsigned()
+                    let exports = try p.parseVector { q throws(WasmParserError) -> CoreInlineExport in
+                        let name = try q.stream.parseName()
+                        let sort = try q.parseCoreSort()
+                        let idx: UInt32 = try q.parseUnsigned()
                         return CoreInlineExport(name: name, sort: sort, index: idx)
                     }
                     return .exports(exports)
                 default:
-                    throw makeError(.malformedSectionID(kind))
+                    throw p.makeError(.malformedSectionID(kind))
                 }
             }
         }
 
         /// Parse component instance section (section 5).
-        func parseInstanceSection() throws(WasmParserError) -> [ComponentInstanceDefinition] {
-            try parseVector { () throws(WasmParserError) -> ComponentInstanceDefinition in
-                let kind = try stream.consumeAny()
+        mutating func parseInstanceSection() throws(WasmParserError) -> [ComponentInstanceDefinition] {
+            try parseVector { p throws(WasmParserError) -> ComponentInstanceDefinition in
+                let kind = try p.stream.consumeAny()
                 switch kind {
                 case 0x00:
-                    let componentIdx: UInt32 = try parseUnsigned()
-                    let args = try parseVector { () throws(WasmParserError) -> ComponentInstantiateArg in
-                        let name = try stream.parseName()
-                        let (sort, idx) = try parseSortIdx()
+                    let componentIdx: UInt32 = try p.parseUnsigned()
+                    let args = try p.parseVector { q throws(WasmParserError) -> ComponentInstantiateArg in
+                        let name = try q.stream.parseName()
+                        let (sort, idx) = try q.parseSortIdx()
                         return ComponentInstantiateArg(name: name, sort: sort, index: idx)
                     }
                     return .instantiate(componentIndex: componentIdx, args: args)
                 case 0x01:
-                    let exports = try parseVector { () throws(WasmParserError) -> ComponentInlineExport in
-                        let name = try parseImportExportName()
-                        let (sort, idx) = try parseSortIdx()
+                    let exports = try p.parseVector { q throws(WasmParserError) -> ComponentInlineExport in
+                        let name = try q.parseImportExportName()
+                        let (sort, idx) = try q.parseSortIdx()
                         return ComponentInlineExport(name: name, sort: sort, index: idx)
                     }
                     return .exports(exports)
                 default:
-                    throw makeError(.malformedSectionID(kind))
+                    throw p.makeError(.malformedSectionID(kind))
                 }
             }
         }
 
         /// Parse alias section (section 6).
-        func parseAliasSection() throws(WasmParserError) -> [ComponentAlias] {
-            try parseVector { () throws(WasmParserError) -> ComponentAlias in
-                let sort = try parseSort()
-                let targetKind = try stream.consumeAny()
+        mutating func parseAliasSection() throws(WasmParserError) -> [ComponentAlias] {
+            try parseVector { p throws(WasmParserError) -> ComponentAlias in
+                let sort = try p.parseSort()
+                let targetKind = try p.stream.consumeAny()
                 let target: ComponentAliasTarget
                 switch targetKind {
                 case 0x00:
-                    let instanceIdx: UInt32 = try parseUnsigned()
-                    let name = try stream.parseName()
+                    let instanceIdx: UInt32 = try p.parseUnsigned()
+                    let name = try p.stream.parseName()
                     target = .export(instanceIndex: instanceIdx, name: name)
                 case 0x01:
-                    let instanceIdx: UInt32 = try parseUnsigned()
-                    let name = try stream.parseName()
+                    let instanceIdx: UInt32 = try p.parseUnsigned()
+                    let name = try p.stream.parseName()
                     target = .coreExport(instanceIndex: instanceIdx, name: name)
                 case 0x02:
-                    let count: UInt32 = try parseUnsigned()
-                    let idx: UInt32 = try parseUnsigned()
+                    let count: UInt32 = try p.parseUnsigned()
+                    let idx: UInt32 = try p.parseUnsigned()
                     target = .outer(count: count, index: idx)
                 default:
-                    throw makeError(.malformedSectionID(targetKind))
+                    throw p.makeError(.malformedSectionID(targetKind))
                 }
                 return ComponentAlias(sort: sort, target: target)
             }
         }
 
         /// Parse type section (section 7).
-        func parseTypeSection() throws(WasmParserError) -> [ComponentTypeDef] {
-            try parseVector { () throws(WasmParserError) -> ComponentTypeDef in
-                try parseTypeDef()
+        mutating func parseTypeSection() throws(WasmParserError) -> [ComponentTypeDef] {
+            try parseVector { p throws(WasmParserError) -> ComponentTypeDef in
+                try p.parseTypeDef()
             }
         }
 
         /// Parse a single type definition.
-        func parseTypeDef() throws(WasmParserError) -> ComponentTypeDef {
+        mutating func parseTypeDef() throws(WasmParserError) -> ComponentTypeDef {
             let byte = try stream.peek() ?? 0
 
             // Check if it's a defined value type (primitive or composite)
@@ -596,9 +603,9 @@
             let opcode = try stream.consumeAny()
             switch opcode {
             case 0x40:  // functype
-                let params = try parseVector { () throws(WasmParserError) -> ComponentFuncType.Param in
-                    let name = try stream.parseName()
-                    let valType = try parseValType()
+                let params = try parseVector { p throws(WasmParserError) -> ComponentFuncType.Param in
+                    let name = try p.stream.parseName()
+                    let valType = try p.parseValType()
                     return ComponentFuncType.Param(name: name, type: valType)
                 }
                 let resultKind = try stream.consumeAny()
@@ -613,11 +620,13 @@
                 return .function(ComponentFuncType(params: params, result: result))
 
             case 0x41:  // componenttype
-                let decls = try parseVector { () throws(WasmParserError) -> ComponentOrInstanceDecl in try parseComponentOrInstanceDecl(isComponent: true) }
+                let decls = try parseVector { p throws(WasmParserError) -> ComponentOrInstanceDecl in
+                    try p.parseComponentOrInstanceDecl(isComponent: true)
+                }
                 return .component(ComponentTypeDecl(declarations: decls))
 
             case 0x42:  // instancetype
-                let decls = try parseVector { () throws(WasmParserError) -> InstanceDecl in try parseInstanceDeclOnly() }
+                let decls = try parseVector { p throws(WasmParserError) -> InstanceDecl in try p.parseInstanceDeclOnly() }
                 return .instance(InstanceTypeDecl(declarations: decls))
 
             case 0x3f:  // resourcetype
@@ -632,7 +641,7 @@
         }
 
         /// Parse component or instance declaration.
-        func parseComponentOrInstanceDecl(isComponent: Bool) throws(WasmParserError) -> ComponentOrInstanceDecl {
+        mutating func parseComponentOrInstanceDecl(isComponent: Bool) throws(WasmParserError) -> ComponentOrInstanceDecl {
             let kind = try stream.consumeAny()
             switch kind {
             case 0x03 where isComponent:
@@ -646,13 +655,13 @@
         }
 
         /// Parse instance declaration only.
-        func parseInstanceDeclOnly() throws(WasmParserError) -> InstanceDecl {
+        mutating func parseInstanceDeclOnly() throws(WasmParserError) -> InstanceDecl {
             let kind = try stream.consumeAny()
             return try parseInstanceDecl(fromKind: kind)
         }
 
         /// Parse instance declaration from kind byte.
-        func parseInstanceDecl(fromKind kind: UInt8) throws(WasmParserError) -> InstanceDecl {
+        mutating func parseInstanceDecl(fromKind kind: UInt8) throws(WasmParserError) -> InstanceDecl {
             switch kind {
             case 0x00:
                 // core type
@@ -677,7 +686,7 @@
         }
 
         /// Parse a single alias (not in a vector).
-        func parseSingleAlias() throws(WasmParserError) -> ComponentAlias {
+        mutating func parseSingleAlias() throws(WasmParserError) -> ComponentAlias {
             let sort = try parseSort()
             let targetKind = try stream.consumeAny()
             let target: ComponentAliasTarget
@@ -701,18 +710,18 @@
         }
 
         /// Parse a core type definition.
-        func parseCoreTypeDef() throws(WasmParserError) -> CoreTypeDef {
+        mutating func parseCoreTypeDef() throws(WasmParserError) -> CoreTypeDef {
             let byte = try stream.peek() ?? 0
             if byte == 0x50 {
                 _ = try stream.consumeAny()
                 // Module type
-                let decls = try parseVector { () throws(WasmParserError) -> CoreModuleDecl in try parseCoreModuleDecl() }
+                let decls = try parseVector { p throws(WasmParserError) -> CoreModuleDecl in try p.parseCoreModuleDecl() }
                 return .module(CoreModuleType(declarations: decls))
             } else if byte == 0x60 {
                 // Function type
                 _ = try stream.consumeAny()
-                let params = try parseVector { () throws(WasmParserError) -> ValueType in try parseCoreValueType() }
-                let results = try parseVector { () throws(WasmParserError) -> ValueType in try parseCoreValueType() }
+                let params = try parseVector { p throws(WasmParserError) -> ValueType in try p.parseCoreValueType() }
+                let results = try parseVector { p throws(WasmParserError) -> ValueType in try p.parseCoreValueType() }
                 return .function(FunctionType(parameters: params, results: results))
             } else {
                 throw makeError(.malformedSectionID(byte))
@@ -720,7 +729,7 @@
         }
 
         /// Parse core value type.
-        func parseCoreValueType() throws(WasmParserError) -> ValueType {
+        mutating func parseCoreValueType() throws(WasmParserError) -> ValueType {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x7F: return .i32
@@ -734,7 +743,7 @@
         }
 
         /// Parse core module declaration.
-        func parseCoreModuleDecl() throws(WasmParserError) -> CoreModuleDecl {
+        mutating func parseCoreModuleDecl() throws(WasmParserError) -> CoreModuleDecl {
             let kind = try stream.consumeAny()
             switch kind {
             case 0x00:
@@ -765,7 +774,7 @@
         }
 
         /// Parse core import descriptor.
-        func parseCoreImportDesc() throws(WasmParserError) -> ImportDescriptor {
+        mutating func parseCoreImportDesc() throws(WasmParserError) -> ImportDescriptor {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00:
@@ -788,7 +797,7 @@
         }
 
         /// Parse reference type.
-        func parseReferenceType() throws(WasmParserError) -> ReferenceType {
+        mutating func parseReferenceType() throws(WasmParserError) -> ReferenceType {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x69: return .exnRef
@@ -800,7 +809,7 @@
         }
 
         /// Parse limits.
-        func parseLimits() throws(WasmParserError) -> Limits {
+        mutating func parseLimits() throws(WasmParserError) -> Limits {
             let flags = try stream.consumeAny()
             let hasMax = (flags & 0x01) != 0
             let min: UInt64 = try UInt64(parseUnsigned(UInt32.self))
@@ -809,7 +818,7 @@
         }
 
         /// Parse mutability.
-        func parseMutability() throws(WasmParserError) -> Mutability {
+        mutating func parseMutability() throws(WasmParserError) -> Mutability {
             let byte = try stream.consumeAny()
             switch byte {
             case 0x00: return .constant
@@ -820,80 +829,80 @@
         }
 
         /// Parse canon section (section 8).
-        func parseCanonSection() throws(WasmParserError) -> [CanonicalDefinition] {
-            try parseVector { () throws(WasmParserError) -> CanonicalDefinition in
-                let kind = try stream.consumeAny()
+        mutating func parseCanonSection() throws(WasmParserError) -> [CanonicalDefinition] {
+            try parseVector { p throws(WasmParserError) -> CanonicalDefinition in
+                let kind = try p.stream.consumeAny()
                 switch kind {
                 case 0x00:
-                    let sortMarker = try stream.consumeAny()
+                    let sortMarker = try p.stream.consumeAny()
                     guard sortMarker == 0x00 else {
-                        throw makeError(.malformedSectionID(sortMarker))
+                        throw p.makeError(.malformedSectionID(sortMarker))
                     }
-                    let funcIdx: UInt32 = try parseUnsigned()
-                    let opts = try parseCanonicalOptions()
-                    let typeIdx: UInt32 = try parseUnsigned()
+                    let funcIdx: UInt32 = try p.parseUnsigned()
+                    let opts = try p.parseCanonicalOptions()
+                    let typeIdx: UInt32 = try p.parseUnsigned()
                     return .lift(coreFuncIndex: funcIdx, options: opts, typeIndex: typeIdx)
 
                 case 0x01:
-                    let sortMarker = try stream.consumeAny()
+                    let sortMarker = try p.stream.consumeAny()
                     guard sortMarker == 0x00 else {
-                        throw makeError(.malformedSectionID(sortMarker))
+                        throw p.makeError(.malformedSectionID(sortMarker))
                     }
-                    let funcIdx: UInt32 = try parseUnsigned()
-                    let opts = try parseCanonicalOptions()
+                    let funcIdx: UInt32 = try p.parseUnsigned()
+                    let opts = try p.parseCanonicalOptions()
                     return .lower(funcIndex: funcIdx, options: opts)
 
                 case 0x02:
-                    let typeIdx: UInt32 = try parseUnsigned()
+                    let typeIdx: UInt32 = try p.parseUnsigned()
                     return .resourceNew(typeIndex: typeIdx)
 
                 case 0x03:
-                    let typeIdx: UInt32 = try parseUnsigned()
+                    let typeIdx: UInt32 = try p.parseUnsigned()
                     return .resourceDrop(typeIndex: typeIdx)
 
                 case 0x04:
-                    let typeIdx: UInt32 = try parseUnsigned()
+                    let typeIdx: UInt32 = try p.parseUnsigned()
                     return .resourceRep(typeIndex: typeIdx)
 
                 default:
                     // Skip other canon builtins for now
-                    throw makeError(.malformedSectionID(kind))
+                    throw p.makeError(.malformedSectionID(kind))
                 }
             }
         }
 
         /// Parse start section (section 9).
-        func parseStartSection() throws(WasmParserError) -> ComponentStart {
+        mutating func parseStartSection() throws(WasmParserError) -> ComponentStart {
             let funcIdx: UInt32 = try parseUnsigned()
-            let args: [UInt32] = try parseVector { () throws(WasmParserError) -> UInt32 in try parseUnsigned() }
+            let args: [UInt32] = try parseVector { p throws(WasmParserError) -> UInt32 in try p.parseUnsigned() }
             let resultCount: UInt32 = try parseUnsigned()
             return ComponentStart(funcIndex: funcIdx, args: args, resultCount: resultCount)
         }
 
         /// Parse import section (section 10).
-        func parseImportSection() throws(WasmParserError) -> [ComponentImportDef] {
-            try parseVector { () throws(WasmParserError) -> ComponentImportDef in
-                let name = try parseImportExportName()
-                let externDesc = try parseExternDesc()
+        mutating func parseImportSection() throws(WasmParserError) -> [ComponentImportDef] {
+            try parseVector { p throws(WasmParserError) -> ComponentImportDef in
+                let name = try p.parseImportExportName()
+                let externDesc = try p.parseExternDesc()
                 return ComponentImportDef(name: name, externDesc: externDesc)
             }
         }
 
         /// Parse export section (section 11).
-        func parseExportSection() throws(WasmParserError) -> [ComponentExportDef] {
-            try parseVector { () throws(WasmParserError) -> ComponentExportDef in
-                let name = try parseImportExportName()
-                let (sort, idx) = try parseSortIdx()
+        mutating func parseExportSection() throws(WasmParserError) -> [ComponentExportDef] {
+            try parseVector { p throws(WasmParserError) -> ComponentExportDef in
+                let name = try p.parseImportExportName()
+                let (sort, idx) = try p.parseSortIdx()
                 // Parse optional extern desc
                 // 0x00 = no extern desc present
                 // 0x01-0x05 = extern desc type prefix
-                let marker = try stream.peek() ?? 0
+                let marker = try p.stream.peek() ?? 0
                 let externDesc: ComponentExternDesc?
                 if marker == 0x00 {
-                    _ = try stream.consumeAny()  // consume the absence marker
+                    _ = try p.stream.consumeAny()  // consume the absence marker
                     externDesc = nil
                 } else if marker >= 0x01 && marker <= 0x05 {
-                    externDesc = try parseExternDesc()
+                    externDesc = try p.parseExternDesc()
                 } else {
                     externDesc = nil
                 }
@@ -902,11 +911,11 @@
         }
 
         /// Parse value section (section 12).
-        func parseValueSection() throws(WasmParserError) -> [ComponentValueDef] {
-            try parseVector { () throws(WasmParserError) -> ComponentValueDef in
-                let valType = try parseValType()
-                let len: UInt32 = try parseUnsigned()
-                let valueBytes = try stream.consume(count: Int(len))
+        mutating func parseValueSection() throws(WasmParserError) -> [ComponentValueDef] {
+            try parseVector { p throws(WasmParserError) -> ComponentValueDef in
+                let valType = try p.parseValType()
+                let len: UInt32 = try p.parseUnsigned()
+                let valueBytes = try p.stream.consume(count: Int(len))
                 return ComponentValueDef(type: valType, value: Array(valueBytes))
             }
         }
@@ -952,7 +961,7 @@
                     payload = .coreInstanceSection(try parseCoreInstanceSection())
 
                 case .coreType:
-                    let coreTypes = try parseVector { () throws(WasmParserError) -> CoreTypeDef in try parseCoreTypeDef() }
+                    let coreTypes = try parseVector { p throws(WasmParserError) -> CoreTypeDef in try p.parseCoreTypeDef() }
                     payload = .coreTypeSection(coreTypes)
 
                 case .component:

--- a/Sources/WasmParser/LEB.swift
+++ b/Sources/WasmParser/LEB.swift
@@ -5,9 +5,9 @@ public enum LEBError: Swift.Error, Equatable {
 }
 
 @inlinable
-func decodeLEB128<IntType, Stream>(
-    stream: Stream
-) throws(WasmParserError) -> IntType where IntType: FixedWidthInteger, IntType: UnsignedInteger, Stream: ByteStream {
+func decodeLEB128<IntType, Source>(
+    stream: inout ByteStream<Source>
+) throws(WasmParserError) -> IntType where IntType: FixedWidthInteger, IntType: UnsignedInteger, Source: ByteStreamSource {
     let firstByte = try stream.consumeAny()
     var result: IntType = IntType(firstByte & 0b0111_1111)
     if _fastPath(firstByte & 0b1000_0000 == 0) {
@@ -33,9 +33,9 @@ func decodeLEB128<IntType, Stream>(
 }
 
 @inlinable
-func decodeLEB128<IntType, Stream>(
-    stream: Stream, bitWidth: Int = IntType.bitWidth
-) throws(WasmParserError) -> IntType where IntType: FixedWidthInteger, IntType: RawSignedInteger, Stream: ByteStream {
+func decodeLEB128<IntType, Source>(
+    stream: inout ByteStream<Source>, bitWidth: Int = IntType.bitWidth
+) throws(WasmParserError) -> IntType where IntType: FixedWidthInteger, IntType: RawSignedInteger, Source: ByteStreamSource {
     let firstByte = try stream.consumeAny()
     var result = IntType.Unsigned(firstByte & 0b0111_1111)
     if _fastPath(firstByte & 0b1000_0000 == 0) {

--- a/Sources/WasmParser/Stream/ByteStream.swift
+++ b/Sources/WasmParser/Stream/ByteStream.swift
@@ -1,60 +1,97 @@
-public protocol ByteStream: ~Copyable {
-    var currentIndex: Int { get }
+/// A cursor-based mutable view into a `ByteStreamSource`.
+@usableFromInline
+struct ByteStream<Source: ByteStreamSource> {
+    @usableFromInline var currentIndex: Int
+    @usableFromInline let source: Source
 
-    func consumeAny() throws(WasmParserError) -> UInt8
-    func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8>
+    @inlinable
+    init(_ source: Source) {
+        self.currentIndex = 0
+        self.source = source
+    }
 
-    func peek() throws(WasmParserError) -> UInt8?
-}
+    /// Consumes and returns the next byte in the stream, or throws if the stream has ended.
+    @inlinable
+    mutating func consumeAny() throws(WasmParserError) -> UInt8 {
+        guard let byte = try source.readByte(at: currentIndex) else {
+            throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: currentIndex)
+        }
+        currentIndex += 1
+        return byte
+    }
 
-extension ByteStream {
+    /// Consumes and returns the next `count` bytes in the stream, or throws if fewer than `count` bytes remain.
+    @inlinable
+    mutating func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8> {
+        guard count > 0 else { return [] }
+        guard let bytes = try source.readBytes(from: currentIndex, to: currentIndex + count) else {
+            throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: currentIndex)
+        }
+        currentIndex += count
+        return bytes
+    }
+
+    /// Returns the next byte in the stream without consuming it, or `nil` if the stream has ended.
+    @inlinable
+    func peek() throws(WasmParserError) -> UInt8? {
+        return try source.readByte(at: currentIndex)
+    }
+
+    /// Returns `true` if the stream has reached its end, or `false` otherwise.
     @usableFromInline
     func hasReachedEnd() throws(WasmParserError) -> Bool {
         try peek() == nil
     }
 }
-public final class StaticByteStream: ByteStream {
+
+/// A cursor-agnostic provider of the bytes backing a `ByteStream`.
+///
+/// Implementations are addressed by absolute offset and know nothing about the
+/// stream's current position.
+///
+/// Rationale: the read cursor is usually a byte source's only mutable state, so
+/// moving it onto `ByteStream` lets the source stay immutable. An address-mapped
+/// source (one backed by a memory region) can then serve reads without mutating
+/// itself. That keeps `Span`-based memory safety simple: borrowed bytes are tied
+/// to the immutable source's lifetime alone.
+public protocol ByteStreamSource: ~Escapable {
+    /// Returns the byte at `offset`, or `nil` if `offset` is past the end.
+    func readByte(at offset: Int) throws(WasmParserError) -> UInt8?
+    /// Returns the bytes in `startOffset..<endOffset`, or `nil` if fewer than
+    /// `endOffset` bytes are available.
+    func readBytes(from startOffset: Int, to endOffset: Int) throws(WasmParserError) -> ArraySlice<UInt8>?
+}
+
+public final class StaticByteStreamSource: ByteStreamSource {
     public let bytes: ArraySlice<UInt8>
-    public var currentIndex: Int
+    public var count: Int { return bytes.count }
 
     public init(bytes: [UInt8]) {
         self.bytes = ArraySlice(bytes)
-        currentIndex = bytes.startIndex
     }
 
     public init(bytes: ArraySlice<UInt8>) {
         self.bytes = bytes
-        currentIndex = bytes.startIndex
     }
 
-    @discardableResult
-    public func consumeAny() throws(WasmParserError) -> UInt8 {
-        guard bytes.indices.contains(currentIndex) else {
-            throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: self.currentIndex)
-        }
-
-        let consumed = bytes[currentIndex]
-        currentIndex = bytes.index(after: currentIndex)
-        return consumed
-    }
-
-    public func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8> {
-        guard count > 0 else { return [] }
-        let updatedIndex = currentIndex + count
-
-        guard bytes.indices.contains(updatedIndex - 1) else {
-            throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: currentIndex)
-        }
-
-        defer { currentIndex = updatedIndex }
-
-        return bytes[currentIndex..<updatedIndex]
-    }
-
-    public func peek() -> UInt8? {
-        guard bytes.indices.contains(currentIndex) else {
+    @inlinable
+    public func readByte(at offset: Int) throws(WasmParserError) -> UInt8? {
+        // `offset` is relative to the start of the backing bytes, which may be a
+        // slice with a non-zero start index.
+        let index = bytes.startIndex + offset
+        guard index < bytes.endIndex else {
             return nil
         }
-        return bytes[currentIndex]
+        return self.bytes[index]
+    }
+
+    @inlinable
+    public func readBytes(from startOffset: Int, to endOffset: Int) throws(WasmParserError) -> ArraySlice<UInt8>? {
+        let lowerIndex = bytes.startIndex + startOffset
+        let upperIndex = bytes.startIndex + endOffset
+        guard upperIndex <= bytes.endIndex else {
+            return nil
+        }
+        return self.bytes[lowerIndex..<upperIndex]
     }
 }

--- a/Sources/WasmParser/Stream/FileHandleStream.swift
+++ b/Sources/WasmParser/Stream/FileHandleStream.swift
@@ -8,7 +8,7 @@
         import ucrt
     #endif
 
-    extension Parser where Stream == FileHandleStream {
+    extension Parser where Source == FileHandleStreamSource {
 
         /// Initialize a new parser with the given file handle
         ///
@@ -16,7 +16,7 @@
         ///   - fileHandle: The file handle to the WebAssembly binary file to parse
         ///   - features: Enabled WebAssembly features for parsing
         public init(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws {
-            self.init(stream: try FileHandleStream(fileHandle: fileHandle), features: features)
+            self.init(stream: try FileHandleStreamSource(fileHandle: fileHandle), features: features)
         }
 
         /// Initialize a new parser with the given file path
@@ -34,90 +34,74 @@
                 let accessMode: FileDescriptor.AccessMode = .readOnly
             #endif
             let fileHandle = try FileDescriptor.open(filePath, accessMode)
-            self.init(stream: try FileHandleStream(fileHandle: fileHandle), features: features)
+            self.init(stream: try FileHandleStreamSource(fileHandle: fileHandle), features: features)
         }
     }
 
-    public final class FileHandleStream: ByteStream {
-        private(set) public var currentIndex: Int = 0
-
+    public final class FileHandleStreamSource: ByteStreamSource {
         private let fileHandle: FileDescriptor
         private let bufferLength: Int
 
-        private var endOffset: Int = 0
-        private var startOffset: Int = 0
+        private var bufferEndOffset: Int = 0
+        private var bufferStartOffset: Int = 0
         private var bytes: [UInt8] = []
 
         public init(fileHandle: FileDescriptor, bufferLength: Int = 1024 * 8) throws {
             self.fileHandle = fileHandle
             self.bufferLength = bufferLength
 
-            try readMoreIfNeeded()
+            try readMoreIfNeeded(offset: 0)
         }
 
-        private func readMoreIfNeeded() throws(WasmParserError) {
-            guard Int(endOffset) == currentIndex else { return }
-            startOffset = currentIndex
+        public func readByte(at offset: Int) throws(WasmParserError) -> UInt8? {
+            try readMoreIfNeeded(offset: offset)
+
+            let index = offset - bufferStartOffset
+            guard bytes.indices.contains(index) else {
+                return nil
+            }
+            return bytes[index]
+        }
+
+        public func readBytes(from startOffset: Int, to endOffset: Int) throws(WasmParserError) -> ArraySlice<UInt8>? {
+            let bytesToRead = endOffset - bufferEndOffset
+
+            if bytesToRead > 0 {
+                let data: [UInt8]
+                do {
+                    data = try fileHandle.read(upToCount: bytesToRead)
+                } catch {
+                    throw WasmParserError("I/O error: \(error)", offset: startOffset)
+                }
+                // Fewer bytes than requested means the stream ended early; that is
+                // an out-of-range read, which `ByteStream` reports as needed.
+                guard data.count == bytesToRead else {
+                    return nil
+                }
+
+                bytes.append(contentsOf: [UInt8](data))
+                bufferEndOffset = bufferEndOffset + data.count
+            }
+
+            // `bytes` is indexed relative to `bufferStartOffset`, so translate the
+            // absolute [startOffset, endOffset) range into buffer-local indices.
+            let lowerIndex = startOffset - bufferStartOffset
+            let upperIndex = endOffset - bufferStartOffset
+            return bytes[lowerIndex..<upperIndex]
+        }
+
+        private func readMoreIfNeeded(offset: Int) throws(WasmParserError) {
+            guard Int(bufferEndOffset) == offset else { return }
+            bufferStartOffset = offset
 
             do {
                 let data = try fileHandle.read(upToCount: bufferLength)
 
                 bytes = [UInt8](data)
             } catch {
-                throw WasmParserError("I/O error: \(error)", offset: currentIndex)
+                throw WasmParserError("I/O error: \(error)", offset: offset)
             }
-            endOffset = startOffset + bytes.count
-        }
-
-        @discardableResult
-        public func consumeAny() throws(WasmParserError) -> UInt8 {
-            guard let consumed = try peek() else {
-                throw WasmParserError(message: .unexpectedEnd, offset: currentIndex)
-            }
-            currentIndex = bytes.index(after: currentIndex)
-            return consumed
-        }
-
-        public func consume(count: Int) throws(WasmParserError) -> ArraySlice<UInt8> {
-            let bytesToRead = currentIndex + count - endOffset
-
-            guard bytesToRead > 0 else {
-                let bytesIndex = currentIndex - startOffset
-                let result = bytes[bytesIndex..<bytesIndex + count]
-                currentIndex = currentIndex + count
-                return result
-            }
-
-            let data: [UInt8]
-            do {
-                data = try fileHandle.read(upToCount: bytesToRead)
-            } catch {
-                throw WasmParserError("I/O error: \(error)", offset: currentIndex)
-            }
-            guard data.count == bytesToRead else {
-                throw WasmParserError(kind: .parserUnexpectedEnd(expected: nil), offset: currentIndex)
-            }
-
-            bytes.append(contentsOf: [UInt8](data))
-            endOffset = endOffset + data.count
-
-            let bytesIndex = currentIndex - startOffset
-            let result = bytes[bytesIndex..<bytesIndex + count]
-
-            currentIndex = endOffset
-
-            return result
-        }
-
-        public func peek() throws(WasmParserError) -> UInt8? {
-            try readMoreIfNeeded()
-
-            let index = currentIndex - startOffset
-            guard bytes.indices.contains(index) else {
-                return nil
-            }
-
-            return bytes[index]
+            bufferEndOffset = bufferStartOffset + bytes.count
         }
     }
 

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -3,9 +3,9 @@ import WasmTypes
 /// A streaming parser for WebAssembly binary format.
 ///
 /// The parser is designed to be used to incrementally parse a WebAssembly binary bytestream.
-public struct Parser<Stream: ByteStream> {
+public struct Parser<Source: ByteStreamSource> {
     @usableFromInline
-    let stream: Stream
+    var stream: ByteStream<Source>
     @usableFromInline let limits: ParsingLimits
     @usableFromInline var orderTracking = OrderTracking()
 
@@ -22,8 +22,8 @@ public struct Parser<Stream: ByteStream> {
         return stream.currentIndex
     }
 
-    public init(stream: Stream, features: WasmFeatureSet = .default) {
-        self.stream = stream
+    public init(stream: Source, features: WasmFeatureSet = .default) {
+        self.stream = ByteStream(stream)
         self.features = features
         self.nextParseTarget = .header
         self.limits = .default
@@ -31,11 +31,18 @@ public struct Parser<Stream: ByteStream> {
 
     @usableFromInline
     internal func makeError(_ message: WasmParserError.Message) -> WasmParserError {
-        return WasmParserError(message: message, offset: offset)
+        return stream.makeError(message)
     }
 }
 
-extension Parser where Stream == StaticByteStream {
+extension ByteStream {
+    @usableFromInline
+    internal func makeError(_ message: WasmParserError.Message) -> WasmParserError {
+        return WasmParserError(message: message, offset: currentIndex)
+    }
+}
+
+extension Parser where Source == StaticByteStreamSource {
 
     /// Initialize a new parser with the given bytes
     ///
@@ -43,7 +50,16 @@ extension Parser where Stream == StaticByteStream {
     ///   - bytes: The bytes of the WebAssembly binary file to parse
     ///   - features: Enabled WebAssembly features for parsing
     public init(bytes: [UInt8], features: WasmFeatureSet = .default) {
-        self.init(stream: StaticByteStream(bytes: bytes), features: features)
+        self.init(stream: StaticByteStreamSource(bytes: bytes), features: features)
+    }
+
+    /// Initialize a new parser with the given bytes
+    ///
+    /// - Parameters:
+    ///   - bytes: The bytes of the WebAssembly binary file to parse
+    ///   - features: Enabled WebAssembly features for parsing
+    public init(bytes: ArraySlice<UInt8>, features: WasmFeatureSet = .default) {
+        self.init(stream: StaticByteStreamSource(bytes: bytes), features: features)
     }
 }
 
@@ -56,7 +72,7 @@ public struct ExpressionParser {
     /// is not a part of the initial `FileHandleStream` buffer
     let initialStreamOffset: Int
     @usableFromInline
-    var parser: Parser<StaticByteStream>
+    var parser: Parser<StaticByteStreamSource>
 
     /// Whether the final `end` opcode has been returned. We track this explicitly
     /// rather than checking `hasReachedEnd()` upfront because an exhausted stream
@@ -70,7 +86,7 @@ public struct ExpressionParser {
 
     public init(code: Code) {
         self.parser = Parser(
-            stream: StaticByteStream(bytes: code.expression),
+            stream: StaticByteStreamSource(bytes: code.expression),
             features: code.features
         )
         self.codeOffset = code.offset
@@ -154,11 +170,11 @@ public struct WasmFeatureSet: OptionSet, Sendable {
 /// <https://webassembly.github.io/spec/core/binary/conventions.html#vectors>
 extension ByteStream {
     @inlinable
-    func parseVector<Content>(content parser: () throws(WasmParserError) -> Content) throws(WasmParserError) -> [Content] {
+    mutating func parseVector<Content>(content parser: (inout Self) throws(WasmParserError) -> Content) throws(WasmParserError) -> [Content] {
         var contents = [Content]()
         let count: UInt32 = try parseUnsigned()
         for _ in 0..<count {
-            try contents.append(parser())
+            try contents.append(parser(&self))
         }
         return contents
     }
@@ -168,27 +184,27 @@ extension ByteStream {
 /// <https://webassembly.github.io/spec/core/binary/values.html#integers>
 extension ByteStream {
     @inlinable
-    func parseUnsigned<T: RawUnsignedInteger>(_: T.Type = T.self) throws(WasmParserError) -> T {
-        try decodeLEB128(stream: self)
+    mutating func parseUnsigned<T: RawUnsignedInteger>(_: T.Type = T.self) throws(WasmParserError) -> T {
+        try decodeLEB128(stream: &self)
     }
 
     @inlinable
-    func parseSigned<T: FixedWidthInteger & RawSignedInteger>() throws(WasmParserError) -> T {
-        try decodeLEB128(stream: self)
+    mutating func parseSigned<T: FixedWidthInteger & RawSignedInteger>() throws(WasmParserError) -> T {
+        try decodeLEB128(stream: &self)
     }
 
     @usableFromInline
-    func parseVarSigned33() throws(WasmParserError) -> Int64 {
-        try decodeLEB128(stream: self, bitWidth: 33)
+    mutating func parseVarSigned33() throws(WasmParserError) -> Int64 {
+        try decodeLEB128(stream: &self, bitWidth: 33)
     }
 }
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/binary/values.html#names>
 extension ByteStream {
-    package func parseName() throws(WasmParserError) -> String {
-        let bytes = try parseVector { () throws(WasmParserError) -> UInt8 in
-            try consumeAny()
+    package mutating func parseName() throws(WasmParserError) -> String {
+        let bytes = try parseVector { (s) throws(WasmParserError) -> UInt8 in
+            try s.consumeAny()
         }
 
         // TODO(optimize): Utilize ASCII fast path in UTF8 decoder
@@ -210,23 +226,23 @@ extension ByteStream {
 
 extension Parser {
     @inlinable
-    func parseVector<Content>(content parser: () throws(WasmParserError) -> Content) throws(WasmParserError) -> [Content] {
+    mutating func parseVector<Content>(content parser: (inout ByteStream<Source>) throws(WasmParserError) -> Content) throws(WasmParserError) -> [Content] {
         try stream.parseVector(content: parser)
     }
 
     @inline(__always)
     @inlinable
-    func parseUnsigned<T: RawUnsignedInteger>(_: T.Type = T.self) throws(WasmParserError) -> T {
+    mutating func parseUnsigned<T: RawUnsignedInteger>(_: T.Type = T.self) throws(WasmParserError) -> T {
         try stream.parseUnsigned(T.self)
     }
 
     @inlinable
-    func parseInteger<T: RawUnsignedInteger>() throws(WasmParserError) -> T {
+    mutating func parseInteger<T: RawUnsignedInteger>() throws(WasmParserError) -> T {
         let signed: T.Signed = try stream.parseSigned()
         return T(bitPattern: signed)
     }
 
-    func parseName() throws(WasmParserError) -> String {
+    mutating func parseName() throws(WasmParserError) -> String {
         try stream.parseName()
     }
 }
@@ -235,7 +251,7 @@ extension Parser {
 /// <https://webassembly.github.io/spec/core/binary/values.html#floating-point>
 extension Parser {
     @usableFromInline
-    func parseFloat() throws(WasmParserError) -> UInt32 {
+    mutating func parseFloat() throws(WasmParserError) -> UInt32 {
         let consumedLittleEndian = try stream.consume(count: 4).reversed()
         let bitPattern = consumedLittleEndian.reduce(UInt32(0)) { acc, byte in
             acc << 8 + UInt32(byte)
@@ -244,7 +260,7 @@ extension Parser {
     }
 
     @usableFromInline
-    func parseDouble() throws(WasmParserError) -> UInt64 {
+    mutating func parseDouble() throws(WasmParserError) -> UInt64 {
         let consumedLittleEndian = try stream.consume(count: 8).reversed()
         let bitPattern = consumedLittleEndian.reduce(UInt64(0)) { acc, byte in
             acc << 8 + UInt64(byte)
@@ -253,14 +269,21 @@ extension Parser {
     }
 }
 
+/// Parse operations that only mutate the byte stream. They live on `ByteStream`
+/// (rather than `Parser`) so the closure-taking vector parsers can invoke them on
+/// the `inout ByteStream` handed to the closure, avoiding overlapping exclusive
+/// access to `Parser`. WebAssembly feature flags — which some of these consult —
+/// are threaded in explicitly rather than stored on the stream, keeping
+/// `ByteStream` a format-agnostic cursor.
+///
 /// > Note:
 /// <https://webassembly.github.io/spec/core/binary/types.html#types>
-extension Parser {
+extension ByteStream {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/types.html#value-types>
     @usableFromInline
-    func parseValueType() throws(WasmParserError) -> ValueType {
-        let b = try stream.consumeAny()
+    mutating func parseValueType(features: WasmFeatureSet) throws(WasmParserError) -> ValueType {
+        let b = try consumeAny()
 
         switch b {
         case 0x7F: return .i32
@@ -269,7 +292,7 @@ extension Parser {
         case 0x7C: return .f64
         case 0x7B: return .v128
         default:
-            guard let refType = try parseReferenceType(byte: b) else {
+            guard let refType = try parseReferenceType(byte: b, features: features) else {
                 throw makeError(.malformedValueType(b))
             }
             return .ref(refType)
@@ -280,7 +303,7 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/function-references/core/binary/types.html#reference-types>
     @usableFromInline
-    func parseReferenceType(byte: UInt8) throws(WasmParserError) -> ReferenceType? {
+    mutating func parseReferenceType(byte: UInt8, features: WasmFeatureSet) throws(WasmParserError) -> ReferenceType? {
         switch byte {
         case 0x63: return try ReferenceType(isNullable: true, heapType: parseHeapType())
         case 0x64: return try ReferenceType(isNullable: false, heapType: parseHeapType())
@@ -296,20 +319,20 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/function-references/core/binary/types.html#heap-types>
     @usableFromInline
-    func parseHeapType() throws(WasmParserError) -> HeapType {
-        let b = try stream.peek()
+    mutating func parseHeapType() throws(WasmParserError) -> HeapType {
+        let b = try peek()
         switch b {
         case 0x69:
-            _ = try stream.consumeAny()
+            _ = try consumeAny()
             return .exnRef
         case 0x6F:
-            _ = try stream.consumeAny()
+            _ = try consumeAny()
             return .externRef
         case 0x70:
-            _ = try stream.consumeAny()
+            _ = try consumeAny()
             return .funcRef
         default:
-            let rawIndex = try stream.parseVarSigned33()
+            let rawIndex = try parseVarSigned33()
             guard let index = TypeIndex(exactly: rawIndex) else {
                 throw makeError(.invalidFunctionType(rawIndex))
             }
@@ -318,32 +341,10 @@ extension Parser {
     }
 
     /// > Note:
-    /// <https://webassembly.github.io/spec/core/binary/types.html#result-types>
-    @inlinable
-    func parseResultType() throws(WasmParserError) -> BlockType {
-        guard let nextByte = try stream.peek() else {
-            throw makeError(.unexpectedEnd)
-        }
-        switch nextByte {
-        case 0x40:
-            _ = try stream.consumeAny()
-            return .empty
-        case 0x7B...0x7F, 0x70, 0x6F, 0x69, 0x63, 0x64:
-            return try .type(parseValueType())
-        default:
-            let rawIndex = try stream.parseVarSigned33()
-            guard let index = TypeIndex(exactly: rawIndex) else {
-                throw makeError(.invalidFunctionType(rawIndex))
-            }
-            return .funcType(index)
-        }
-    }
-
-    /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/types.html#function-types>
     @inlinable
-    func parseFunctionType() throws(WasmParserError) -> FunctionType {
-        let opcode = try stream.consumeAny()
+    mutating func parseFunctionType(features: WasmFeatureSet) throws(WasmParserError) -> FunctionType {
+        let opcode = try consumeAny()
 
         // XXX: spectest expects the first byte should be parsed as a LEB128 with 1 byte limit
         // but the spec itself doesn't require it, so just check the continue bit of LEB128 here.
@@ -354,16 +355,16 @@ extension Parser {
             throw makeError(.malformedFunctionType(opcode))
         }
 
-        let parameters = try parseVector { () throws(WasmParserError) in try parseValueType() }
-        let results = try parseVector { () throws(WasmParserError) in try parseValueType() }
+        let parameters = try parseVector { (s) throws(WasmParserError) in try s.parseValueType(features: features) }
+        let results = try parseVector { (s) throws(WasmParserError) in try s.parseValueType(features: features) }
         return FunctionType(parameters: parameters, results: results)
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/types.html#limits>
     @usableFromInline
-    func parseLimits() throws(WasmParserError) -> Limits {
-        let b = try stream.consumeAny()
+    mutating func parseLimits(features: WasmFeatureSet) throws(WasmParserError) -> Limits {
+        let b = try consumeAny()
         let sharedMask: UInt8 = 0b0010
         let isMemory64Mask: UInt8 = 0b0100
 
@@ -401,16 +402,16 @@ extension Parser {
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/types.html#memory-types>
-    func parseMemoryType() throws(WasmParserError) -> MemoryType {
-        return try parseLimits()
+    mutating func parseMemoryType(features: WasmFeatureSet) throws(WasmParserError) -> MemoryType {
+        return try parseLimits(features: features)
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/types.html#table-types>
     @inlinable
-    func parseTableType() throws(WasmParserError) -> TableType {
+    mutating func parseTableType(features: WasmFeatureSet) throws(WasmParserError) -> TableType {
         let elementType: ReferenceType
-        let b = try stream.consumeAny()
+        let b = try consumeAny()
 
         switch b {
         case 0x70:
@@ -420,26 +421,26 @@ extension Parser {
         default:
             throw WasmParserError(
                 kind: .parserUnexpectedByte(b, expected: [0x6F, 0x70]),
-                offset: stream.currentIndex
+                offset: currentIndex
             )
         }
 
-        let limits = try parseLimits()
+        let limits = try parseLimits(features: features)
         return TableType(elementType: elementType, limits: limits)
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/types.html#global-types>
     @inlinable
-    func parseGlobalType() throws(WasmParserError) -> GlobalType {
-        let valueType = try parseValueType()
+    mutating func parseGlobalType(features: WasmFeatureSet) throws(WasmParserError) -> GlobalType {
+        let valueType = try parseValueType(features: features)
         let mutability = try parseMutability()
         return GlobalType(mutability: mutability, valueType: valueType)
     }
 
     @inlinable
-    func parseMutability() throws(WasmParserError) -> Mutability {
-        let b = try stream.consumeAny()
+    mutating func parseMutability() throws(WasmParserError) -> Mutability {
+        let b = try consumeAny()
         switch b {
         case 0x00:
             return .constant
@@ -450,25 +451,86 @@ extension Parser {
         }
     }
 
+    @inlinable mutating func parseVectorBytes() throws(WasmParserError) -> ArraySlice<UInt8> {
+        let count: UInt32 = try parseUnsigned()
+        return try consume(count: Int(count))
+    }
+
+    /// > Note:
+    /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-importdesc>
+    mutating func parseImportDescriptor(features: WasmFeatureSet) throws(WasmParserError) -> ImportDescriptor {
+        let descriptorOffset = currentIndex
+        let b = try consumeAny()
+        switch b {
+        case 0x00: return try .function(parseUnsigned())
+        case 0x01: return try .table(parseTableType(features: features))
+        case 0x02: return try .memory(parseMemoryType(features: features))
+        case 0x03: return try .global(parseGlobalType(features: features))
+        case 0x04 where features.contains(.exceptionHandling):
+            let attribute: UInt8 = try parseUnsigned()
+            guard attribute == 0 else { throw makeError(.invalidTagAttribute(attribute)) }
+            return try .tag(parseUnsigned())
+        default:
+            throw WasmParserError(kind: .parserUnexpectedByte(b, expected: nil), offset: descriptorOffset)
+        }
+    }
+
+    /// > Note:
+    /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-exportdesc>
+    mutating func parseExportDescriptor(features: WasmFeatureSet) throws(WasmParserError) -> ExportDescriptor {
+        let descriptorOffset = currentIndex
+        let b = try consumeAny()
+        switch b {
+        case 0x00: return try .function(parseUnsigned())
+        case 0x01: return try .table(parseUnsigned())
+        case 0x02: return try .memory(parseUnsigned())
+        case 0x03: return try .global(parseUnsigned())
+        case 0x04 where features.contains(.exceptionHandling): return try .tag(parseUnsigned())
+        default:
+            throw WasmParserError(kind: .parserUnexpectedByte(b, expected: nil), offset: descriptorOffset)
+        }
+    }
+}
+
+/// > Note:
+/// <https://webassembly.github.io/spec/core/binary/types.html#types>
+extension Parser {
+    /// > Note:
+    /// <https://webassembly.github.io/spec/core/binary/types.html#result-types>
+    @inlinable
+    mutating func parseResultType() throws(WasmParserError) -> BlockType {
+        guard let nextByte = try stream.peek() else {
+            throw makeError(.unexpectedEnd)
+        }
+        switch nextByte {
+        case 0x40:
+            _ = try stream.consumeAny()
+            return .empty
+        case 0x7B...0x7F, 0x70, 0x6F, 0x69, 0x63, 0x64:
+            return try .type(stream.parseValueType(features: features))
+        default:
+            let rawIndex = try stream.parseVarSigned33()
+            guard let index = TypeIndex(exactly: rawIndex) else {
+                throw makeError(.invalidFunctionType(rawIndex))
+            }
+            return .funcType(index)
+        }
+    }
+
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/instructions.html#memory-instructions>
     @inlinable
-    func parseMemarg() throws(WasmParserError) -> MemArg {
+    mutating func parseMemarg() throws(WasmParserError) -> MemArg {
         let align: UInt32 = try parseUnsigned()
         let offset: UInt64 = try features.contains(.memory64) ? parseUnsigned(UInt64.self) : UInt64(parseUnsigned(UInt32.self))
         return MemArg(offset: offset, align: align)
-    }
-
-    @inlinable func parseVectorBytes() throws(WasmParserError) -> ArraySlice<UInt8> {
-        let count: UInt32 = try parseUnsigned()
-        return try stream.consume(count: Int(count))
     }
 }
 
 /// > Note:
 /// <https://webassembly.github.io/spec/core/binary/instructions.html>
 extension Parser: BinaryInstructionDecoder {
-    @inlinable func parseMemoryIndex() throws(WasmParserError) -> UInt32 {
+    @inlinable mutating func parseMemoryIndex() throws(WasmParserError) -> UInt32 {
         let zero = try stream.consumeAny()
         guard zero == 0x00 else {
             throw makeError(.zeroExpected(actual: zero))
@@ -490,7 +552,7 @@ extension Parser: BinaryInstructionDecoder {
     @inlinable mutating func visitBr() throws(WasmParserError) -> UInt32 { try parseUnsigned() }
     @inlinable mutating func visitBrIf() throws(WasmParserError) -> UInt32 { try parseUnsigned() }
     @inlinable mutating func visitBrTable() throws(WasmParserError) -> BrTable {
-        let labelIndices: [UInt32] = try parseVector { () throws(WasmParserError) in try parseUnsigned() }
+        let labelIndices: [UInt32] = try parseVector { (s) throws(WasmParserError) in try s.parseUnsigned() }
         let labelIndex: UInt32 = try parseUnsigned()
         return BrTable(labelIndices: labelIndices, defaultIndex: labelIndex)
     }
@@ -498,25 +560,25 @@ extension Parser: BinaryInstructionDecoder {
     @inlinable mutating func visitThrowRef() throws(WasmParserError) { /* no immediates */  }
     @inlinable mutating func visitTryTable() throws(WasmParserError) -> (blockType: BlockType, tryCatch: TryCatch) {
         let blockType = try parseResultType()
-        let catches: [CatchClause] = try parseVector { () throws(WasmParserError) in
-            let clauseId: UInt8 = try parseUnsigned()
+        let catches: [CatchClause] = try parseVector { (s) throws(WasmParserError) in
+            let clauseId: UInt8 = try s.parseUnsigned()
             switch clauseId {
             case 0x00:
-                let tagIndex: UInt32 = try parseUnsigned()
-                let label: UInt32 = try parseUnsigned()
+                let tagIndex: UInt32 = try s.parseUnsigned()
+                let label: UInt32 = try s.parseUnsigned()
                 return .catch(tagIndex: tagIndex, labelIndex: label)
             case 0x01:
-                let tagIndex: UInt32 = try parseUnsigned()
-                let label: UInt32 = try parseUnsigned()
+                let tagIndex: UInt32 = try s.parseUnsigned()
+                let label: UInt32 = try s.parseUnsigned()
                 return .catchRef(tagIndex: tagIndex, labelIndex: label)
             case 0x02:
-                let label: UInt32 = try parseUnsigned()
+                let label: UInt32 = try s.parseUnsigned()
                 return .catchAll(labelIndex: label)
             case 0x03:
-                let label: UInt32 = try parseUnsigned()
+                let label: UInt32 = try s.parseUnsigned()
                 return .catchAllRef(labelIndex: label)
             default:
-                throw makeError(.invalidCatchClauseId(clauseId))
+                throw s.makeError(.invalidCatchClauseId(clauseId))
             }
         }
         return (blockType, TryCatch(catches: catches))
@@ -555,7 +617,8 @@ extension Parser: BinaryInstructionDecoder {
     }
 
     @inlinable mutating func visitTypedSelect() throws(WasmParserError) -> WasmTypes.ValueType {
-        let results = try parseVector { () throws(WasmParserError) in try parseValueType() }
+        let features = self.features
+        let results = try parseVector { (s) throws(WasmParserError) in try s.parseValueType(features: features) }
         guard results.count == 1 else {
             throw makeError(.invalidResultArity(expected: 1, actual: results.count))
         }
@@ -592,7 +655,7 @@ extension Parser: BinaryInstructionDecoder {
         return IEEE754.Float64(bitPattern: n)
     }
     @inlinable mutating func visitRefNull() throws(WasmParserError) -> WasmTypes.HeapType {
-        return try parseHeapType()
+        return try stream.parseHeapType()
     }
     @inlinable mutating func visitBrOnNull() throws(WasmParserError) -> UInt32 {
         return 0
@@ -720,7 +783,7 @@ extension Parser: BinaryInstructionDecoder {
         let lane = try stream.consumeAny()
         return (memarg: memarg, lane: lane)
     }
-    @inlinable func claimNextByte() throws(WasmParserError) -> UInt8 {
+    @inlinable mutating func claimNextByte() throws(WasmParserError) -> UInt8 {
         return try stream.consumeAny()
     }
 
@@ -749,7 +812,7 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#custom-section>
     @usableFromInline
-    func parseCustomSection(size: UInt32) throws(WasmParserError) -> CustomSection {
+    mutating func parseCustomSection(size: UInt32) throws(WasmParserError) -> CustomSection {
         let preNameIndex = stream.currentIndex
         let name = try parseName()
         let nameSize = stream.currentIndex - preNameIndex
@@ -767,81 +830,69 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#type-section>
     @inlinable
-    func parseTypeSection() throws(WasmParserError) -> [FunctionType] {
-        return try parseVector { () throws(WasmParserError) in try parseFunctionType() }
+    mutating func parseTypeSection() throws(WasmParserError) -> [FunctionType] {
+        let features = self.features
+        return try parseVector { (s) throws(WasmParserError) in try s.parseFunctionType(features: features) }
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#import-section>
     @usableFromInline
-    func parseImportSection() throws(WasmParserError) -> [Import] {
-        return try parseVector { () throws(WasmParserError) in
-            let module = try parseName()
-            let name = try parseName()
-            let descriptor = try parseImportDescriptor()
+    mutating func parseImportSection() throws(WasmParserError) -> [Import] {
+        let features = self.features
+        return try parseVector { (s) throws(WasmParserError) in
+            let module = try s.parseName()
+            let name = try s.parseName()
+            let descriptor = try s.parseImportDescriptor(features: features)
             return Import(module: module, name: name, descriptor: descriptor)
-        }
-    }
-
-    /// > Note:
-    /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-importdesc>
-    func parseImportDescriptor() throws(WasmParserError) -> ImportDescriptor {
-        let descriptorOffset = stream.currentIndex
-        let b = try stream.consumeAny()
-        switch b {
-        case 0x00: return try .function(parseUnsigned())
-        case 0x01: return try .table(parseTableType())
-        case 0x02: return try .memory(parseMemoryType())
-        case 0x03: return try .global(parseGlobalType())
-        case 0x04 where features.contains(.exceptionHandling):
-            let attribute: UInt8 = try parseUnsigned()
-            guard attribute == 0 else { throw makeError(.invalidTagAttribute(attribute)) }
-            return try .tag(parseUnsigned())
-        default:
-            throw WasmParserError(kind: .parserUnexpectedByte(b, expected: nil), offset: descriptorOffset)
         }
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#function-section>
     @inlinable
-    func parseFunctionSection() throws(WasmParserError) -> [TypeIndex] {
-        return try parseVector { () throws(WasmParserError) in try parseUnsigned() }
+    mutating func parseFunctionSection() throws(WasmParserError) -> [TypeIndex] {
+        return try parseVector { (s) throws(WasmParserError) in try s.parseUnsigned() }
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#table-section>
     @usableFromInline
-    func parseTableSection() throws(WasmParserError) -> [Table] {
-        return try parseVector { () throws(WasmParserError) in try Table(type: parseTableType()) }
+    mutating func parseTableSection() throws(WasmParserError) -> [Table] {
+        let features = self.features
+        return try parseVector { (s) throws(WasmParserError) in try Table(type: s.parseTableType(features: features)) }
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#memory-section>
     @usableFromInline
-    func parseMemorySection() throws(WasmParserError) -> [Memory] {
-        return try parseVector { () throws(WasmParserError) in try Memory(type: parseLimits()) }
+    mutating func parseMemorySection() throws(WasmParserError) -> [Memory] {
+        let features = self.features
+        return try parseVector { (s) throws(WasmParserError) in try Memory(type: s.parseLimits(features: features)) }
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#global-section>
     @usableFromInline
     mutating func parseGlobalSection() throws(WasmParserError) -> [Global] {
-        return try parseVector { () throws(WasmParserError) in
-            let type = try parseGlobalType()
+        let count: UInt32 = try parseUnsigned()
+        var globals: [Global] = []
+        for _ in 0..<count {
+            let type = try stream.parseGlobalType(features: features)
             let expression = try parseConstExpression()
-            return Global(type: type, initializer: expression)
+            globals.append(Global(type: type, initializer: expression))
         }
+        return globals
     }
 
     /// > Note:
     /// <https://webassembly.github.io/exception-handling/core/binary/modules.html#tag-section>
     @usableFromInline
-    func parseTagSection() throws(WasmParserError) -> [Tag] {
-        return try parseVector { () throws(WasmParserError) in
-            let attribute: UInt8 = try parseUnsigned()
-            guard attribute == 0 else { throw makeError(.invalidTagAttribute(attribute)) }
-            let typeIndex: TypeIndex = try parseUnsigned()
+    mutating func parseTagSection() throws(WasmParserError) -> [Tag] {
+        return try parseVector { (s) throws(WasmParserError) in
+            let attribute: UInt8 = try s.parseUnsigned()
+            guard attribute == 0 else { throw s.makeError(.invalidTagAttribute(attribute)) }
+            let typeIndex: TypeIndex = try s.parseUnsigned()
             return Tag(type: typeIndex)
         }
     }
@@ -849,34 +900,19 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#export-section>
     @usableFromInline
-    func parseExportSection() throws(WasmParserError) -> [Export] {
-        return try parseVector { () throws(WasmParserError) in
-            let name = try parseName()
-            let descriptor = try parseExportDescriptor()
+    mutating func parseExportSection() throws(WasmParserError) -> [Export] {
+        let features = self.features
+        return try parseVector { (s) throws(WasmParserError) in
+            let name = try s.parseName()
+            let descriptor = try s.parseExportDescriptor(features: features)
             return Export(name: name, descriptor: descriptor)
-        }
-    }
-
-    /// > Note:
-    /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-exportdesc>
-    func parseExportDescriptor() throws(WasmParserError) -> ExportDescriptor {
-        let descriptorOffset = stream.currentIndex
-        let b = try stream.consumeAny()
-        switch b {
-        case 0x00: return try .function(parseUnsigned())
-        case 0x01: return try .table(parseUnsigned())
-        case 0x02: return try .memory(parseUnsigned())
-        case 0x03: return try .global(parseUnsigned())
-        case 0x04 where features.contains(.exceptionHandling): return try .tag(parseUnsigned())
-        default:
-            throw WasmParserError(kind: .parserUnexpectedByte(b, expected: nil), offset: descriptorOffset)
         }
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#start-section>
     @usableFromInline
-    func parseStartSection() throws(WasmParserError) -> FunctionIndex {
+    mutating func parseStartSection() throws(WasmParserError) -> FunctionIndex {
         return try parseUnsigned()
     }
 
@@ -884,7 +920,9 @@ extension Parser {
     /// <https://webassembly.github.io/spec/core/binary/modules.html#element-section>
     @inlinable
     mutating func parseElementSection() throws(WasmParserError) -> [ElementSegment] {
-        return try parseVector { () throws(WasmParserError) in
+        let count: UInt32 = try parseUnsigned()
+        var segments: [ElementSegment] = []
+        for _ in 0..<count {
             let flag = try ElementSegment.Flag(rawValue: parseUnsigned())
 
             let type: ReferenceType
@@ -911,7 +949,7 @@ extension Parser {
             }
 
             if flag.segmentHasRefType {
-                let valueType = try parseValueType()
+                let valueType = try stream.parseValueType(features: features)
 
                 guard case .ref(let refType) = valueType else {
                     throw makeError(.expectedRefType(actual: valueType))
@@ -931,27 +969,39 @@ extension Parser {
             }
 
             if flag.contains(.usesExpressions) {
-                initializer = try parseVector { () throws(WasmParserError) in try parseConstExpression() }
-            } else {
-                initializer = try parseVector { () throws(WasmParserError) in
-                    try [Instruction.refFunc(functionIndex: parseUnsigned() as UInt32)]
+                let initCount: UInt32 = try parseUnsigned()
+                var expressions: [ConstExpression] = []
+                for _ in 0..<initCount {
+                    expressions.append(try parseConstExpression())
                 }
+                initializer = expressions
+            } else {
+                let initCount: UInt32 = try parseUnsigned()
+                var expressions: [ConstExpression] = []
+                for _ in 0..<initCount {
+                    expressions.append(try [Instruction.refFunc(functionIndex: parseUnsigned() as UInt32)])
+                }
+                initializer = expressions
             }
 
-            return ElementSegment(type: type, initializer: initializer, mode: mode)
+            segments.append(ElementSegment(type: type, initializer: initializer, mode: mode))
         }
+        return segments
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#code-section>
     @inlinable
-    func parseCodeSection() throws(WasmParserError) -> [Code] {
-        return try parseVector { () throws(WasmParserError) in
+    mutating func parseCodeSection() throws(WasmParserError) -> [Code] {
+        let features = self.features
+        let count: UInt32 = try parseUnsigned()
+        var codes: [Code] = []
+        for _ in 0..<count {
             let size = try parseUnsigned() as UInt32
             let bodyStart = stream.currentIndex
-            let localTypes = try parseVector { () throws(WasmParserError) -> (n: UInt32, type: ValueType) in
-                let n: UInt32 = try parseUnsigned()
-                let t = try parseValueType()
+            let localTypes = try stream.parseVector { (s) throws(WasmParserError) -> (n: UInt32, type: ValueType) in
+                let n: UInt32 = try s.parseUnsigned()
+                let t = try s.parseValueType(features: features)
                 return (n, t)
             }
             let totalLocals = localTypes.reduce(UInt64(0)) { $0 + UInt64($1.n) }
@@ -966,43 +1016,49 @@ extension Parser {
             let expressionBytes = try stream.consume(
                 count: Int(size) - (expressionStart - bodyStart)
             )
-            return Code(
-                locals: locals, expression: expressionBytes,
-                offset: expressionStart, features: features
+            codes.append(
+                Code(
+                    locals: locals, expression: expressionBytes,
+                    offset: expressionStart, features: features
+                )
             )
         }
+        return codes
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#data-section>
     @inlinable
     mutating func parseDataSection() throws(WasmParserError) -> [DataSegment] {
-        return try parseVector { () throws(WasmParserError) in
+        let count: UInt32 = try parseUnsigned()
+        var segments: [DataSegment] = []
+        for _ in 0..<count {
             let kind: UInt32 = try parseUnsigned()
             switch kind {
             case 0:
                 let offset = try parseConstExpression()
-                let initializer = try parseVectorBytes()
-                return .active(.init(index: 0, offset: offset, initializer: initializer))
+                let initializer = try stream.parseVectorBytes()
+                segments.append(.active(.init(index: 0, offset: offset, initializer: initializer)))
 
             case 1:
-                return try .passive(parseVectorBytes())
+                segments.append(try .passive(stream.parseVectorBytes()))
 
             case 2:
                 let index: UInt32 = try parseUnsigned()
                 let offset = try parseConstExpression()
-                let initializer = try parseVectorBytes()
-                return .active(.init(index: index, offset: offset, initializer: initializer))
+                let initializer = try stream.parseVectorBytes()
+                segments.append(.active(.init(index: index, offset: offset, initializer: initializer)))
             default:
                 throw makeError(.malformedDataSegmentKind(kind))
             }
         }
+        return segments
     }
 
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#data-count-section>
     @usableFromInline
-    func parseDataCountSection() throws(WasmParserError) -> UInt32 {
+    mutating func parseDataCountSection() throws(WasmParserError) -> UInt32 {
         return try parseUnsigned()
     }
 }
@@ -1031,7 +1087,7 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-magic>
     @usableFromInline
-    func parseMagicNumber() throws(WasmParserError) {
+    mutating func parseMagicNumber() throws(WasmParserError) {
         let magicNumber = try stream.consume(count: 4)
         guard magicNumber.elementsEqual(WASM_MAGIC) else {
             throw makeError(.invalidMagicNumber(.init(magicNumber)))
@@ -1041,7 +1097,7 @@ extension Parser {
     /// > Note:
     /// <https://webassembly.github.io/spec/core/binary/modules.html#binary-version>
     @usableFromInline
-    func parseVersion() throws(WasmParserError) -> [UInt8] {
+    mutating func parseVersion() throws(WasmParserError) -> [UInt8] {
         let version = try Array(stream.consume(count: 4))
         guard version == [0x01, 0x00, 0x00, 0x00] else {
             throw makeError(.unknownVersion(.init(version)))
@@ -1221,22 +1277,22 @@ public enum ParsedNames {
 /// A parser for the name custom section.
 ///
 /// > Note: <https://webassembly.github.io/spec/core/appendix/custom.html#name-section>
-public struct NameSectionParser<Stream: ByteStream> {
-    let stream: Stream
+public struct NameSectionParser<Source: ByteStreamSource> {
+    var stream: ByteStream<Source>
 
-    public init(stream: Stream) {
-        self.stream = stream
+    public init(stream: Source) {
+        self.stream = ByteStream(stream)
     }
 
     /// Parses the entire name section.
     ///
     /// - Throws: If the stream is malformed or the section is invalid.
     /// - Returns: A list of parsed names.
-    public func parseAll() throws(WasmParserError) -> [ParsedNames] {
+    public mutating func parseAll() throws(WasmParserError) -> [ParsedNames] {
         var results: [ParsedNames] = []
         while try !stream.hasReachedEnd() {
             let id = try stream.consumeAny()
-            guard let result = try parseNameSubsection(type: id) else {
+            guard let result = try Self.parseNameSubsection(type: id, stream: &stream) else {
                 continue
             }
             results.append(result)
@@ -1244,28 +1300,28 @@ public struct NameSectionParser<Stream: ByteStream> {
         return results
     }
 
-    func parseNameSubsection(type: UInt8) throws(WasmParserError) -> ParsedNames? {
+    static func parseNameSubsection(type: UInt8, stream: inout ByteStream<Source>) throws(WasmParserError) -> ParsedNames? {
         let size = try stream.parseUnsigned(UInt32.self)
         switch type {
         case 0: return .moduleName(try stream.parseName())
-        case 1: return .functions(try parseNameMap())
-        case 2: return .locals(try parseIndirectNameMap())
-        case 3: return .labels(try parseIndirectNameMap())
-        case 4: return .types(try parseNameMap())
-        case 5: return .tables(try parseNameMap())
-        case 6: return .memories(try parseNameMap())
-        case 7: return .globals(try parseNameMap())
-        case 8: return .elements(try parseNameMap())
-        case 9: return .dataSegments(try parseNameMap())
+        case 1: return .functions(try parseNameMap(stream: &stream))
+        case 2: return .locals(try parseIndirectNameMap(stream: &stream))
+        case 3: return .labels(try parseIndirectNameMap(stream: &stream))
+        case 4: return .types(try parseNameMap(stream: &stream))
+        case 5: return .tables(try parseNameMap(stream: &stream))
+        case 6: return .memories(try parseNameMap(stream: &stream))
+        case 7: return .globals(try parseNameMap(stream: &stream))
+        case 8: return .elements(try parseNameMap(stream: &stream))
+        case 9: return .dataSegments(try parseNameMap(stream: &stream))
         default:
             _ = try stream.consume(count: Int(size))
             return nil
         }
     }
 
-    func parseNameMap() throws(WasmParserError) -> NameMap {
+    static func parseNameMap(stream: inout ByteStream<Source>) throws(WasmParserError) -> NameMap {
         var nameMap: NameMap = [:]
-        _ = try stream.parseVector { () throws(WasmParserError) in
+        _ = try stream.parseVector { (stream) throws(WasmParserError) in
             let index = try stream.parseUnsigned(UInt32.self)
             let name = try stream.parseName()
             nameMap[index] = name
@@ -1273,11 +1329,11 @@ public struct NameSectionParser<Stream: ByteStream> {
         return nameMap
     }
 
-    func parseIndirectNameMap() throws(WasmParserError) -> [UInt32: NameMap] {
+    static func parseIndirectNameMap(stream: inout ByteStream<Source>) throws(WasmParserError) -> [UInt32: NameMap] {
         var map: [UInt32: NameMap] = [:]
-        _ = try stream.parseVector { () throws(WasmParserError) in
+        _ = try stream.parseVector { (stream) throws(WasmParserError) in
             let outerIndex = try stream.parseUnsigned(UInt32.self)
-            map[outerIndex] = try parseNameMap()
+            map[outerIndex] = try parseNameMap(stream: &stream)
         }
         return map
     }

--- a/Tests/WATTests/EncoderTests.swift
+++ b/Tests/WATTests/EncoderTests.swift
@@ -391,8 +391,8 @@ struct EncoderTests {
             customSections.append(section)
         }
         let nameSection = customSections.first(where: { $0.name == "name" })
-        let nameParser = NameSectionParser(
-            stream: StaticByteStream(bytes: nameSection?.bytes ?? [])
+        var nameParser = NameSectionParser(
+            stream: StaticByteStreamSource(bytes: nameSection?.bytes ?? [])
         )
         let names = try nameParser.parseAll()
         #expect(names.count == 1)
@@ -435,8 +435,8 @@ struct EncoderTests {
             }
         }
         let sectionBytes = Array(nameBytes ?? [])
-        let nameParser = NameSectionParser(
-            stream: StaticByteStream(bytes: sectionBytes)
+        var nameParser = NameSectionParser(
+            stream: StaticByteStreamSource(bytes: sectionBytes)
         )
         let parsed = try nameParser.parseAll()
         #expect(parsed.count == 10)

--- a/Tests/WasmParserTests/LEBTests.swift
+++ b/Tests/WasmParserTests/LEBTests.swift
@@ -56,14 +56,14 @@ import Testing
 
 extension FixedWidthInteger where Self: UnsignedInteger {
     fileprivate init(LEB bytes: [UInt8]) throws {
-        let stream = StaticByteStream(bytes: bytes)
-        self = try decodeLEB128(stream: stream)
+        var stream = ByteStream(StaticByteStreamSource(bytes: bytes))
+        self = try decodeLEB128(stream: &stream)
     }
 }
 
 extension FixedWidthInteger where Self: RawSignedInteger {
     fileprivate init(LEB bytes: [UInt8]) throws {
-        let stream = StaticByteStream(bytes: bytes)
-        self = try decodeLEB128(stream: stream)
+        var stream = ByteStream(StaticByteStreamSource(bytes: bytes))
+        self = try decodeLEB128(stream: &stream)
     }
 }

--- a/Utilities/Sources/WasmGen.swift
+++ b/Utilities/Sources/WasmGen.swift
@@ -546,7 +546,7 @@ enum WasmGen {
             var offset: Int { get }
 
             /// Claim the next byte to be decoded
-            @inlinable func claimNextByte() throws(WasmParserError) -> UInt8
+            @inlinable mutating func claimNextByte() throws(WasmParserError) -> UInt8
 
             /// Throw an error due to unknown opcode.
             func throwUnknown(_ opcode: [UInt8]) throws(WasmParserError) -> Never


### PR DESCRIPTION
Introduce a ByteStream struct that owns the cursor and out-of-range policy, and reduce StaticByteStream/FileHandleStream to cursor-agnostic ByteStreamSource providers returning nil for OOB reads. Parse operations move to a ByteStream extension so vector-parsing closures avoid overlapping exclusive access.

This is a preliminary step toward Span-based zero-copy parsing.