### PR TITLE
Make _CWasmKit headers portable to non-Clang compilers

### DIFF
--- a/Sources/_CWasmKit/include/Platform.h
+++ b/Sources/_CWasmKit/include/Platform.h
@@ -1,12 +1,25 @@
 #ifndef WASMKIT_PLATFORM_H
 #define WASMKIT_PLATFORM_H
 
+// Clang nullability annotations; no-op on other compilers.
+#if defined(__clang__)
+#  define WASMKIT_NONNULL _Nonnull
+#  define WASMKIT_NULLABLE _Nullable
+#else
+#  define WASMKIT_NONNULL
+#  define WASMKIT_NULLABLE
+#endif
+
 // NOTE: The `swiftasynccc` attribute is considered to be a Clang extension
 // rather than a language standard feature after LLVM 19. We check
-// `__has_attribute(swiftasynccc)` too for compatibility with older versions.
+// `__has_extension(swiftasynccc)` too for compatibility with older versions.
 // See https://github.com/llvm/llvm-project/pull/85347
-#if !defined(__wasi__) && (__has_feature(swiftasynccc) || __has_extension(swiftasynccc))
-#  define WASMKIT_HAS_SWIFTASYNCCC 1
+#if defined(__clang__) && !defined(__wasi__)
+#  if __has_feature(swiftasynccc) || __has_extension(swiftasynccc)
+#    define WASMKIT_HAS_SWIFTASYNCCC 1
+#  else
+#    define WASMKIT_HAS_SWIFTASYNCCC 0
+#  endif
 #else
 #  define WASMKIT_HAS_SWIFTASYNCCC 0
 #endif

--- a/Sources/_CWasmKit/include/TrapGuard.h
+++ b/Sources/_CWasmKit/include/TrapGuard.h
@@ -4,23 +4,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-#ifndef _Nullable
-#  ifndef __clang__
-#    define _Nullable
-#  endif
-#endif
-
-#ifndef _Nonnull
-#  ifndef __clang__
-#    define _Nonnull
-#  endif
-#endif
+#include "Platform.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef void (*wasmkit_trap_guard_fn)(void *_Nullable ctx);
+typedef void (*wasmkit_trap_guard_fn)(void *WASMKIT_NULLABLE ctx);
 
 /// Runs `fn(ctx)` while converting SIGSEGV/SIGBUS faults inside the current
 /// linear-memory reserved range into a non-local return.
@@ -28,13 +18,13 @@ typedef void (*wasmkit_trap_guard_fn)(void *_Nullable ctx);
 /// Return value:
 /// - false: completed normally
 /// - true: trapped due to out-of-bounds linear-memory access
-bool wasmkit_trap_guard_run(wasmkit_trap_guard_fn _Nonnull fn, void *_Nullable ctx);
+bool wasmkit_trap_guard_run(wasmkit_trap_guard_fn WASMKIT_NONNULL fn, void *WASMKIT_NULLABLE ctx);
 
 /// Updates the currently-active trap guard (if any) with the current memory base
 /// and linear-memory reservation size (in bytes).
 ///
 /// Passing `reservation_size == 0` disables handling of faults for the current thread.
-void wasmkit_trap_guard_set_current_memory(void *_Nullable md, size_t reservation_size);
+void wasmkit_trap_guard_set_current_memory(void *WASMKIT_NULLABLE md, size_t reservation_size);
 
 #ifdef __cplusplus
 }

--- a/Sources/_CWasmKit/include/_CWasmKit.h
+++ b/Sources/_CWasmKit/include/_CWasmKit.h
@@ -16,32 +16,32 @@
 #endif
 
 #define WASMKIT_DEFINE_ATOMICS(WIDTH, CTYPE) \
-static inline CTYPE wasmkit_atomic_load_##WIDTH(const void *_Nonnull ptr) { \
+static inline CTYPE wasmkit_atomic_load_##WIDTH(const void *WASMKIT_NONNULL ptr) { \
     return __atomic_load_n((const CTYPE *)ptr, __ATOMIC_SEQ_CST); \
 } \
-static inline void wasmkit_atomic_store_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline void wasmkit_atomic_store_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     __atomic_store_n((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
-static inline CTYPE wasmkit_atomic_rmw_add_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline CTYPE wasmkit_atomic_rmw_add_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     return __atomic_fetch_add((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
-static inline CTYPE wasmkit_atomic_rmw_sub_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline CTYPE wasmkit_atomic_rmw_sub_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     return __atomic_fetch_sub((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
-static inline CTYPE wasmkit_atomic_rmw_and_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline CTYPE wasmkit_atomic_rmw_and_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     return __atomic_fetch_and((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
-static inline CTYPE wasmkit_atomic_rmw_or_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline CTYPE wasmkit_atomic_rmw_or_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     return __atomic_fetch_or((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
-static inline CTYPE wasmkit_atomic_rmw_xor_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline CTYPE wasmkit_atomic_rmw_xor_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     return __atomic_fetch_xor((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
-static inline CTYPE wasmkit_atomic_rmw_xchg_##WIDTH(void *_Nonnull ptr, CTYPE val) { \
+static inline CTYPE wasmkit_atomic_rmw_xchg_##WIDTH(void *WASMKIT_NONNULL ptr, CTYPE val) { \
     return __atomic_exchange_n((CTYPE *)ptr, val, __ATOMIC_SEQ_CST); \
 } \
 static inline _Bool wasmkit_atomic_cmpxchg_##WIDTH( \
-    void *_Nonnull ptr, CTYPE *_Nonnull expected, CTYPE desired \
+    void *WASMKIT_NONNULL ptr, CTYPE *WASMKIT_NONNULL expected, CTYPE desired \
 ) { \
     return __atomic_compare_exchange_n( \
         (CTYPE *)ptr, expected, desired, 0, \
@@ -61,9 +61,9 @@ static inline void wasmkit_atomic_fence(void) {
 // MARK: - Execution Parameters
 // See ExecutionContext.swift for more information about each execution
 // parameter.
-typedef uint64_t *_Nonnull Sp;
-typedef void *_Nullable Pc;
-typedef void *_Nullable Md;
+typedef uint64_t *WASMKIT_NONNULL Sp;
+typedef void *WASMKIT_NULLABLE Pc;
+typedef void *WASMKIT_NULLABLE Md;
 typedef size_t Ms;
 
 #include "TrapGuard.h"
@@ -75,8 +75,8 @@ typedef size_t Ms;
 ///
 /// See https://clang.llvm.org/docs/AttributeReference.html#swiftasynccall for
 /// more information about `swiftasynccall`.
-typedef SWIFT_CC(swiftasync) void (* _Nonnull wasmkit_tc_exec)(
-    uint64_t *_Nonnull sp, Pc, Md, Ms, SWIFT_CONTEXT void *_Nullable state);
+typedef SWIFT_CC(swiftasync) void (* WASMKIT_NONNULL wasmkit_tc_exec)(
+    uint64_t *WASMKIT_NONNULL sp, Pc, Md, Ms, SWIFT_CONTEXT void *WASMKIT_NULLABLE state);
 
 /// The entry point for executing a direct-threaded interpreter loop.
 /// The interpreter loop is implemented as a tail-recursive function that
@@ -88,7 +88,7 @@ typedef SWIFT_CC(swiftasync) void (* _Nonnull wasmkit_tc_exec)(
 /// convention and it leads to a miscompilation of the tail call.
 /// See https://github.com/swiftlang/swift/issues/69264
 static inline void wasmkit_tc_start(
-    wasmkit_tc_exec exec, Sp sp, Pc pc, Md md, Ms ms, void *_Nullable state
+    wasmkit_tc_exec exec, Sp sp, Pc pc, Md md, Ms ms, void *WASMKIT_NULLABLE state
 ) {
   exec(sp, pc, md, ms, state);
 }
@@ -106,15 +106,15 @@ struct SwiftError;
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern void swift_errorRelease(const struct SwiftError *_Nonnull object);
+extern void swift_errorRelease(const struct SwiftError *WASMKIT_NONNULL object);
 #ifdef __cplusplus
 }
 #endif
 
 /// Releases the given Swift error object.
-static inline void wasmkit_swift_errorRelease(const void *_Nonnull object) {
+static inline void wasmkit_swift_errorRelease(const void *WASMKIT_NONNULL object) {
 #ifdef __cplusplus
-    swift_errorRelease(static_cast<const struct SwiftError *_Nonnull>(object));
+    swift_errorRelease(static_cast<const struct SwiftError *WASMKIT_NONNULL>(object));
 #else
     swift_errorRelease(object);
 #endif


### PR DESCRIPTION
Spell nullability annotations with project-prefixed WASMKIT_NONNULL/ WASMKIT_NULLABLE macros in the handwritten headers instead of re-defining the reserved _Nonnull/_Nullable identifiers for non-Clang compilers (e.g. ESP-IDF's riscv32-esp-elf-gcc), and evaluate the swiftasynccc feature check only under Clang. Clang-only sources (InlineCode.h, DirectThreadedCode.inc) keep the native spellings.