### PR TITLE
Debugger: fix step-into for calls w/ arguments, add `qWasmGlobal`

### DIFF
--- a/Sources/GDBRemoteProtocol/GDBHostCommand.swift
+++ b/Sources/GDBRemoteProtocol/GDBHostCommand.swift
@@ -48,6 +48,7 @@ package struct GDBHostCommand: Equatable {
         case insertSoftwareBreakpoint
         case removeSoftwareBreakpoint
         case wasmLocal
+        case wasmGlobal
         case memoryRegionInfo
         case detach
 
@@ -103,6 +104,8 @@ package struct GDBHostCommand: Equatable {
                 self = .kill
             case "qWasmLocal":
                 self = .wasmLocal
+            case "qWasmGlobal":
+                self = .wasmGlobal
             case "qMemoryRegionInfo":
                 self = .memoryRegionInfo
             case "D":

--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -22,6 +22,8 @@
             case noReverseInstructionMappingAvailable(UnsafeMutablePointer<UInt64>)
             case stackFrameIndexOOB(UInt)
             case stackLocalIndexOOB(UInt)
+            case globalIndexOOB(UInt)
+            case globalUnsupportedType(UInt)
             case notStoppedAtBreakpoint
             case linearMemoryNotInitialized
             case linearMemoryOOB(Range<Int>)
@@ -65,6 +67,15 @@
         /// For token threading the head slot is the opcode ID itself; for direct
         /// threading it is a function pointer that we map back.
         private let headSlotToOpcodeID: [CodeSlot: OpcodeID]
+
+        private static let callFamilyOpcodes: Set<OpcodeID> = [
+            Instruction.call(.init(rawCallee: UInt64(0), spAddend: VReg(0))).opcodeID,
+            Instruction.compilingCall(.init(rawCallee: UInt64(0), spAddend: VReg(0))).opcodeID,
+            Instruction.internalCall(.init(rawCallee: UInt64(0), spAddend: VReg(0))).opcodeID,
+            Instruction.callIndirect(.init(tableIndex: UInt32(0), rawType: UInt32(0), index: VReg(0), spAddend: VReg(0))).opcodeID,
+            Instruction.returnCall(.init(rawCallee: UInt64(0))).opcodeID,
+            Instruction.returnCallIndirect(.init(tableIndex: UInt32(0), rawType: UInt32(0), index: VReg(0))).opcodeID,
+        ]
 
         /// Initializes a new debugger state instance.
         /// - Parameters:
@@ -323,6 +334,17 @@
             throw Error.stackFrameIndexOOB(frameIndex)
         }
 
+        /// Globals are module-wide, so the GDB `qWasmGlobal:<frame>;<index>` frame argument is
+        /// irrelevant (matches LLDB eWasmTagGlobal).
+        package func getGlobal(index: UInt) throws -> UInt64 {
+            let globals = self.instance.handle.globals
+            guard index < UInt(globals.count) else { throw Error.globalIndexOOB(index) }
+            switch globals[Int(index)].storage {
+            case .scalar(let untyped): return untyped.storage
+            case .v128: throw Error.globalUnsupportedType(index)  // 128-bit can't fit a single reply
+            }
+        }
+
         package func readLinearMemory<T>(address: UInt, length: UInt, reader: (UnsafeRawBufferPointer) -> T) throws(Error) -> T {
             guard let md, ms > 0 else {
                 throw Error.linearMemoryNotInitialized
@@ -381,8 +403,51 @@
                 return
             }
 
+            // The head slot is non-control because a call with args maps its wasm address to a
+            // prep slot, not the call.
+            if let calleeEntry = self.stepInTargetIfCall(breakpoint: breakpoint) {
+                try self.enableBreakpoint(address: calleeEntry)
+                return
+            }
+
             // Non-control instruction: fall back to next Wasm address
             try self.enableBreakpoint(address: breakpoint.wasmPc + 1)
+        }
+
+        /// The call is the last iseq emit for its wasm address (prep slots come first), so `lastIseq`
+        /// points at the real call head, never an operand. Callee resolution, including the
+        /// indirect-call runtime table index, is left to the existing `predictNext_*` predictors, which
+        /// also compile the callee. Their iseq base may be an elided instruction with no reverse wasm
+        /// mapping, so it is mapped through the callee function's originalAddress; enableBreakpoint then
+        /// forward-resolves that to the first emitted instruction.
+        private mutating func stepInTargetIfCall(breakpoint: BreakpointState) -> Int? {
+            let mapping = self.instance.handle.instructionMapping
+            guard let headPc = mapping.lastIseq(forWasmAddress: breakpoint.wasmPc),
+                // Equal means the breakpoint already sits on the head; the control-head path handled it.
+                headPc != breakpoint.iseq.pc,
+                let opcodeID = headSlotToOpcodeID[headPc.pointee],
+                Self.callFamilyOpcodes.contains(opcodeID),
+                let targets = Instruction.predictNextPcs(
+                    opcodeID: opcodeID, operandPc: headPc.advanced(by: 1), sp: breakpoint.iseq.sp,
+                    predictor: &self
+                ),
+                // Empty for a host/imported or unresolvable callee.
+                let calleeIseq = targets.first
+            else { return nil }
+
+            return self.wasmOrigin(ofIseqBase: calleeIseq)
+        }
+
+        private func wasmOrigin(ofIseqBase base: Pc) -> Int? {
+            for entry in self.functionAddresses {
+                let iseq: InstructionSequence
+                switch self.instance.handle.functions[entry.instanceFunctionIndex].wasm.code {
+                case .debuggable(_, let compiled), .compiled(let compiled): iseq = compiled
+                case .uncompiled: continue
+                }
+                if iseq.instructions.baseAddress == base { return entry.address }
+            }
+            return nil
         }
 
         deinit {

--- a/Sources/WasmKit/Execution/DebuggerInstructionMapping.swift
+++ b/Sources/WasmKit/Execution/DebuggerInstructionMapping.swift
@@ -11,6 +11,10 @@ struct DebuggerInstructionMapping {
         /// Used for handling breakpoint requests issued by a ``Debugger`` instance.
         private var wasmToIseq = [Int: Pc]()
 
+        /// Last iseq slot per wasm address. A call with args lowers to prep slots then the call, all
+        /// sharing one wasm address; `wasmToIseq` keeps the first (a prep slot), this keeps the call.
+        private var lastWasmToIseq = [Int: Pc]()
+
         /// Wasm addresses sorted in ascending order for binary search when of the next closest mapped
         /// instruction, when no key is found in `wasmToIseqMapping`.
         private var wasmMappings = [Int]()
@@ -23,6 +27,7 @@ struct DebuggerInstructionMapping {
             if self.wasmToIseq[wasm] == nil {
                 self.wasmToIseq[wasm] = iseq
             }
+            self.lastWasmToIseq[wasm] = iseq
             // Insert in sorted order to maintain the binary search invariant.
             // With lazy compilation, functions may be compiled out of address order,
             // so simple append would break the sorted invariant.
@@ -67,6 +72,10 @@ struct DebuggerInstructionMapping {
 
         func findWasm(forIseqAddress pc: Pc) -> Int? {
             self.iseqToWasm[pc]
+        }
+
+        func lastIseq(forWasmAddress address: Int) -> Pc? {
+            self.lastWasmToIseq[address]
         }
     #endif
 }

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -49,6 +49,7 @@
             case killRequestReceived
             case unknownHexEncodedArguments(String)
             case unknownWasmLocalArguments(String)
+            case unknownWasmGlobalArguments(String)
         }
 
         private let moduleFilePath: FilePath
@@ -336,6 +337,22 @@
                 responseKind = .hexEncodedBinary(
                     self.allocator.buffer(
                         integer: try self.debugger.getLocal(frameIndex: frameIndex, localIndex: localIndex),
+                        endianness: .little
+                    ).readableBytesView
+                )
+
+            case .wasmGlobal:
+                // Keep empty fields so a malformed `<frame>;` is rejected rather than read as `<frame>`.
+                let arguments = command.arguments.split(separator: ";", omittingEmptySubsequences: false)
+                guard arguments.count == 2,
+                    let globalIndex = UInt(arguments[1])
+                else {
+                    throw Error.unknownWasmGlobalArguments(command.arguments)
+                }
+
+                responseKind = .hexEncodedBinary(
+                    self.allocator.buffer(
+                        integer: try self.debugger.getGlobal(index: globalIndex),
                         endianness: .little
                     ).readableBytesView
                 )

--- a/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
+++ b/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
@@ -61,4 +61,20 @@ struct GDBRemoteProtocolTests {
         #expect(packet == expectedPacket)
         #expect(decoder.accummulatedChecksum == 0)
     }
+
+    @Test
+    func decodingWasmGlobal() throws {
+        var decoder = self.decoder
+        var buffer = ByteBuffer(string: "+$qWasmGlobal:0;1#30")
+        let packet = try decoder.decode(buffer: &buffer)
+        #expect(packet?.payload.kind == .wasmGlobal)
+        #expect(packet?.payload.arguments == "0;1")
+    }
+
+    @Test
+    func wasmGlobalMemberwiseInit() {
+        let command = GDBHostCommand(kind: .wasmGlobal, arguments: "0;1")
+        #expect(command.kind == .wasmGlobal)
+        #expect(command.arguments == "0;1")
+    }
 }

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -1,0 +1,200 @@
+#if WasmDebuggingSupport
+
+    import Foundation
+    import GDBRemoteProtocol
+    import Logging
+    import NIOCore
+    import SystemPackage
+    import Testing
+    import WAT
+
+    @testable import WasmKit
+    @testable import WasmKitGDBHandler
+
+    @Suite
+    struct WasmKitGDBHandlerTests {
+        // A user breakpoint on the callee's first instruction is consumed by
+        // runPreservingCurrentBreakpoint (it is the entrypoint's step-over target). `$f` does real
+        // work before an elided `local.get` so the divergent site sits past that, and the trailing
+        // arithmetic leaves an emitted instruction for a single step to land on.
+        static let wat = """
+            (module
+              (func (export "_start") (result i32)
+                (call $f))
+              (func $f (result i32)
+                (local $x i32)
+                (i32.const 1)
+                (drop)
+                (local.set $x (i32.const 7))
+                (local.get $x)
+                (i32.const 5)
+                (i32.add)
+                (local.set $x)
+                (local.get $x)
+                (i32.const 2)
+                (i32.mul)
+                (drop)
+                (i32.const 42)))
+            """
+
+        private let offset = DebuggerMemoryView.executableCodeOffset
+        private let allocator = ByteBufferAllocator()
+
+        private func divergentAddresses() throws -> (requested: Int, resolved: Int) {
+            let bytes = try wat2wasm(Self.wat)
+            let module = try parseWasm(bytes: bytes)
+            let base = module.functions[1].code.originalAddress
+
+            let firstEmitted = try resolve(module: module, address: base)
+            var site: (requested: Int, resolved: Int)?
+            for delta in 1..<0x40 {
+                let requested = base + delta
+                guard let resolved = try? resolve(module: module, address: requested) else { continue }
+                if resolved != requested && resolved > firstEmitted {
+                    site = (requested, resolved)
+                    break
+                }
+            }
+            return try #require(site, "no elided-instruction site resolves forward in the fixture")
+        }
+
+        private func resolve(module: Module, address: Int) throws -> Int {
+            let store = Store(engine: Engine())
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+            return try debugger.enableBreakpoint(address: address)
+        }
+
+        // Closes on both paths because WASIBridgeToHost's deinit preconditions on close() having run.
+        private func withHandler<R>(_ body: (WasmKitGDBHandler) async throws -> R) async throws -> R {
+            let bytes = try wat2wasm(Self.wat)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("wasmkit-gdb-\(UUID().uuidString).wasm")
+            try Data(bytes).write(to: url)
+            var log = Logger(label: "test")
+            log.logLevel = .critical
+            let h = try await WasmKitGDBHandler(
+                moduleFilePath: FilePath(url.path),
+                engineConfiguration: EngineConfiguration(),
+                logger: log, allocator: ByteBufferAllocator())
+            do {
+                let result = try await body(h)
+                try await h.close()
+                return result
+            } catch {
+                try await h.close()
+                throw error
+            }
+        }
+
+        private func pairs(_ r: GDBTargetResponse) -> [String: String] {
+            guard case .keyValuePairs(let kvs) = r.kind else { return [:] }
+            return Dictionary(kvs, uniquingKeysWith: { a, _ in a })
+        }
+
+        // The `Z0,<addr>,1` hex form LLDB sends, built by the same encoding path the handler uses
+        // for stop replies so the expected value tracks any change to that encoding.
+        private func hostHex(_ wasmAddr: Int) -> String {
+            var buffer = self.allocator.buffer(capacity: MemoryLayout<UInt64>.size)
+            buffer.writeInteger(UInt64(wasmAddr) + offset, endianness: .big)
+            return buffer.hexDump(format: .compact)
+        }
+
+        private func insert(_ h: WasmKitGDBHandler, at wasmAddr: Int) async throws {
+            _ = try await h.handle(
+                command: .init(
+                    kind: .insertSoftwareBreakpoint, arguments: "\(hostHex(wasmAddr)),1"))
+        }
+
+        @Test
+        func breakpointStopReportsBreakpointReasonAtRequestedAddress() async throws {
+            let (requested, resolved) = try divergentAddresses()
+            try await withHandler { h in
+                try await insert(h, at: requested)
+                let stop = try await h.handle(command: .init(kind: .continue, arguments: ""))
+                let kv = pairs(stop)
+                #expect(kv["reason"] == "breakpoint")
+                #expect(kv["thread-pcs"] == hostHex(requested))
+                #expect(kv["thread-pcs"] != hostHex(resolved))
+            }
+        }
+
+        @Test
+        func removeBreakpointUninstallsAtResolvedAddress() async throws {
+            let (requested, _) = try divergentAddresses()
+            try await withHandler { h in
+                try await insert(h, at: requested)
+                _ = try await h.handle(
+                    command: .init(
+                        kind: .removeSoftwareBreakpoint, arguments: "\(hostHex(requested)),1"))
+                let resp = try await h.handle(command: .init(kind: .continue, arguments: ""))
+                // Run to completion yields a `W..` exit reply, not a key-value stop reply.
+                if case .string(let s) = resp.kind {
+                    #expect(s.hasPrefix("W"))
+                } else {
+                    Issue.record("expected exit reply after removing the only breakpoint, got \(resp.kind)")
+                }
+            }
+        }
+
+        @Test
+        func stepLandingReportsTraceNotBreakpoint() async throws {
+            let (requested, _) = try divergentAddresses()
+            try await withHandler { h in
+                try await insert(h, at: requested)
+                _ = try await h.handle(command: .init(kind: .continue, arguments: ""))
+                let step = try await h.handle(command: .init(kind: .resumeThreads, arguments: "s:1"))
+                #expect(pairs(step)["reason"] == "trace")
+            }
+        }
+
+        static let globalWAT = """
+            (module
+              (global $g (mut i32) (i32.const 7))
+              (func (export "_start") (result i32) (global.get $g)))
+            """
+
+        private func withGlobalHandler<R>(_ body: (WasmKitGDBHandler) async throws -> R) async throws -> R {
+            let bytes = try wat2wasm(Self.globalWAT)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("wasmkit-gdb-\(UUID().uuidString).wasm")
+            try Data(bytes).write(to: url)
+            var log = Logger(label: "test")
+            log.logLevel = .critical
+            let h = try await WasmKitGDBHandler(
+                moduleFilePath: FilePath(url.path),
+                engineConfiguration: EngineConfiguration(),
+                logger: log, allocator: ByteBufferAllocator())
+            do {
+                let result = try await body(h)
+                try await h.close()
+                return result
+            } catch {
+                try await h.close()
+                throw error
+            }
+        }
+
+        @Test
+        func wasmGlobalRepliesWithLittleEndianValue() async throws {
+            try await withGlobalHandler { h in
+                let resp = try await h.handle(command: .init(kind: .wasmGlobal, arguments: "0;0"))
+                guard case .hexEncodedBinary(let view) = resp.kind else {
+                    Issue.record("expected hexEncodedBinary, got \(resp.kind)")
+                    return
+                }
+                var buffer = ByteBuffer(bytes: view)
+                #expect(buffer.readInteger(endianness: .little, as: UInt64.self) == 7)
+            }
+        }
+
+        @Test
+        func wasmGlobalRejectsMissingIndex() async throws {
+            _ = try await withGlobalHandler { h in
+                await #expect(throws: WasmKitGDBHandler.Error.self) {
+                    _ = try await h.handle(command: .init(kind: .wasmGlobal, arguments: "0;"))
+                }
+            }
+        }
+    }
+
+#endif

--- a/Tests/WasmKitTests/DebuggerGlobalTests.swift
+++ b/Tests/WasmKitTests/DebuggerGlobalTests.swift
@@ -1,0 +1,25 @@
+#if WasmDebuggingSupport
+
+    import Testing
+    import WAT
+    import WasmParser
+
+    @testable import WasmKit
+
+    @Suite
+    struct DebuggerGlobalTests {
+        @Test
+        func getGlobalReadsInitializedValue() throws {
+            let store = Store(engine: Engine())
+            let module = try parseWasm(bytes: try wat2wasm("""
+                (module (global $g (mut i32) (i32.const 1))
+                  (func (export "_start") (result i32) (global.get $g)))
+                """))
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+            try debugger.stopAtEntrypoint()
+            try debugger.run()
+            #expect(try debugger.getGlobal(index: 0) == 1)
+        }
+    }
+
+#endif

--- a/Tests/WasmKitTests/DebuggerGlobalTests.swift
+++ b/Tests/WasmKitTests/DebuggerGlobalTests.swift
@@ -11,10 +11,12 @@
         @Test
         func getGlobalReadsInitializedValue() throws {
             let store = Store(engine: Engine())
-            let module = try parseWasm(bytes: try wat2wasm("""
-                (module (global $g (mut i32) (i32.const 1))
-                  (func (export "_start") (result i32) (global.get $g)))
-                """))
+            let module = try parseWasm(
+                bytes: try wat2wasm(
+                    """
+                    (module (global $g (mut i32) (i32.const 1))
+                      (func (export "_start") (result i32) (global.get $g)))
+                    """))
             var debugger = try Debugger(module: module, store: store, imports: [:])
             try debugger.stopAtEntrypoint()
             try debugger.run()

--- a/Tests/WasmKitTests/DebuggerStepIntoTests.swift
+++ b/Tests/WasmKitTests/DebuggerStepIntoTests.swift
@@ -79,7 +79,8 @@
 
             try debugger.step()
             let landing = try requireStopped(debugger)
-            #expect(landing >= calleeOrigin && landing < startBase,
+            #expect(
+                landing >= calleeOrigin && landing < startBase,
                 "step should land inside the callee [\(calleeOrigin), \(startBase)), got \(landing)")
             #expect(landing != bp + 1, "must not be a step-over")
         }

--- a/Tests/WasmKitTests/DebuggerStepIntoTests.swift
+++ b/Tests/WasmKitTests/DebuggerStepIntoTests.swift
@@ -1,0 +1,108 @@
+#if WasmDebuggingSupport
+
+    import Testing
+    import WAT
+    import WasmParser
+
+    @testable import WasmKit
+
+    /// Callee starts with an elided `local.get`, so its resolved entry differs from originalAddress.
+    private let stepInCallWAT = """
+        (module
+          (func $callee (param i32) (result i32) (local $x i32)
+            (local.get $x) (drop)
+            (i32.add (local.get 0) (i32.const 1)))
+          (func (export "_start") (result i32)
+            (i32.const 10)
+            (call $callee)))
+        """
+
+    private let stepInReturnCallWAT = """
+        (module
+          (func $callee (param i32) (result i32) (local $x i32)
+            (local.get $x) (drop)
+            (i32.add (local.get 0) (local.get 0)))
+          (func (export "_start") (result i32)
+            (i32.const 21)
+            (return_call $callee)))
+        """
+
+    private let stepInCallIndirectWAT = """
+        (module
+          (type $t (func (param i32) (result i32)))
+          (func $callee (type $t) (param i32) (result i32) (local $x i32)
+            (local.get $x) (drop)
+            (i32.add (local.get 0) (i32.const 1)))
+          (func (export "_start") (result i32)
+            (i32.const 10)
+            (call_indirect (type $t) (i32.const 0)))
+          (table 1 funcref)
+          (elem (i32.const 0) func $callee))
+        """
+
+    /// Zero-argument call: no prep slots, so the breakpoint sits directly on the call head and the
+    /// existing control-head path handles it. Guards that the elided-callee cold path still steps in
+    /// (findWasm on the callee's iseq base is not the step-over fallback).
+    private let stepInZeroArgCallWAT = """
+        (module
+          (func $callee (result i32) (local $x i32)
+            (local.get $x) (drop)
+            (i32.const 42))
+          (func (export "_start") (result i32)
+            (call $callee)))
+        """
+
+    @Suite
+    struct DebuggerStepIntoTests {
+        private func requireStopped(_ debugger: borrowing Debugger) throws -> Int {
+            guard case .stoppedAtBreakpoint(let bp) = debugger.state else {
+                Issue.record("expected stoppedAtBreakpoint, got \(debugger.state)")
+                throw CancellationError()
+            }
+            return bp.wasmPc
+        }
+
+        /// Steps at the call site and asserts the landing is inside the callee. The callee is defined
+        /// before `_start`, so its whole body is below `startBase`; a step-over would stay at or above
+        /// the call site. The callee is deliberately NOT compiled beforehand, exercising the cold path
+        /// where the predictor must compile it and its elided first instruction has no reverse mapping.
+        private func assertStepsInto(_ wat: String, callOffset: Int, features: WasmFeatureSet = []) throws {
+            let store = Store(engine: Engine())
+            let module = try parseWasm(bytes: try wat2wasm(wat, features: features), features: features)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+            let calleeOrigin = module.functions[0].code.originalAddress
+            let startBase = module.functions[1].code.originalAddress
+            let bp = try debugger.enableBreakpoint(address: startBase + callOffset)
+
+            try debugger.run()
+            #expect(try requireStopped(debugger) == bp)
+
+            try debugger.step()
+            let landing = try requireStopped(debugger)
+            #expect(landing >= calleeOrigin && landing < startBase,
+                "step should land inside the callee [\(calleeOrigin), \(startBase)), got \(landing)")
+            #expect(landing != bp + 1, "must not be a step-over")
+        }
+
+        @Test func stepIntoCall() throws {
+            // _start body: i32.const 10 (2) + call (2) + end
+            try assertStepsInto(stepInCallWAT, callOffset: 2)
+        }
+
+        @Test func stepIntoReturnCall() throws {
+            // _start body: i32.const 21 (2) + return_call (2) + end
+            try assertStepsInto(stepInReturnCallWAT, callOffset: 2, features: [.tailCall])
+        }
+
+        @Test func stepIntoCallIndirect() throws {
+            // _start body: i32.const 10 (2) + i32.const 0 (2) + call_indirect (3) + end
+            try assertStepsInto(stepInCallIndirectWAT, callOffset: 4)
+        }
+
+        @Test func stepIntoZeroArgCall() throws {
+            // _start body: call (2) + end; the call head is the first (only) slot for its wasm address.
+            try assertStepsInto(stepInZeroArgCallWAT, callOffset: 0)
+        }
+    }
+
+#endif

--- a/Tests/WasmKitTests/DebuggerTests.swift
+++ b/Tests/WasmKitTests/DebuggerTests.swift
@@ -558,16 +558,15 @@
             )
         }
 
-        /// Verifies that `step` on a `call` instruction correctly steps over the call
-        /// and stops at the next instruction in the caller.
         @Test
-        func stepStepsOverCall() throws {
+        func stepEntersCall() throws {
             let store = Store(engine: Engine())
             let bytes = try wat2wasm(callWAT)
             let module = try parseWasm(bytes: bytes)
             var debugger = try Debugger(module: module, store: store, imports: [:])
 
             let startBase = module.functions[0].code.originalAddress
+            let calleeOrigin = module.functions[1].code.originalAddress  // $add_one, defined after _start
             // _start body: i32.const 10 (2) + call 1 (2) + end (1)
             let breakpointAddress = try debugger.enableBreakpoint(address: startBase + 2)
 
@@ -577,22 +576,19 @@
             try debugger.step()
             let wasmPc = try requireBreakpoint(debugger)
 
-            #expect(
-                wasmPc > breakpointAddress,
-                "step on call should advance past the call site (offset 2), got offset \(wasmPc - startBase)"
-            )
+            #expect(wasmPc >= calleeOrigin, "step on call should enter the callee at/after \(calleeOrigin), got \(wasmPc)")
+            #expect(wasmPc != breakpointAddress + 1, "must not be a step-over")
         }
 
-        /// Verifies that `step` on a `call_indirect` instruction correctly steps over
-        /// the indirect call and stops at the next instruction in the caller.
         @Test
-        func stepStepsOverCallIndirect() throws {
+        func stepEntersCallIndirect() throws {
             let store = Store(engine: Engine())
             let bytes = try wat2wasm(callIndirectWAT)
             let module = try parseWasm(bytes: bytes)
             var debugger = try Debugger(module: module, store: store, imports: [:])
 
             let startBase = module.functions[0].code.originalAddress
+            let calleeOrigin = module.functions[1].code.originalAddress  // $add_one, defined after _start
             // _start body: i32.const 10 (2) + i32.const 0 (2) + call_indirect (3) + end (1)
             let breakpointAddress = try debugger.enableBreakpoint(address: startBase + 4)
 
@@ -602,10 +598,8 @@
             try debugger.step()
             let wasmPc = try requireBreakpoint(debugger)
 
-            #expect(
-                wasmPc > breakpointAddress,
-                "step on call_indirect should advance past the call site (offset 4), got offset \(wasmPc - startBase)"
-            )
+            #expect(wasmPc >= calleeOrigin, "step on call_indirect should enter the callee at/after \(calleeOrigin), got \(wasmPc)")
+            #expect(wasmPc != breakpointAddress + 1, "must not be a step-over")
         }
 
         /// Verifies that `step` on a `return_call` (tail call) lands at the

--- a/Tests/WasmKitTests/DebuggerVariableTests.swift
+++ b/Tests/WasmKitTests/DebuggerVariableTests.swift
@@ -1,0 +1,53 @@
+#if WasmDebuggingSupport
+
+    import Testing
+    import WAT
+    import WasmParser
+
+    @testable import WasmKit
+
+    /// Locks in the `getLocal` path LLDB drives through `qWasmLocal`: after a step-in, both the
+    /// callee's own locals and the parent caller frame's local must still read their correct values.
+    ///
+    /// Multi-param callees are avoided because `getLocal`'s frame-header param addressing predates this
+    /// change and mishandles them (not on the Swift async-variable path, which resolves through the
+    /// async-context pointer rather than Wasm params).
+    /// TODO: fix multi-parameter `getLocal` frame-header addressing (Debugger.getLocal, the `- 4` path).
+    private let localsAcrossFramesWAT = """
+        (module
+          (func $callee (param $a i32) (result i32) (local $x i32)
+            (local.set $x (i32.const 99))
+            (i32.add (local.get $a) (local.get $x)))
+          (func (export "_start") (result i32) (local $c i32)
+            (i32.const 7) (local.set $c)
+            (call $callee (i32.const 10))))
+        """
+
+    @Suite
+    struct DebuggerVariableTests {
+        @Test
+        func localValuesSurviveStepIntoAcrossFrames() throws {
+            let store = Store(engine: Engine())
+            let module = try parseWasm(bytes: try wat2wasm(localsAcrossFramesWAT))
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            let startBase = module.functions[1].code.originalAddress
+            // _start body: i32.const 7 (2) + local.set (2) + i32.const 10 (2) + call (2)
+            let callSite = startBase + 6
+            _ = try debugger.enableBreakpoint(address: callSite)
+            try debugger.run()
+
+            #expect(try debugger.getLocal(frameIndex: 0, localIndex: 0) == 7, "caller local $c")
+
+            try debugger.step()
+
+            #expect(try debugger.getLocal(frameIndex: 0, localIndex: 0) == 10, "callee param $a")
+            #expect(try debugger.getLocal(frameIndex: 1, localIndex: 0) == 7, "caller local $c from parent frame")
+
+            // $x is uninitialised until its local.set runs, so step past it before reading.
+            try debugger.step()
+            #expect(try debugger.getLocal(frameIndex: 0, localIndex: 1) == 99, "callee local $x after local.set")
+        }
+    }
+
+#endif


### PR DESCRIPTION
Stepping into a call with arguments stepped over it, because the call lowers to prep slots then the call but the mapping kept only the first slot. A last-wins wasm-to-iseq map now recovers the real call head and reuses the existing predictors, fixing step-into for direct, indirect, and tail calls. It also implements `qWasmGlobal` so Swift module globals read instead of failing with an unhandled DWARF opcode, and adds step-into, variable, and global regression tests.