### PR TITLE
Add MultiThread trait and PlatformMutex wrapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,13 +39,17 @@ let package = Package(
         .library(name: "_CabiShims", targets: ["_CabiShims"]),
     ],
     traits: [
-        .default(enabledTraits: ["FileSystem"]),
+        .default(enabledTraits: ["FileSystem", "MultiThread"]),
         "FileSystem",
         "ComponentModel",
         "WasmDebuggingSupport",
         // Collects instruction-trigram statistics during execution and dumps
         // them to stderr on exit. Development-only diagnostics.
         "EngineStats",
+        // Serializes shared engine state with real locks. Disable only for
+        // single-threaded environments (e.g. bare-metal Embedded Swift) where
+        // the Synchronization module provides no Mutex.
+        "MultiThread",
     ],
     targets: [
         cliCommandsTarget,

--- a/Sources/WasmKit/CMakeLists.txt
+++ b/Sources/WasmKit/CMakeLists.txt
@@ -47,13 +47,19 @@ add_wasmkit_library(WasmKit
   Execution/Value.swift
   Execution/V128Storage.swift
   Platform/AtomicParkingLot.swift
+  Platform/PlatformMutex.swift
   Platform/SystemVirtualMemory.swift
 )
 
+# Joined -DName form: separate "-D;Name" pairs lose their "-D" to CMake's
+# COMPILE_OPTIONS de-duplication when more than one define is present.
 if(WASMKIT_ENABLE_FILESYSTEM)
   target_compile_options(WasmKit PRIVATE
-    $<$<COMPILE_LANGUAGE:Swift>:-D;FileSystem>)
+    $<$<COMPILE_LANGUAGE:Swift>:-DFileSystem>)
 endif()
+
+target_compile_options(WasmKit PRIVATE
+  $<$<COMPILE_LANGUAGE:Swift>:-DMultiThread>)
 
 target_link_wasmkit_libraries(WasmKit PUBLIC
   _CWasmKit WasmParser SystemExtras WasmTypes SystemPackage)

--- a/Sources/WasmKit/Execution/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/StoreAllocator.swift
@@ -1,4 +1,3 @@
-import Synchronization
 import WasmParser
 
 /// A simple bump allocator for a single type.
@@ -169,17 +168,21 @@ struct Interned<T: Internable>: Equatable, Hashable, Sendable {
 
 /// A deduplicating interner for values of type `Item`.
 ///
-/// Thread-safe: all access is serialized by an internal `Mutex`.
+/// Thread-safe when the `MultiThread` trait is enabled: all access is
+/// serialized by the internal `PlatformMutex`.
 final class Interner<Item: Hashable & Internable & Sendable>: Sendable {
     private struct State {
         var itemByIntern: [Item]
         var internByItem: [Item: Interned<Item>]
     }
 
-    private let state: Mutex<State>
+    // `var` because the single-threaded PlatformMutex fallback mutates in
+    // place; the mutex itself guarantees exclusivity, which Sendable checking
+    // cannot see.
+    nonisolated(unsafe) private var state: PlatformMutex<State>
 
     init() {
-        state = Mutex(State(itemByIntern: [], internByItem: [:]))
+        state = PlatformMutex(State(itemByIntern: [], internByItem: [:]))
     }
 
     /// Interns the given `item` and returns an interned value.

--- a/Sources/WasmKit/Platform/PlatformMutex.swift
+++ b/Sources/WasmKit/Platform/PlatformMutex.swift
@@ -1,0 +1,41 @@
+/// A mutual-exclusion wrapper around a piece of state.
+///
+/// With the `MultiThread` package trait enabled (the default), this is backed
+/// by `Synchronization.Mutex`. With the trait disabled -- for single-threaded
+/// environments such as bare-metal Embedded Swift targets, where the
+/// `Synchronization` module provides no `Mutex` -- it degrades to plain
+/// unsynchronized storage with the same non-copyable shape.
+#if MultiThread
+    import Synchronization
+
+    struct PlatformMutex<State>: ~Copyable, Sendable {
+        private let inner: Mutex<State>
+
+        init(_ initial: consuming sending State) {
+            self.inner = Mutex(initial)
+        }
+
+        borrowing func withLock<Result, E: Error>(
+            _ body: (inout sending State) throws(E) -> sending Result
+        ) throws(E) -> sending Result {
+            try inner.withLock(body)
+        }
+    }
+#else
+    /// Single-threaded fallback: disabling the `MultiThread` trait is a promise
+    /// that the process never accesses WasmKit state from more than one thread,
+    /// so plain storage without a lock is enough.
+    struct PlatformMutex<State>: ~Copyable, @unchecked Sendable {
+        private var state: State
+
+        init(_ initial: consuming State) {
+            self.state = initial
+        }
+
+        mutating func withLock<Result, E: Error>(
+            _ body: (inout State) throws(E) -> Result
+        ) throws(E) -> Result {
+            try body(&state)
+        }
+    }
+#endif

--- a/Sources/WasmParser/CMakeLists.txt
+++ b/Sources/WasmParser/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_wasmkit_libraries(WasmParser PUBLIC
 
 if(WASMKIT_ENABLE_FILESYSTEM)
   target_compile_options(WasmParser PRIVATE
-    $<$<COMPILE_LANGUAGE:Swift>:-D;FileSystem>)
+    $<$<COMPILE_LANGUAGE:Swift>:-DFileSystem>)
   target_link_wasmkit_libraries(WasmParser PUBLIC
     SystemPackage)
 endif()


### PR DESCRIPTION
Part of the Embedded Swift support work (#357), split out for incremental review.

Adds a `MultiThread` package trait (enabled by default) and a `PlatformMutex` wrapper in `Sources/WasmKit/Platform/`:

- With the trait enabled, `PlatformMutex` is backed by `Synchronization.Mutex`, forwarding the closure directly so the state type needs no `Sendable` bound.
- With the trait disabled, it degrades to plain unsynchronized storage with the same non-copyable shape. This serves single-threaded environments such as bare-metal Embedded Swift targets, where the `Synchronization` module provides no `Mutex`. Disabling the trait is a promise that the process runs single-threaded, so the fallback carries `@unchecked Sendable`.

`Interner` adopts the wrapper, replacing its direct `Mutex` use. Its lock property is annotated `nonisolated(unsafe)` because the single-threaded fallback mutates in place (`mutating withLock`), which `Sendable` checking cannot see through. The class conformance itself stays checked.

The CMake build defines `MultiThread` unconditionally. No functional change with default traits.
