### PR TITLE
Basic multi-memory proposal support

### DIFF
--- a/Sources/WAT/BinaryEncoding/BinaryInstructionEncoder.swift
+++ b/Sources/WAT/BinaryEncoding/BinaryInstructionEncoder.swift
@@ -35,6 +35,7 @@ protocol BinaryInstructionEncoder: InstructionVisitor {
     mutating func encodeImmediates(value: Int64) throws(VisitorError)
     mutating func encodeImmediates(value: V128) throws(VisitorError)
     mutating func encodeImmediates(blockType: BlockType, tryCatch: TryCatch) throws(VisitorError)
+    mutating func encodeImmediates(dataIndex: UInt32, memory: UInt32) throws(VisitorError)
     mutating func encodeImmediates(dstMem: UInt32, srcMem: UInt32) throws(VisitorError)
     mutating func encodeImmediates(dstTable: UInt32, srcTable: UInt32) throws(VisitorError)
     mutating func encodeImmediates(elemIndex: UInt32, table: UInt32) throws(VisitorError)
@@ -405,9 +406,9 @@ extension BinaryInstructionEncoder {
 
         try encodeInstruction(opcode)
     }
-    mutating func visitMemoryInit(dataIndex: UInt32) throws(VisitorError) {
+    mutating func visitMemoryInit(dataIndex: UInt32, memory: UInt32) throws(VisitorError) {
         try encodeInstruction([0xFC, 0x08])
-        try encodeImmediates(dataIndex: dataIndex)
+        try encodeImmediates(dataIndex: dataIndex, memory: memory)
     }
     mutating func visitDataDrop(dataIndex: UInt32) throws(VisitorError) {
         try encodeInstruction([0xFC, 0x09])

--- a/Sources/WAT/BinaryEncoding/Encoder.swift
+++ b/Sources/WAT/BinaryEncoding/Encoder.swift
@@ -503,12 +503,6 @@ struct ExpressionEncoder: BinaryInstructionEncoder {
     }
 
     // MARK: Special instructions
-    mutating func visitMemoryInit(dataIndex: UInt32) {
-        encodeInstruction([0xFC, 0x08])
-        encodeImmediates(dataIndex: dataIndex)
-        encodeByte(0x00)  // reserved value
-    }
-
     mutating func visitTypedSelect(type: ValueType) {
         encodeInstruction([0x1C])
         encodeByte(0x01)  // number of result types
@@ -531,6 +525,12 @@ struct ExpressionEncoder: BinaryInstructionEncoder {
     mutating func encodeImmediates(dataIndex: UInt32) {
         hasDataSegmentInstruction = true
         encodeUnsigned(dataIndex)
+    }
+    mutating func encodeImmediates(dataIndex: UInt32, memory: UInt32) {
+        // For memory 0, encoding the memory index yields the single 0x00 the pre-multi-memory reserved byte produced.
+        hasDataSegmentInstruction = true
+        encodeUnsigned(dataIndex)
+        encodeUnsigned(memory)
     }
     mutating func encodeImmediates(elemIndex: UInt32) { encodeUnsigned(elemIndex) }
     mutating func encodeImmediates(functionIndex: UInt32) { encodeUnsigned(functionIndex) }

--- a/Sources/WAT/ParseTextInstruction.swift
+++ b/Sources/WAT/ParseTextInstruction.swift
@@ -313,8 +313,8 @@ func parseTextInstruction<V: InstructionVisitor>(
     case "i64.extend16_s": return { visitor throws(V.VisitorError) in return try visitor.visitUnary(.i64Extend16S) }
     case "i64.extend32_s": return { visitor throws(V.VisitorError) in return try visitor.visitUnary(.i64Extend32S) }
     case "memory.init":
-        let (dataIndex) = try expressionParser.visitMemoryInit(wat: &wat)
-        return { visitor throws(V.VisitorError) in return try visitor.visitMemoryInit(dataIndex: dataIndex) }
+        let (dataIndex, memory) = try expressionParser.visitMemoryInit(wat: &wat)
+        return { visitor throws(V.VisitorError) in return try visitor.visitMemoryInit(dataIndex: dataIndex, memory: memory) }
     case "data.drop":
         let (dataIndex) = try expressionParser.visitDataDrop(wat: &wat)
         return { visitor throws(V.VisitorError) in return try visitor.visitDataDrop(dataIndex: dataIndex) }

--- a/Sources/WAT/Parser/ExpressionParser.swift
+++ b/Sources/WAT/Parser/ExpressionParser.swift
@@ -156,7 +156,7 @@ struct ExpressionParser<Visitor: InstructionVisitor> where Visitor.VisitorError 
             return nil
         }
 
-        // Relaxed-SIMD `(either <result>…)`: a non-deterministic expectation matching any candidate.
+        // Relaxed-SIMD `(either <result>...)`: a non-deterministic expectation matching any candidate.
         if try parser.takeParenBlockStart("either") {
             var candidates: [WastExpectValue] = []
             while let candidate = try parseWastExpectValue() {
@@ -936,8 +936,23 @@ extension ExpressionParser {
     mutating func visitRefFunc(wat: inout Wat) throws(WatParserError) -> UInt32 {
         return try functionIndex(wat: &wat)
     }
-    mutating func visitMemoryInit(wat: inout Wat) throws(WatParserError) -> UInt32 {
-        return try dataIndex(wat: &wat)
+    mutating func visitMemoryInit(wat: inout Wat) throws(WatParserError) -> (dataIndex: UInt32, memory: UInt32) {
+        // Two styles; when both indices are present the memory index is first:
+        //   memory.init $dataidx
+        //   memory.init $memidx $dataidx
+        let dataUse: Parser.IndexOrId
+        let memoryUse: Parser.IndexOrId?
+        let use1 = try parser.expectIndexOrId()
+        if let use2 = try parser.takeIndexOrId() {
+            dataUse = use2
+            memoryUse = use1
+        } else {
+            dataUse = use1
+            memoryUse = nil
+        }
+        let memory = try memoryUse.map { use throws(WatParserError) in UInt32(try wat.memories.resolve(use: use).index) } ?? 0
+        let dataIndex = UInt32(try wat.data.resolve(use: dataUse).index)
+        return (dataIndex, memory)
     }
     mutating func visitDataDrop(wat: inout Wat) throws(WatParserError) -> UInt32 {
         return try dataIndex(wat: &wat)

--- a/Sources/WAT/Parser/WastParser.swift
+++ b/Sources/WAT/Parser/WastParser.swift
@@ -26,7 +26,8 @@ struct WastParser {
                 let location = originalParser.lexer.location()
                 return .module(
                     ModuleDirective(
-                        source: .text(try parseWAT(&originalParser, features: features)), id: nil, location: location
+                        source: .text(try parseWAT(&originalParser, features: features)), id: nil, location: location,
+                        isModuleDefinition: false
                     ))
             }
             throw WatParserError("unexpected wast directive token", location: parser.lexer.location())
@@ -223,7 +224,7 @@ public enum WastExpectValue {
     /// Corresponds to `f64.const nan:arithmetic` in WAST.
     case f64ArithmeticNaN
     /// A relaxed-SIMD non-deterministic expectation: the result matches if it equals any candidate.
-    /// Corresponds to `(either <result>…)` in WAST.
+    /// Corresponds to `(either <result>...)` in WAST.
     indirect case either([WastExpectValue])
 }
 
@@ -327,13 +328,16 @@ public struct ModuleDirective {
     public let id: String?
     /// The location of the module in the source
     public let location: Location
+    /// The `(module definition ...)` form decodes and validates without instantiating.
+    public let isModuleDefinition: Bool
 
     static func parse(wastParser: inout WastParser) throws(WatParserError) -> ModuleDirective {
         let location = wastParser.parser.lexer.location()
         try wastParser.parser.expectKeyword("module")
+        let isModuleDefinition = try wastParser.parser.takeKeyword("definition")
         let id = try wastParser.parser.takeId()
         let source = try ModuleSource.parse(wastParser: &wastParser)
-        return ModuleDirective(source: source, id: id?.value, location: location)
+        return ModuleDirective(source: source, id: id?.value, location: location, isModuleDefinition: isModuleDefinition)
     }
 }
 

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -466,7 +466,8 @@ struct MemoryEntity: ~Copyable {
     static let pageSize = 64 * 1024
 
     static func maxPageCount(isMemory64: Bool) -> UInt64 {
-        isMemory64 ? UInt64.max : UInt64(1 << 32) / UInt64(pageSize)
+        // memory64: 2^64 bytes / pageSize = 2^48 pages.
+        isMemory64 ? (1 << 48) : UInt64(1 << 32) / UInt64(pageSize)
     }
 
     private struct MallocStorage {
@@ -825,6 +826,37 @@ extension MemoryEntity: ValidatableEntity {
 }
 
 typealias InternalMemory = EntityHandle<MemoryEntity>
+
+extension InternalMemory {
+    /// Implements cross-memory `memory.copy` (multi-memory) between two memory handles.
+    func copy(from sourceMemory: InternalMemory, sourceOffset: UInt64, destOffset: UInt64, count: UInt64) throws {
+        // Aliased handle: two exclusive `withValue` accesses would overlap, so dispatch to the
+        // overlap-safe intra-memory copy under one access.
+        if self == sourceMemory {
+            try withValue { try $0.copy(from: sourceOffset, to: destOffset, count: count) }
+            return
+        }
+        // Distinct memory handles cannot overlap, so `copyMemory`'s non-overlap requirement holds.
+        try withValue { destination in
+            try sourceMemory.withValue { source in
+                let (destinationEnd, destinationOverflow) = destOffset.addingReportingOverflow(count)
+                let (sourceEnd, sourceOverflow) = sourceOffset.addingReportingOverflow(count)
+                guard !destinationOverflow, destinationEnd <= destination.byteCount,
+                    !sourceOverflow, sourceEnd <= source.byteCount
+                else {
+                    throw Trap(.memoryOutOfBounds)
+                }
+                let count = Int(count)
+                guard count > 0 else { return }
+                guard let destinationBase = destination.baseAddress,
+                    let sourceBase = source.baseAddress
+                else { return }
+                destinationBase.advanced(by: Int(destOffset))
+                    .copyMemory(from: sourceBase.advanced(by: Int(sourceOffset)), byteCount: count)
+            }
+        }
+    }
+}
 
 /// A WebAssembly `memory` instance.
 /// > Note:

--- a/Sources/WasmKit/Execution/Instructions/Instruction.swift
+++ b/Sources/WasmKit/Execution/Instructions/Instruction.swift
@@ -751,14 +751,15 @@ extension Instruction {
         var destOffset: VReg
         var sourceOffset: VReg
         var size: VReg
+        var memory: UInt32
         @inline(__always) static func load(from pc: inout Pc) -> Self {
             let (segmentIndex, destOffset, sourceOffset) = pc.read((UInt32, VReg, VReg).self)
-            let (size, _, _, _, _, _, _) = pc.read((VReg, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8).self)
-            return Self(segmentIndex: segmentIndex, destOffset: destOffset, sourceOffset: sourceOffset, size: size)
+            let (size, memory) = pc.read((VReg, UInt32).self)
+            return Self(segmentIndex: segmentIndex, destOffset: destOffset, sourceOffset: sourceOffset, size: size, memory: memory)
         }
         @inline(__always) static func emit(to emitSlot: ((Self) -> CodeSlot) -> Void) {
             emitSlot { unsafeBitCast(($0.segmentIndex, $0.destOffset, $0.sourceOffset) as (UInt32, VReg, VReg), to: CodeSlot.self) }
-            emitSlot { unsafeBitCast(($0.size, 0, 0, 0, 0, 0, 0) as (VReg, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8), to: CodeSlot.self) }
+            emitSlot { unsafeBitCast(($0.size, $0.memory) as (VReg, UInt32), to: CodeSlot.self) }
         }
     }
 
@@ -777,12 +778,16 @@ extension Instruction {
         var destOffset: VReg
         var sourceOffset: VReg
         var size: LVReg
+        var destMemory: UInt32
+        var sourceMemory: UInt32
         @inline(__always) static func load(from pc: inout Pc) -> Self {
             let (destOffset, sourceOffset, size) = pc.read((VReg, VReg, LVReg).self)
-            return Self(destOffset: destOffset, sourceOffset: sourceOffset, size: size)
+            let (destMemory, sourceMemory) = pc.read((UInt32, UInt32).self)
+            return Self(destOffset: destOffset, sourceOffset: sourceOffset, size: size, destMemory: destMemory, sourceMemory: sourceMemory)
         }
         @inline(__always) static func emit(to emitSlot: ((Self) -> CodeSlot) -> Void) {
             emitSlot { unsafeBitCast(($0.destOffset, $0.sourceOffset, $0.size) as (VReg, VReg, LVReg), to: CodeSlot.self) }
+            emitSlot { unsafeBitCast(($0.destMemory, $0.sourceMemory) as (UInt32, UInt32), to: CodeSlot.self) }
         }
     }
 
@@ -790,12 +795,15 @@ extension Instruction {
         var destOffset: VReg
         var value: VReg
         var size: LVReg
+        var memory: UInt32
         @inline(__always) static func load(from pc: inout Pc) -> Self {
             let (destOffset, value, size) = pc.read((VReg, VReg, LVReg).self)
-            return Self(destOffset: destOffset, value: value, size: size)
+            let (memory, _, _, _, _) = pc.read((UInt32, UInt8, UInt8, UInt8, UInt8).self)
+            return Self(destOffset: destOffset, value: value, size: size, memory: memory)
         }
         @inline(__always) static func emit(to emitSlot: ((Self) -> CodeSlot) -> Void) {
             emitSlot { unsafeBitCast(($0.destOffset, $0.value, $0.size) as (VReg, VReg, LVReg), to: CodeSlot.self) }
+            emitSlot { unsafeBitCast(($0.memory, 0, 0, 0, 0) as (UInt32, UInt8, UInt8, UInt8, UInt8), to: CodeSlot.self) }
         }
     }
 

--- a/Sources/WasmKit/Execution/Instructions/Memory.swift
+++ b/Sources/WasmKit/Execution/Instructions/Memory.swift
@@ -66,7 +66,7 @@ extension Execution {
     }
     mutating func memoryInit(sp: Sp, immediate: Instruction.MemoryInitOperand) throws {
         let instance = currentInstance(sp: sp)
-        let memory = instance.memories[0]
+        let memory = instance.memories[Int(immediate.memory)]
         try memory.withValue { memory in
             let segment = instance.dataSegments[Int(immediate.segmentIndex)]
 
@@ -81,17 +81,18 @@ extension Execution {
         segment.withValue { $0.drop() }
     }
     mutating func memoryCopy(sp: Sp, immediate: Instruction.MemoryCopyOperand) throws {
-        let memory = currentInstance(sp: sp).memories[0]
-        try memory.withValue { memory in
-            let isMemory64 = memory.limit.isMemory64
-            let size = sp[immediate.size].asAddressOffset(isMemory64)
-            let source = sp[immediate.sourceOffset].asAddressOffset(isMemory64)
-            let destination = sp[immediate.destOffset].asAddressOffset(isMemory64)
-            try memory.copy(from: source, to: destination, count: size)
-        }
+        let instance = currentInstance(sp: sp)
+        let destinationMemory = instance.memories[Int(immediate.destMemory)]
+        let sourceMemory = instance.memories[Int(immediate.sourceMemory)]
+        let destIsMemory64 = destinationMemory.withValue { $0.limit.isMemory64 }
+        let sourceIsMemory64 = sourceMemory.withValue { $0.limit.isMemory64 }
+        let size = sp[immediate.size].asAddressOffset(destIsMemory64 || sourceIsMemory64)
+        let source = sp[immediate.sourceOffset].asAddressOffset(sourceIsMemory64)
+        let destination = sp[immediate.destOffset].asAddressOffset(destIsMemory64)
+        try destinationMemory.copy(from: sourceMemory, sourceOffset: source, destOffset: destination, count: size)
     }
     mutating func memoryFill(sp: Sp, immediate: Instruction.MemoryFillOperand) throws {
-        let memory = currentInstance(sp: sp).memories[0]
+        let memory = currentInstance(sp: sp).memories[Int(immediate.memory)]
         try memory.withValue { memoryInstance in
             let isMemory64 = memoryInstance.limit.isMemory64
             let copyCounter = Int(sp[immediate.size].asAddressOffset(isMemory64))

--- a/Sources/WasmKit/Module.swift
+++ b/Sources/WasmKit/Module.swift
@@ -161,6 +161,12 @@ public struct Module: Sendable {
         Instance(handle: try self.instantiateHandle(store: store, imports: imports), store: store)
     }
 
+    /// Validate this module without instantiating it, for the WAST `(module definition ...)`
+    /// directive that asserts validity without building an instance.
+    package func validate() throws(WasmKitError) {
+        try ModuleValidator(module: self).validate()
+    }
+
     #if WasmDebuggingSupport
         /// Instantiate this module with the given imports.
         ///

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -2811,9 +2811,9 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         try visitConversion(from, to, instruction)
     }
 
-    mutating func visitMemoryInit(dataIndex: UInt32) throws(WasmKitError) -> Output {
+    mutating func visitMemoryInit(dataIndex: UInt32, memory: UInt32) throws(WasmKitError) -> Output {
         try self.validator.validateDataSegment(dataIndex)
-        let addressType = try module.addressType(memoryIndex: 0)
+        let addressType = try module.addressType(memoryIndex: memory)
         try pop3Emit((.i32, .i32, addressType)) { values, stack in
             let (size, sourceOffset, destOffset) = values
             return .memoryInit(
@@ -2821,7 +2821,8 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
                     segmentIndex: dataIndex,
                     destOffset: destOffset,
                     sourceOffset: sourceOffset,
-                    size: size
+                    size: size,
+                    memory: memory
                 )
             )
         }
@@ -2831,35 +2832,42 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         emit(.memoryDataDrop(Instruction.MemoryDataDropOperand(segmentIndex: dataIndex)))
     }
     mutating func visitMemoryCopy(dstMem: UInt32, srcMem: UInt32) throws(WasmKitError) -> Output {
-        //     C.mems[0] = it limits
-        // -----------------------------
-        // C ⊦ memory.fill : [it i32 it] → []
+        //   C.mems[d] = iN limits   C.mems[s] = iM limits    K = min {N, M}
+        // -----------------------------------------------------------------------------
+        // C |- memory.copy d s : [iN iM iK] -> []
         // https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md
-        let addressType = try module.addressType(memoryIndex: 0)
-        try pop3Emit((addressType, addressType, addressType)) { values, stack in
+        let destIsMemory64 = try module.isMemory64(memoryIndex: dstMem)
+        let sourceIsMemory64 = try module.isMemory64(memoryIndex: srcMem)
+        let lengthIsMemory64 = destIsMemory64 && sourceIsMemory64
+        try pop3Emit(
+            (
+                .address(isMemory64: lengthIsMemory64),
+                .address(isMemory64: sourceIsMemory64),
+                .address(isMemory64: destIsMemory64)
+            )
+        ) { values, stack in
             let (size, sourceOffset, destOffset) = values
             return .memoryCopy(
                 Instruction.MemoryCopyOperand(
                     destOffset: destOffset,
                     sourceOffset: sourceOffset,
-                    size: LVReg(size)
+                    size: LVReg(size),
+                    destMemory: dstMem,
+                    sourceMemory: srcMem
                 )
             )
         }
     }
     mutating func visitMemoryFill(memory: UInt32) throws(WasmKitError) -> Output {
-        //     C.mems[0] = it limits
-        // -----------------------------
-        // C ⊦ memory.fill : [it i32 it] → []
-        // https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md
-        let addressType = try module.addressType(memoryIndex: 0)
+        let addressType = try module.addressType(memoryIndex: memory)
         try pop3Emit((addressType, .i32, addressType)) { values, stack in
             let (size, value, destOffset) = values
             return .memoryFill(
                 Instruction.MemoryFillOperand(
                     destOffset: destOffset,
                     value: value,
-                    size: LVReg(size)
+                    size: LVReg(size),
+                    memory: memory
                 )
             )
         }

--- a/Sources/WasmKit/Validator.swift
+++ b/Sources/WasmKit/Validator.swift
@@ -73,7 +73,7 @@ struct ModuleValidator {
     }
 
     func validate() throws(WasmKitError) {
-        if module.memoryTypes.count > 1 {
+        if module.memoryTypes.count > 1 && !module.features.contains(.multiMemory) {
             throw WasmKitError(message: .multipleMemoriesNotPermitted)
         }
         // Multiple tables are allowed with reference types feature

--- a/Sources/WasmParser/BinaryInstructionDecoder.swift
+++ b/Sources/WasmParser/BinaryInstructionDecoder.swift
@@ -79,7 +79,7 @@ protocol BinaryInstructionDecoder {
     /// Decode `br_on_non_null` immediates
     @inlinable mutating func visitBrOnNonNull() throws(WasmParserError) -> UInt32
     /// Decode `memory.init` immediates
-    @inlinable mutating func visitMemoryInit() throws(WasmParserError) -> UInt32
+    @inlinable mutating func visitMemoryInit() throws(WasmParserError) -> (dataIndex: UInt32, memory: UInt32)
     /// Decode `data.drop` immediates
     @inlinable mutating func visitDataDrop() throws(WasmParserError) -> UInt32
     /// Decode `memory.copy` immediates
@@ -684,8 +684,8 @@ func parseBinaryInstruction(
         case 0x07:
             return .conversion(.i64TruncSatF64U)
         case 0x08:
-            let (dataIndex) = try decoder.visitMemoryInit()
-            return .memoryInit(dataIndex: dataIndex)
+            let (dataIndex, memory) = try decoder.visitMemoryInit()
+            return .memoryInit(dataIndex: dataIndex, memory: memory)
         case 0x09:
             let (dataIndex) = try decoder.visitDataDrop()
             return .dataDrop(dataIndex: dataIndex)

--- a/Sources/WasmParser/InstructionVisitor.swift
+++ b/Sources/WasmParser/InstructionVisitor.swift
@@ -496,7 +496,7 @@ public enum Instruction: Equatable, Sendable {
     case `unary`(Instruction.Unary)
     case `binary`(Instruction.Binary)
     case `conversion`(Instruction.Conversion)
-    case `memoryInit`(dataIndex: UInt32)
+    case `memoryInit`(dataIndex: UInt32, memory: UInt32)
     case `dataDrop`(dataIndex: UInt32)
     case `memoryCopy`(dstMem: UInt32, srcMem: UInt32)
     case `memoryFill`(memory: UInt32)
@@ -623,7 +623,7 @@ extension AnyInstructionVisitor {
     public mutating func visitUnary(_ unary: Instruction.Unary) throws(VisitorError) { return try self.visit(.unary(unary)) }
     public mutating func visitBinary(_ binary: Instruction.Binary) throws(VisitorError) { return try self.visit(.binary(binary)) }
     public mutating func visitConversion(_ conversion: Instruction.Conversion) throws(VisitorError) { return try self.visit(.conversion(conversion)) }
-    public mutating func visitMemoryInit(dataIndex: UInt32) throws(VisitorError) { return try self.visit(.memoryInit(dataIndex: dataIndex)) }
+    public mutating func visitMemoryInit(dataIndex: UInt32, memory: UInt32) throws(VisitorError) { return try self.visit(.memoryInit(dataIndex: dataIndex, memory: memory)) }
     public mutating func visitDataDrop(dataIndex: UInt32) throws(VisitorError) { return try self.visit(.dataDrop(dataIndex: dataIndex)) }
     public mutating func visitMemoryCopy(dstMem: UInt32, srcMem: UInt32) throws(VisitorError) { return try self.visit(.memoryCopy(dstMem: dstMem, srcMem: srcMem)) }
     public mutating func visitMemoryFill(memory: UInt32) throws(VisitorError) { return try self.visit(.memoryFill(memory: memory)) }
@@ -802,7 +802,7 @@ public protocol InstructionVisitor: ~Copyable {
     /// Visiting `conversion` category instruction.
     mutating func visitConversion(_: Instruction.Conversion) throws(VisitorError)
     /// Visiting `memory.init` instruction.
-    mutating func visitMemoryInit(dataIndex: UInt32) throws(VisitorError)
+    mutating func visitMemoryInit(dataIndex: UInt32, memory: UInt32) throws(VisitorError)
     /// Visiting `data.drop` instruction.
     mutating func visitDataDrop(dataIndex: UInt32) throws(VisitorError)
     /// Visiting `memory.copy` instruction.
@@ -997,7 +997,7 @@ extension InstructionVisitor where Self: ~Copyable {
         case let .unary(unary): return try visitUnary(unary)
         case let .binary(binary): return try visitBinary(binary)
         case let .conversion(conversion): return try visitConversion(conversion)
-        case let .memoryInit(dataIndex): return try visitMemoryInit(dataIndex: dataIndex)
+        case let .memoryInit(dataIndex, memory): return try visitMemoryInit(dataIndex: dataIndex, memory: memory)
         case let .dataDrop(dataIndex): return try visitDataDrop(dataIndex: dataIndex)
         case let .memoryCopy(dstMem, srcMem): return try visitMemoryCopy(dstMem: dstMem, srcMem: srcMem)
         case let .memoryFill(memory): return try visitMemoryFill(memory: memory)
@@ -1121,7 +1121,7 @@ extension InstructionVisitor where Self: ~Copyable {
     public mutating func visitUnary(_ unary: Instruction.Unary) throws(VisitorError) {}
     public mutating func visitBinary(_ binary: Instruction.Binary) throws(VisitorError) {}
     public mutating func visitConversion(_ conversion: Instruction.Conversion) throws(VisitorError) {}
-    public mutating func visitMemoryInit(dataIndex: UInt32) throws(VisitorError) {}
+    public mutating func visitMemoryInit(dataIndex: UInt32, memory: UInt32) throws(VisitorError) {}
     public mutating func visitDataDrop(dataIndex: UInt32) throws(VisitorError) {}
     public mutating func visitMemoryCopy(dstMem: UInt32, srcMem: UInt32) throws(VisitorError) {}
     public mutating func visitMemoryFill(memory: UInt32) throws(VisitorError) {}

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -159,11 +159,14 @@ public struct WasmFeatureSet: OptionSet, Sendable {
     /// The WebAssembly exception handling proposal
     @_alwaysEmitIntoClient
     public static var exceptionHandling: WasmFeatureSet { WasmFeatureSet(rawValue: 1 << 5) }
+    /// The WebAssembly multi-memory proposal
+    @_alwaysEmitIntoClient
+    public static var multiMemory: WasmFeatureSet { WasmFeatureSet(rawValue: 1 << 6) }
 
     /// The default feature set
     public static let `default`: WasmFeatureSet = [.referenceTypes, .exceptionHandling]
     /// The feature set with all features enabled
-    public static let all: WasmFeatureSet = [.memory64, .referenceTypes, .threads, .tailCall, .simd, .exceptionHandling]
+    public static let all: WasmFeatureSet = [.memory64, .referenceTypes, .threads, .tailCall, .simd, .exceptionHandling, .multiMemory]
 }
 
 /// > Note:
@@ -531,6 +534,10 @@ extension Parser {
 /// <https://webassembly.github.io/spec/core/binary/instructions.html>
 extension Parser: BinaryInstructionDecoder {
     @inlinable mutating func parseMemoryIndex() throws(WasmParserError) -> UInt32 {
+        // Pre-multi-memory, the spec encodes this as a reserved zero byte, not a memory index.
+        if features.contains(.multiMemory) {
+            return try parseUnsigned()
+        }
         let zero = try stream.consumeAny()
         guard zero == 0x00 else {
             throw makeError(.zeroExpected(actual: zero))
@@ -665,10 +672,10 @@ extension Parser: BinaryInstructionDecoder {
     }
 
     @inlinable mutating func visitRefFunc() throws(WasmParserError) -> UInt32 { try parseUnsigned() }
-    @inlinable mutating func visitMemoryInit() throws(WasmParserError) -> UInt32 {
+    @inlinable mutating func visitMemoryInit() throws(WasmParserError) -> (dataIndex: UInt32, memory: UInt32) {
         let dataIndex: DataIndex = try parseUnsigned()
-        _ = try parseMemoryIndex()
-        return dataIndex
+        let memory = try parseMemoryIndex()
+        return (dataIndex, memory)
     }
 
     @inlinable mutating func visitDataDrop() throws(WasmParserError) -> UInt32 {
@@ -676,17 +683,13 @@ extension Parser: BinaryInstructionDecoder {
     }
 
     @inlinable mutating func visitMemoryCopy() throws(WasmParserError) -> (dstMem: UInt32, srcMem: UInt32) {
-        _ = try parseMemoryIndex()
-        _ = try parseMemoryIndex()
-        return (0, 0)
+        let destination = try parseMemoryIndex()
+        let source = try parseMemoryIndex()
+        return (destination, source)
     }
 
     @inlinable mutating func visitMemoryFill() throws(WasmParserError) -> UInt32 {
-        let zero = try stream.consumeAny()
-        guard zero == 0x00 else {
-            throw makeError(.zeroExpected(actual: zero))
-        }
-        return 0
+        try parseMemoryIndex()
     }
 
     @inlinable mutating func visitTableInit() throws(WasmParserError) -> (elemIndex: UInt32, table: UInt32) {

--- a/Tests/WATTests/ParserTests.swift
+++ b/Tests/WATTests/ParserTests.swift
@@ -83,6 +83,64 @@ struct ParserTests {
     }
 
     @Test
+    func parseModuleDefinitionDoesNotThrow() throws {
+        #expect(throws: Never.self) {
+            _ = try self.parseWast("(module definition (memory 65536))")
+        }
+    }
+
+    @Test
+    func parseModuleDefinitionBare() throws {
+        let m = try #require(try parseModule("(module definition (memory 65536))"))
+        #expect(m.isModuleDefinition)
+        #expect(m.id == nil)
+        #expect({ if case .text = m.source { return true } else { return false } }())
+    }
+
+    @Test
+    func parseModuleDefinitionNamed() throws {
+        // Id appears AFTER `definition` (instance.wast:3/109 shape).
+        let m = try #require(try parseModule("(module definition $M (memory 0))"))
+        #expect(m.isModuleDefinition)
+        #expect(m.id == "$M")
+    }
+
+    @Test
+    func parseModuleDefinitionBinary() throws {
+        // `definition` with a binary source (exact-func-import.wast:219 shape).
+        let m = try #require(try parseModule(#"(module definition binary "\00asm\01\00\00\00")"#))
+        #expect(m.isModuleDefinition)
+        #expect({ if case .binary(let b) = m.source { return b == [0, 97, 115, 109, 1, 0, 0, 0] } else { return false } }())
+    }
+
+    @Test
+    func parsePlainModuleIsNotDefinition() throws {
+        let m = try #require(try parseModule("(module (memory 1))"))
+        #expect(!m.isModuleDefinition)
+    }
+
+    @Test
+    func parseAssertInvalidWrappedDefinitionThreadsFlag() throws {
+        // The flag must thread through the wrapped construction site. The harness ignores the flag
+        // for assert_invalid, so behavior there is unchanged.
+        let directives = try parseWast(#"(assert_invalid (module definition (memory 65537)) "size")"#)
+        guard case .assertInvalid(let module, _) = try #require(directives.first) else {
+            #expect(Bool(false), "expected assert_invalid directive")
+            return
+        }
+        #expect(module.isModuleDefinition)
+    }
+
+    @Test
+    func parseEitherAssertReturnDoesNotThrow() throws {
+        #expect(throws: Never.self) {
+            _ = try self.parseWast(
+                #"(module (func (export "f") (result v128) (v128.const i32x4 0 0 0 0)))"#
+                    + #"(assert_return (invoke "f") (either (v128.const i32x4 0 0 0 0) (v128.const i32x4 1 0 0 0)))"#)
+        }
+    }
+
+    @Test
     func parseWastModuleSkip() throws {
         let directives = try parseWast(
             #"""

--- a/Tests/WasmKitTests/ExecutionTests.swift
+++ b/Tests/WasmKitTests/ExecutionTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import WAT
+import WasmParser
 
 @testable import WasmKit
 
@@ -30,6 +31,67 @@ struct ExecutionTests {
         let _start = try #require(instance.exports[function: "_start"])
         let results = try _start()
         #expect(results == [.i32(42)])
+    }
+
+    @Test
+    func moduleValidateWithoutInstantiating() throws {
+        // validate() never allocates, so a max-size memory and 0xffff_ffff-entry table pass without OOM.
+        let maxMemory = try parseWasm(bytes: wat2wasm("(module (memory 65536))"))
+        try maxMemory.validate()
+        let maxTable = try parseWasm(bytes: wat2wasm("(module (table 0xffff_ffff funcref))"))
+        try maxTable.validate()
+
+        // The parser does not enforce the page max, so (memory 65537) decodes and only
+        // ModuleValidator.checkMemoryType rejects it.
+        let overMax = try parseWasm(bytes: wat2wasm("(module (memory 65537))"))
+        #expect(throws: WasmKitError.self) { try overMax.validate() }
+
+        // validate() checks the start signature but does not run its body, so this unreachable start never traps.
+        let withStart = try parseWasm(bytes: wat2wasm("(module (func) (func unreachable) (start 1))"))
+        try withStart.validate()
+    }
+
+    @Test
+    func relaxedSimdOpsExecute() throws {
+        // Exercises the 4 relaxed_trunc ops the spectest never runs (i32x4_relaxed_trunc.wast has no
+        // assert_return) plus the dot products. Each func returns 1 iff the op matches its expected vector.
+        let module = try parseWasm(
+            bytes: wat2wasm(
+                #"""
+                (module
+                  (func (export "madd") (result i32)
+                    (i32.and
+                      (i32x4.all_true (f32x4.eq
+                        (f32x4.relaxed_madd (v128.const f32x4 2 0 0 0) (v128.const f32x4 3 0 0 0) (v128.const f32x4 4 0 0 0))
+                        (v128.const f32x4 10 0 0 0)))
+                      (i32x4.all_true (f32x4.eq
+                        (f32x4.relaxed_nmadd (v128.const f32x4 2 0 0 0) (v128.const f32x4 3 0 0 0) (v128.const f32x4 4 0 0 0))
+                        (v128.const f32x4 -2 0 0 0)))))
+                  (func (export "trunc") (result i32)
+                    (i32x4.all_true (i32x4.eq
+                      (i32x4.relaxed_trunc_f32x4_s (v128.const f32x4 1.9 -1.9 0 0))
+                      (v128.const i32x4 1 4294967295 0 0))))
+                  (func (export "dot") (result i32)
+                    (i16x8.all_true (i16x8.eq
+                      (i16x8.relaxed_dot_i8x16_i7x16_s
+                        (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+                        (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15))
+                      (v128.const i16x8 1 13 41 85 145 221 313 421))))
+                  (func (export "dotadd") (result i32)
+                    (i32x4.all_true (i32x4.eq
+                      (i32x4.relaxed_dot_i8x16_i7x16_add_s
+                        (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+                        (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+                        (v128.const i32x4 0 1 2 3))
+                      (v128.const i32x4 14 127 368 737)))))
+                """#
+            )
+        )
+        let instance = try module.instantiate(store: Store(engine: Engine()))
+        for name in ["madd", "trunc", "dot", "dotadd"] {
+            let f = try #require(instance.exports[function: name])
+            #expect(try f() == [.i32(1)], "relaxed-simd \(name) produced wrong result")
+        }
     }
 
     @Test
@@ -143,5 +205,53 @@ struct ExecutionTests {
                     "_start",
                 ])
         }
+    }
+
+    @Test
+    func multiMemoryBulkOpsMutateTheIndexedMemory() throws {
+        // Cross-memory `memory.copy 1 0` is the path no vendored file exercises; verified host-side via memory 1.
+        let features: WasmFeatureSet = [.referenceTypes, .multiMemory]
+        let module = try parseWasm(
+            bytes: wat2wasm(
+                """
+                (module
+                  (memory 1)                  ;; memory 0, copy source
+                  (memory (export "mem") 1)   ;; memory 1, fill/copy/init target
+                  (data (memory 0) (i32.const 0) "\\aa\\bb\\cc\\dd")  ;; active -> memory 0
+                  (data "\\11\\22\\33\\44")                           ;; passive segment 1
+                  (func (export "fillM1")
+                    (memory.fill 1 (i32.const 0) (i32.const 0x07) (i32.const 3)))
+                  (func (export "copyToM1")
+                    (memory.copy 1 0 (i32.const 8) (i32.const 0) (i32.const 4)))
+                  (func (export "initM1")
+                    (memory.init 1 1 (i32.const 16) (i32.const 0) (i32.const 4)))
+                  (func (export "fillOOB")
+                    (memory.fill 1 (i32.const 0) (i32.const 0) (i32.const 0x1_0001))))
+                """,
+                features: features
+            ),
+            features: features
+        )
+        let engine = Engine(configuration: EngineConfiguration(features: features))
+        let store = Store(engine: engine)
+        let instance = try module.instantiate(store: store)
+
+        let fillM1 = try #require(instance.exports[function: "fillM1"])
+        let copyToM1 = try #require(instance.exports[function: "copyToM1"])
+        let initM1 = try #require(instance.exports[function: "initM1"])
+        _ = try fillM1()
+        _ = try copyToM1()
+        _ = try initM1()
+
+        let mem = try #require(instance.exports[memory: "mem"])
+        mem.withUnsafeBufferPointer(offset: 0, count: 24) { buffer in
+            #expect(Array(buffer[0..<3]) == [0x07, 0x07, 0x07])  // memory.fill into memory 1
+            #expect(Array(buffer[8..<12]) == [0xaa, 0xbb, 0xcc, 0xdd])  // cross-memory memory.copy 1 0
+            #expect(Array(buffer[16..<20]) == [0x11, 0x22, 0x33, 0x44])  // memory.init from passive segment 1
+        }
+
+        // The indexed bulk path traps on out-of-bounds just like memory 0.
+        let fillOOB = try #require(instance.exports[function: "fillOOB"])
+        #expect(throws: Trap.self) { _ = try fillOOB() }
     }
 }

--- a/Tests/WasmKitTests/Spectest/TestCase.swift
+++ b/Tests/WasmKitTests/Spectest/TestCase.swift
@@ -221,6 +221,17 @@ extension WastRunContext {
                 return .failed("module could not be parsed: \(error)")
             }
 
+            // `(module definition ...)`: decode and validate WITHOUT instantiating (no allocation, no
+            // start function, no current-instance mutation). A WAST module-linking script directive.
+            if moduleDirective.isModuleDefinition {
+                do {
+                    try module.validate()
+                } catch {
+                    return .failed("module definition could not be validated: \(error)")
+                }
+                return .passed
+            }
+
             do {
                 currentInstance = try instantiate(module: module, name: moduleDirective.id)
             } catch {

--- a/Utilities/Instructions.json
+++ b/Utilities/Instructions.json
@@ -190,7 +190,7 @@
   ["signExtension"       , "i64.extend8_s"                , ["0xC2"]                , []                                                 , "unary"      ],
   ["signExtension"       , "i64.extend16_s"               , ["0xC3"]                , []                                                 , "unary"      ],
   ["signExtension"       , "i64.extend32_s"               , ["0xC4"]                , []                                                 , "unary"      ],
-  ["bulkMemory"          , "memory.init"                  , ["0xFC", "0x08"]        , [["dataIndex", "UInt32"]]                          , null         ],
+  ["bulkMemory"          , "memory.init"                        , ["0xFC", "0x08"]        , [["dataIndex", "UInt32"], ["memory", "UInt32"]]    , null         ],
   ["bulkMemory"          , "data.drop"                    , ["0xFC", "0x09"]        , [["dataIndex", "UInt32"]]                          , null         ],
   ["bulkMemory"          , "memory.copy"                  , ["0xFC", "0x0A"]        , [["dstMem", "UInt32"], ["srcMem", "UInt32"]]       , null         ],
   ["bulkMemory"          , "memory.fill"                  , ["0xFC", "0x0B"]        , [["memory", "UInt32"]]                             , null         ],

--- a/Utilities/Sources/VMSpec/Instruction.swift
+++ b/Utilities/Sources/VMSpec/Instruction.swift
@@ -546,6 +546,7 @@ extension VMGen {
             $0.field(name: "destOffset", type: .VReg)
             $0.field(name: "sourceOffset", type: .VReg)
             $0.field(name: "size", type: .VReg)
+            $0.field(name: "memory", type: .MemoryIndex)
         },
         Instruction(name: "memoryDataDrop", documentation: "WebAssembly Core Instruction `memory.drop`") {
             $0.field(name: "segmentIndex", type: .UInt32)
@@ -554,11 +555,14 @@ extension VMGen {
             $0.field(name: "destOffset", type: .VReg)
             $0.field(name: "sourceOffset", type: .VReg)
             $0.field(name: "size", type: .LVReg)
+            $0.field(name: "destMemory", type: .MemoryIndex)
+            $0.field(name: "sourceMemory", type: .MemoryIndex)
         },
         Instruction(name: "memoryFill", documentation: "WebAssembly Core Instruction `memory.fill`", mayThrow: true) {
             $0.field(name: "destOffset", type: .VReg)
             $0.field(name: "value", type: .VReg)
             $0.field(name: "size", type: .LVReg)
+            $0.field(name: "memory", type: .MemoryIndex)
         },
     ]
 


### PR DESCRIPTION
Add the WebAssembly multi-memory proposal as an opt-in WasmFeatureSet feature. `memory.init`/`copy`/`fill` now carry an explicit memory index through the binary decoder, WAT text parser and encoder, instruction visitor, translator, and runtime; the validator permits multiple memories when `.multiMemory` is set. `memory.copy` supports two distinct memories with per-memory index-type widening. The VM instruction spec is regenerated via VMGen for the new memory-index operands.

Enabling multi-memory for the vendored spec-test suite (which needs a testsuite pin bump) is deferred; default parsing and validation behavior is unchanged.