### PR TITLE
Defensive WIT overlay symbols qualification

### DIFF
--- a/Sources/WITOverlayGenerator/HostGenerators/HostExportFunction.swift
+++ b/Sources/WITOverlayGenerator/HostGenerators/HostExportFunction.swift
@@ -59,7 +59,7 @@ struct HostStaticCanonicalLifting: StaticCanonicalLifting {
         printer.write(line: "}")
 
         return .call(
-            "try CanonicalLifting.liftList",
+            "try WasmKit.CanonicalLifting.liftList",
             arguments: [
                 ("pointer", pointer),
                 ("length", length),
@@ -81,7 +81,7 @@ struct HostStaticCanonicalLowering: StaticCanonicalLowering {
 
     func lowerString(_ value: Operand, encoding: String) throws -> (pointer: Operand, length: Operand) {
         let lowered = Operand.call(
-            "try CanonicalLowering.lowerString",
+            "try WasmKit.CanonicalLowering.lowerString",
             arguments: [
                 (nil, value), ("context", .variable(context.contextVar)),
             ])
@@ -104,7 +104,7 @@ struct HostStaticCanonicalLowering: StaticCanonicalLowering {
         }
         printer.write(line: "}")
         let lowered = Operand.call(
-            "try CanonicalLowering.lowerList",
+            "try WasmKit.CanonicalLowering.lowerList",
             arguments: [
                 (nil, value),
                 ("elementSize", .literal(CanonicalABI.size(type: element).description)),
@@ -262,8 +262,8 @@ struct HostExportFunction {
         printer.write(line: signature.description + " {")
         try printer.indent {
             let optionsVar = builder.variable("options")
-            printer.write(line: "let \(optionsVar) = CanonicalOptions._derive(from: instance, exportName: \"\(name.abiName)\")")
-            printer.write(line: "let \(context.contextVar) = CanonicalCallContext(options: \(optionsVar), instance: instance)")
+            printer.write(line: "let \(optionsVar) = WasmKit.CanonicalOptions._derive(from: instance, exportName: \"\(name.abiName)\")")
+            printer.write(line: "let \(context.contextVar) = WasmKit.CanonicalCallContext(options: \(optionsVar), instance: instance)")
             // Suppress unused variable warning for "context"
             printer.write(line: "_ = \(context.contextVar)")
 
@@ -275,7 +275,7 @@ struct HostExportFunction {
             printer.write(
                 multiline: """
                     guard let \(functionVar) = instance.exports[function: \"\(name.abiName)\"] else {
-                        throw CanonicalABIError(description: "Function \\"\(name.abiName)\\" not found in the instance")
+                        throw WasmKit.CanonicalABIError(description: "Function \\"\(name.abiName)\\" not found in the instance")
                     }
                     """)
             var call = "try \(functionVar)("

--- a/Sources/WITOverlayGenerator/HostGenerators/HostWorldGenerator.swift
+++ b/Sources/WITOverlayGenerator/HostGenerators/HostWorldGenerator.swift
@@ -23,7 +23,7 @@ struct HostWorldGenerator: ASTVisitor {
                 struct \(ConvertCase.pascalCase(world.name)) {
                     let instance: WasmKit.Instance
 
-                    static func link(to imports: inout Imports, store: Store) {
+                    static func link(to imports: inout WasmKit.Imports, store: WasmKit.Store) {
                     }
                 """)
         // Enter world struct body

--- a/Sources/WITOverlayGenerator/TypeGenerators/TypeDefinition.swift
+++ b/Sources/WITOverlayGenerator/TypeGenerators/TypeDefinition.swift
@@ -68,12 +68,12 @@ struct TypeDefinition {
             printer.write(line: "}")
         case .flags(let flags):
             let typeName = try ConvertCase.pascalCase(typeDef.name)
-            printer.write(line: "\(accessLevel) struct \(typeName): OptionSet {")
+            printer.write(line: "\(accessLevel) struct \(typeName): Swift.OptionSet {")
             try printer.indent {
                 let rawValueType = CanonicalABI.rawType(ofFlags: flags.flags.count)
                 let rawSwiftTypes = rawValueType.swiftTypeNames
                 if rawSwiftTypes.count > 1 {
-                    printer.write(line: "\(accessLevel) struct RawValue: Equatable, Hashable {")
+                    printer.write(line: "\(accessLevel) struct RawValue: Swift.Equatable, Swift.Hashable {")
                     printer.indent {
                         for (i, rawSwiftType) in rawSwiftTypes.enumerated() {
                             printer.write(line: "let field\(i): \(rawSwiftType)")

--- a/Tests/WITOverlayGeneratorTests/OverlayQualificationTests.swift
+++ b/Tests/WITOverlayGeneratorTests/OverlayQualificationTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import WIT
+
+@testable import WITOverlayGenerator
+
+/// The overlay emits Swift declarations whose names can shadow the intended `WasmKit.`/`Swift.` symbols, so
+/// unqualified references would bind to the shadow. These assert the qualified spellings.
+@Suite(TestEnvironmentTraits.hostGeneratorAvailability)
+struct OverlayQualificationTests {
+    private func guestCode(_ wit: String) throws -> String {
+        let source = try SourceFileSyntax.parse(wit, fileName: "kw.wit")
+        let packageResolver = PackageResolver()
+        let mainPackage = try packageResolver.register(packageSources: [source])
+        let context = SemanticsContext(rootPackage: mainPackage, packageResolver: packageResolver)
+        return try generateGuest(context: context)
+    }
+
+    private func hostCode(_ wit: String) throws -> String {
+        let source = try SourceFileSyntax.parse(wit, fileName: "kw.wit")
+        let packageResolver = PackageResolver()
+        let mainPackage = try packageResolver.register(packageSources: [source])
+        let context = SemanticsContext(rootPackage: mainPackage, packageResolver: packageResolver)
+        return try generateHost(context: context)
+    }
+
+    // MARK: - Host-runtime (WasmKit) qualification
+
+    @Test func hostLinkQualifiesStoreAndImports() throws {
+        let code = try hostCode("package test:q1;\nworld w { export run: func(); }")
+        #expect(code.contains("store: WasmKit.Store"))
+        #expect(code.contains("inout WasmKit.Imports"))
+    }
+
+    @Test func hostExportBodyQualifiesWasmKitRuntimeTypes() throws {
+        let code = try hostCode("package test:q2;\nworld w { export run: func(); }")
+        #expect(code.contains("throw WasmKit.CanonicalABIError("))
+        #expect(code.contains("WasmKit.CanonicalOptions._derive"))
+        #expect(code.contains("WasmKit.CanonicalCallContext("))
+    }
+
+    /// string and list params/result force the lifting/lowering emissions.
+    @Test func hostExportQualifiesLiftingLowering() throws {
+        let code = try hostCode(
+            "package test:q3;\nworld w { export run: func(s: string, xs: list<u32>) -> list<u32>; }")
+        #expect(code.contains("WasmKit.CanonicalLowering.lowerString"))
+        #expect(code.contains("WasmKit.CanonicalLowering.lowerList"))
+        #expect(code.contains("WasmKit.CanonicalLifting.liftList"))
+    }
+
+    // MARK: - Flags conformance qualification
+
+    @Test func flagsQualifiesOptionSetConformance() throws {
+        let code = try guestCode("package test:q4;\nworld w { flags f { a, b } export run: func(); }")
+        #expect(code.contains(": Swift.OptionSet {"))
+    }
+
+    @Test func wideFlagsQualifiesRawValueConformances() throws {
+        let code = try guestCode(
+            """
+            package test:q5;
+            world w {
+              flags wide {
+                b00,b01,b02,b03,b04,b05,b06,b07,b08,b09,b10,b11,b12,b13,b14,b15,
+                b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,
+                b32,
+              }
+              export run: func();
+            }
+            """)
+        #expect(code.contains("struct RawValue: Swift.Equatable, Swift.Hashable {"))
+    }
+}


### PR DESCRIPTION
Fully qualify the WasmKit runtime and Swift stdlib references emitted by the WIT overlay generator (`WasmKit.CanonicalLifting`/`CanonicalLowering`, `WasmKit.CanonicalOptions._derive`, `WasmKit.CanonicalCallContext`, `WasmKit.CanonicalABIError`, `WasmKit.Store`/`Imports`, and `Swift.OptionSet`/`Equatable`/`Hashable`) so a guest world whose `type` declarations shadow those names still compiles.