### PR TITLE
Fix debugger to attribute breakpoint stops correctly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -355,6 +355,19 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
             exclude: ["LICENSE.txt"],
             swiftSettings: swiftSettings
         ),
+        .testTarget(
+            name: "WasmKitGDBHandlerTests",
+            dependencies: [
+                "WasmKitGDBHandler",
+                "GDBRemoteProtocol",
+                "WAT",
+                "WasmKit",
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "SystemPackage", package: "swift-system"),
+            ],
+            swiftSettings: swiftSettings
+        ),
     ])
 
     cliCommandsTarget.dependencies.append(contentsOf: [

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -60,6 +60,11 @@
         private var memoryView: DebuggerMemoryView
         private let wasi: WASIBridgeToHost
 
+        // Requested and resolved addresses diverge when the requested address lands on an elided
+        // instruction (e.g. local.get) that resolves forward; the host expects stop replies at the
+        // address it set the breakpoint on, not the resolved one.
+        private var resolvedToRequestedBreakpoint = [Int: Int]()
+
         package init(
             moduleFilePath: FilePath,
             engineConfiguration: EngineConfiguration,
@@ -128,11 +133,13 @@
                 ]
                 switch self.debugger.state {
                 case .stoppedAtBreakpoint(let breakpoint):
-                    let pc = breakpoint.wasmPc
+                    let requested = self.resolvedToRequestedBreakpoint[breakpoint.wasmPc]
+                    let pc = requested ?? breakpoint.wasmPc
                     let pcInHostAddressSpace = UInt64(pc) + DebuggerMemoryView.executableCodeOffset
                     result.append(("thread-pcs", self.hexDump(pcInHostAddressSpace, endianness: .big)))
                     result.append(("00", self.hexDump(pcInHostAddressSpace, endianness: .little)))
-                    result.append(("reason", "trace"))
+                    // "breakpoint" only at a host-set site; step/entrypoint landings are "trace".
+                    result.append(("reason", requested != nil ? "breakpoint" : "trace"))
                     return .keyValuePairs(result)
 
                 case .entrypointReturned(let values):
@@ -302,25 +309,29 @@
                 throw Error.killRequestReceived
 
             case .insertSoftwareBreakpoint:
-                try self.debugger.enableBreakpoint(
-                    address: Int(
-                        self.firstHexArgument(
-                            argumentsString: command.arguments,
-                            separator: ",",
-                            endianness: .big
-                        ) - DebuggerMemoryView.executableCodeOffset)
-                )
+                let requested = Int(
+                    try self.firstHexArgument(
+                        argumentsString: command.arguments,
+                        separator: ",",
+                        endianness: .big
+                    ) - DebuggerMemoryView.executableCodeOffset)
+                let resolved = try self.debugger.enableBreakpoint(address: requested)
+                self.resolvedToRequestedBreakpoint[resolved] = requested
                 responseKind = .ok
 
             case .removeSoftwareBreakpoint:
-                try self.debugger.disableBreakpoint(
-                    address: Int(
-                        self.firstHexArgument(
-                            argumentsString: command.arguments,
-                            separator: ",",
-                            endianness: .big
-                        ) - DebuggerMemoryView.executableCodeOffset)
-                )
+                let requested = Int(
+                    try self.firstHexArgument(
+                        argumentsString: command.arguments,
+                        separator: ",",
+                        endianness: .big
+                    ) - DebuggerMemoryView.executableCodeOffset)
+                if let resolved = self.resolvedToRequestedBreakpoint.first(where: { $0.value == requested })?.key {
+                    try self.debugger.disableBreakpoint(address: resolved)
+                    self.resolvedToRequestedBreakpoint[resolved] = nil
+                } else {
+                    try self.debugger.disableBreakpoint(address: requested)
+                }
                 responseKind = .ok
 
             case .wasmLocal:


### PR DESCRIPTION
The handler reported every stop as `reason:trace` at the resolved instruction, so LLDB mapped hits to `eStopReasonTrace` and never attributed them to a breakpoint. It now tracks each host-requested address, replies with `reason:breakpoint` at that address on a real hit while keeping step and entrypoint landings as `trace`, and removes breakpoints at their resolved address. Added a `WasmKitGDBHandlerTests` target covering the stop reason, reported address, and removal.