### PR TITLE
Add printable core types and a typed Trap kind in WasmKitError

### DIFF
--- a/Sources/WasmKit/Execution/Errors.swift
+++ b/Sources/WasmKit/Execution/Errors.swift
@@ -18,13 +18,13 @@ public struct Backtrace: CustomStringConvertible, Sendable {
     public var description: String {
         symbols.enumerated().map { (index, symbol) in
             let name = symbol.name ?? "unknown"
-            return "    \(index): (\(symbol.address)) \(name)"
+            return "    \(index): (0x\(String(UInt(bitPattern: symbol.address), radix: 16))) \(name)"
         }.joined(separator: "\n")
     }
 }
 
 /// An error that occurs during execution of a WebAssembly module.
-public struct Trap: Error, CustomStringConvertible {
+public struct Trap: Error, CustomStringConvertible, Sendable {
     /// The reason for the trap.
     package private(set) var reason: TrapReason
 
@@ -70,7 +70,7 @@ public struct WasmKitException: Error, CustomStringConvertible {
     }
 
     public var description: String {
-        "wasm exception (payload: \(payload))"
+        "wasm exception (payload: [\(Value.descriptionList(payload))])"
     }
 
     /// Returns true if this exception's tag matches the given tag handle.
@@ -80,8 +80,8 @@ public struct WasmKitException: Error, CustomStringConvertible {
 }
 
 /// A reason for a trap that occurred during execution of a WebAssembly module.
-package enum TrapReason: Error, CustomStringConvertible {
-    package struct Message {
+package enum TrapReason: Error, CustomStringConvertible, Sendable {
+    package struct Message: Sendable {
         let text: String
 
         init(_ text: String) {
@@ -150,10 +150,10 @@ extension TrapReason.Message {
         Self("initial memory size exceeds the resource limit: \(byteSize) bytes")
     }
     static func parameterTypesMismatch(expected: [ValueType], got: [Value]) -> Self {
-        Self("parameter types don't match, expected \(expected), got \(got)")
+        Self("parameter types don't match, expected [\(ValueType.descriptionList(expected))], got [\(Value.descriptionList(got))]")
     }
     static func resultTypesMismatch(expected: [ValueType], got: [Value]) -> Self {
-        Self("result types don't match, expected \(expected), got \(got)")
+        Self("result types don't match, expected [\(ValueType.descriptionList(expected))], got [\(Value.descriptionList(got))]")
     }
     static var cannotAssignToImmutableGlobal: Self {
         Self("cannot assign to an immutable global")
@@ -168,10 +168,10 @@ extension TrapReason.Message {
         Self("`memory.atomic.wait` requires a shared memory")
     }
     static func noGlobalExportWithName(globalName: String, instance: Instance) -> Self {
-        Self("no global export with name \(globalName) in a module instance \(instance)")
+        Self("no global export with name \(globalName) in a module instance")
     }
     static func exportedFunctionNotFound(name: String, instance: Instance) -> Self {
-        Self("exported function \(name) not found in instance \(instance)")
+        Self("exported function \(name) not found in instance")
     }
     static func unimplemented(feature: String) -> Self {
         Self("\(feature) is not implemented yet")

--- a/Sources/WasmKit/WasmKitError.swift
+++ b/Sources/WasmKit/WasmKitError.swift
@@ -16,6 +16,7 @@ public struct WasmKitError: Swift.Error {
     package enum Kind: Sendable {
         case message(Message)
         case parserError(WasmParserError)
+        case trap(Trap)
     }
 
     package let kind: Kind
@@ -49,6 +50,14 @@ extension WasmKitError {
 }
 
 extension WasmKitError {
+    @usableFromInline
+    package init(_ trap: Trap) {
+        self.init(kind: .trap(trap))
+    }
+
+}
+
+extension WasmKitError {
     /// Wrap a closure that throws WasmParserError into one that throws WasmKitError.
     @usableFromInline
     static func wrap<T>(_ body: () throws(WasmParserError) -> T) throws(WasmKitError) -> T {
@@ -58,6 +67,10 @@ extension WasmKitError {
             throw WasmKitError(error)
         }
     }
+}
+
+extension WasmKitError.Message: CustomStringConvertible {
+    public var description: String { text }
 }
 
 extension WasmKitError: CustomStringConvertible {
@@ -71,6 +84,8 @@ extension WasmKitError: CustomStringConvertible {
             }
         case .parserError(let error):
             return error.description
+        case .trap(let trap):
+            return trap.reason.description
         }
     }
 }
@@ -146,7 +161,7 @@ extension WasmKitError.Message {
         Self("data count section is required but not found")
     }
 
-    static func indexOutOfBounds<Index: Numeric, Max: Numeric>(_ entity: StaticString, _ index: Index, max: Max) -> Self {
+    static func indexOutOfBounds<Index: BinaryInteger, Max: BinaryInteger>(_ entity: StaticString, _ index: Index, max: Max) -> Self {
         Self("\(entity) index out of bounds: \(index) (max: \(max))")
     }
 
@@ -206,7 +221,7 @@ extension WasmKitError.Message {
     }
 
     static func expectedTypeOnStackButEmpty(expected: ValueType?) -> Self {
-        let typeHint = expected.map(String.init(describing:)) ?? "a value"
+        let typeHint = expected.map { $0.description } ?? "a value"
         return Self("expected \(typeHint) on the stack top but it's empty")
     }
 
@@ -250,7 +265,7 @@ extension WasmKitError.Message {
     }
 
     static func illegalConstExpressionInstruction(_ constInst: WasmParser.Instruction) -> Self {
-        Self("illegal const expression instruction: \(constInst)")
+        Self("illegal const expression instruction")
     }
 
     static func inconsistentFunctionAndCodeLength(functionCount: Int, codeCount: Int) -> Self {

--- a/Sources/WasmParser/WasmTypes.swift
+++ b/Sources/WasmParser/WasmTypes.swift
@@ -484,3 +484,34 @@ extension Instruction.Store {
         }
     }
 }
+
+extension Limits: CustomStringConvertible {
+    public var description: String {
+        var result = "min: \(min)"
+        if let max = max { result += ", max: \(max)" }
+        if shared { result += ", shared" }
+        if isMemory64 { result += ", memory64" }
+        return result
+    }
+}
+
+extension TableType: CustomStringConvertible {
+    public var description: String {
+        "\(elementType) (\(limits))"
+    }
+}
+
+extension Mutability: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .constant: return "const"
+        case .variable: return "var"
+        }
+    }
+}
+
+extension GlobalType: CustomStringConvertible {
+    public var description: String {
+        "\(mutability) \(valueType)"
+    }
+}

--- a/Sources/WasmTypes/CMakeLists.txt
+++ b/Sources/WasmTypes/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_wasmkit_library(WasmTypes
+  Description.swift
   GuestMemory.swift
   WasmTypes.swift
 )

--- a/Sources/WasmTypes/Description.swift
+++ b/Sources/WasmTypes/Description.swift
@@ -1,0 +1,117 @@
+// Human-readable descriptions for core Wasm types.
+//
+// These are hand-written (rather than relying on the reflection-based default
+// stringification) so that string interpolation of these types also works
+// under Embedded Swift, which has no reflection support.
+
+extension AbstractHeapType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .funcRef: return "func"
+        case .externRef: return "extern"
+        case .exnRef: return "exn"
+        }
+    }
+}
+
+extension HeapType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .abstract(let type): return type.description
+        case .concrete(let typeIndex): return "$\(typeIndex)"
+        }
+    }
+}
+
+extension ReferenceType: CustomStringConvertible {
+    public var description: String {
+        if isNullable {
+            switch heapType {
+            case .abstract(.funcRef): return "funcref"
+            case .abstract(.externRef): return "externref"
+            case .abstract(.exnRef): return "exnref"
+            case .concrete: break
+            }
+        }
+        return "(ref \(isNullable ? "null " : "")\(heapType))"
+    }
+}
+
+extension ValueType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .i32: return "i32"
+        case .i64: return "i64"
+        case .f32: return "f32"
+        case .f64: return "f64"
+        case .v128: return "v128"
+        case .ref(let type): return type.description
+        }
+    }
+}
+
+extension FunctionType: CustomStringConvertible {
+    public var description: String {
+        "(\(ValueType.descriptionList(parameters))) -> (\(ValueType.descriptionList(results)))"
+    }
+}
+
+extension V128: CustomStringConvertible {
+    public var description: String {
+        // Build the hex string in a single byte buffer to avoid per-byte
+        // string allocations.
+        var utf8: [UInt8] = []
+        utf8.reserveCapacity(2 + bytes.count * 2)
+        utf8.append(UInt8(ascii: "0"))
+        utf8.append(UInt8(ascii: "x"))
+        for byte in bytes {
+            utf8.append(hexDigits.utf8Start[Int(byte >> 4)])
+            utf8.append(hexDigits.utf8Start[Int(byte & 0xF)])
+        }
+        return String(decoding: utf8, as: UTF8.self)
+    }
+}
+
+extension Reference: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .function(let address): return "funcref(\(addressDescription(address)))"
+        case .extern(let address): return "externref(\(addressDescription(address)))"
+        case .exception(let address): return "exnref(\(addressDescription(address)))"
+        }
+    }
+}
+
+extension Value: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .i32(let value): return "i32(\(value))"
+        case .i64(let value): return "i64(\(value))"
+        case .f32(let bitPattern): return "f32(0x\(String(bitPattern, radix: 16)))"
+        case .f64(let bitPattern): return "f64(0x\(String(bitPattern, radix: 16)))"
+        case .v128(let value): return "v128(\(value))"
+        case .ref(let reference): return reference.description
+        }
+    }
+}
+
+extension ValueType {
+    /// Returns the descriptions of `types` joined with ", ".
+    public static func descriptionList(_ types: [ValueType]) -> String {
+        types.map { $0.description }.joined(separator: ", ")
+    }
+}
+
+extension Value {
+    /// Returns the descriptions of `values` joined with ", ".
+    public static func descriptionList(_ values: [Value]) -> String {
+        values.map { $0.description }.joined(separator: ", ")
+    }
+}
+
+/// ASCII code units of the lowercase hex digits, indexable in O(1).
+private let hexDigits: StaticString = "0123456789abcdef"
+
+private func addressDescription(_ address: Int?) -> String {
+    address.map { "\($0)" } ?? "null"
+}


### PR DESCRIPTION
Part of the Embedded Swift support work (#357), split out for incremental review. Two commits:

**Add CustomStringConvertible to core Wasm types** — hand-written descriptions for `ValueType`, `ReferenceType`/`HeapType`, `FunctionType`, `Value`, `Reference`, `V128` (WasmTypes) and `Limits`, `TableType`, `GlobalType`, `Mutability` (WasmParser). String interpolation of these types previously fell back to reflection-based stringification, which Embedded Swift lacks; the explicit descriptions produce wasm-flavored text instead, e.g. `(i32, i32) -> (i32)`, `i32(5)`, `funcref`. Array formatting goes through static `descriptionList(_:)` methods on the element types rather than extensions on `Array` itself.

**WasmKitError: carry Trap as a typed error kind** — groundwork for typed throws in the instantiation path. `WasmKitError` gains a `trap` kind so `Trap`-throwing sub-operations can participate in a `throws(WasmKitError)` chain, `Trap`/`TrapReason` are declared `Sendable`, and the few reflection-dependent error messages (value arrays, instance handles, backtrace addresses) are rewritten into explicit formatting so they also compile under Embedded Swift. Error message text changes slightly where reflection dumps were previously used; no test relied on the old text.
