### PR TITLE
Add `--argv0` and `--dir host::guest` mapping to `wasmkit run`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,21 @@ let cliCommandsTarget = Target.target(
     swiftSettings: swiftSettings
 )
 
+let cliCommandsTestTarget = Target.testTarget(
+    name: "CLICommandsTests",
+    dependencies: [
+        "CLICommands",
+        "SystemExtras",
+        "WAT",
+        "WASI",
+        "WasmKit",
+        "WasmKitWASI",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SystemPackage", package: "swift-system"),
+    ],
+    exclude: ["Fixtures"]
+)
+
 let package = Package(
     name: "WasmKit",
     platforms: [.macOS(.v15), .iOS(.v18)],
@@ -59,6 +74,7 @@ let package = Package(
             exclude: ["CMakeLists.txt"],
             swiftSettings: swiftSettings
         ),
+        cliCommandsTestTarget,
         .target(
             name: "WasmKit",
             dependencies: [
@@ -159,7 +175,7 @@ let package = Package(
             exclude: ["CMakeLists.txt"],
             swiftSettings: swiftSettings
         ),
-        .testTarget(name: "WASITests", dependencies: ["WASI", "WasmKitWASI"], swiftSettings: swiftSettings),
+        .testTarget(name: "WASITests", dependencies: ["SystemExtras", "WASI", "WasmKitWASI"], swiftSettings: swiftSettings),
 
         .target(
             name: "SystemExtras",
@@ -172,6 +188,8 @@ let package = Package(
                 .define("SYSTEM_PACKAGE_DARWIN", .when(platforms: DarwinPlatforms))
             ]
         ),
+
+        .testTarget(name: "SystemExtrasTests", dependencies: ["SystemExtras"], swiftSettings: swiftSettings),
 
         .target(name: "CSystemExtras"),
 
@@ -355,8 +373,10 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
                 .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "SystemPackage", package: "swift-system"),
+                "SystemExtras",
                 "WasmKit",
                 "WasmKitWASI",
+                "WASI",
                 "GDBRemoteProtocol",
             ],
             exclude: ["LICENSE.txt"],
@@ -368,6 +388,13 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .product(name: "Logging", package: "swift-log", condition: .when(traits: ["WasmDebuggingSupport"])),
         .product(name: "NIOCore", package: "swift-nio", condition: .when(traits: ["WasmDebuggingSupport"])),
         .product(name: "NIOPosix", package: "swift-nio", condition: .when(traits: ["WasmDebuggingSupport"])),
+        .target(name: "GDBRemoteProtocol", condition: .when(traits: ["WasmDebuggingSupport"])),
+        .target(name: "WasmKitGDBHandler", condition: .when(traits: ["WasmDebuggingSupport"])),
+    ])
+
+    cliCommandsTestTarget.dependencies.append(contentsOf: [
+        .product(name: "Logging", package: "swift-log", condition: .when(traits: ["WasmDebuggingSupport"])),
+        .product(name: "NIOCore", package: "swift-nio", condition: .when(traits: ["WasmDebuggingSupport"])),
         .target(name: "GDBRemoteProtocol", condition: .when(traits: ["WasmDebuggingSupport"])),
         .target(name: "WasmKitGDBHandler", condition: .when(traits: ["WasmDebuggingSupport"])),
     ])

--- a/Sources/CLICommands/DebuggerServer.swift
+++ b/Sources/CLICommands/DebuggerServer.swift
@@ -21,6 +21,7 @@
     import SystemPackage
     import WasmKit
     import WasmKitGDBHandler
+    import WasmKitWASI
 
     struct DebuggerServer {
         var host = "127.0.0.1"
@@ -28,6 +29,7 @@
         var logLevel = Logger.Level.info
         let wasmModulePath: FilePath
         let engineConfiguration: EngineConfiguration
+        let wasiConfiguration: WASIConfiguration
 
         func run() async throws {
             let logger = {
@@ -68,15 +70,14 @@
                         )
                     }
                 }
-                /* the server will now be accepting connections */
-                logger.info("Debugger server listening on port \(port)")
-
                 let debuggerHandler = try await WasmKitGDBHandler(
                     moduleFilePath: self.wasmModulePath,
                     engineConfiguration: self.engineConfiguration,
+                    wasiConfiguration: self.wasiConfiguration,
                     logger: logger,
                     allocator: serverChannel.channel.allocator
                 )
+                logger.info("Debugger server listening on port \(port)")
 
                 // Discarding task group was designed for persistent server purposes, where a single failing request
                 // isn't taking down the entire server. In our case we need to be able to shut down the server on

--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -47,7 +47,7 @@ package struct Run: AsyncParsableCommand {
         let key: String
         let value: String
         init?(argument: String) {
-            var parts = argument.split(separator: "=", maxSplits: 2).makeIterator()
+            var parts = argument.split(separator: "=", maxSplits: 1).makeIterator()
             guard let key = parts.next(), let value = parts.next() else { return nil }
             self.key = String(key)
             self.value = String(value)
@@ -62,8 +62,39 @@ package struct Run: AsyncParsableCommand {
         ))
     var environment: [EnvOption] = []
 
-    @Option(name: .customLong("dir"), help: "Grant access to the given host directory")
-    var directories: [String] = []
+    struct DirOption: ExpressibleByArgument {
+        let argument: String
+
+        /// nil when the value has more than one `::`. Rejecting it from `init?` instead would replace
+        /// the message `derivePreopens()` throws with ArgumentParser's generic one.
+        let paths: (hostPath: String, guestPath: String)?
+
+        init?(argument: String) {
+            self.argument = argument
+            let components = argument.split(separator: "::", omittingEmptySubsequences: false)
+            switch components.count {
+            case 1: self.paths = (argument, argument)
+            case 2: self.paths = (String(components[0]), String(components[1]))
+            default: self.paths = nil
+            }
+        }
+    }
+
+    @Option(
+        name: .customLong("dir"),
+        help: ArgumentHelp(
+            "Grant access to the given host directory, optionally under a different guest path",
+            valueName: "host[::guest]"
+        ))
+    var directories: [DirOption] = []
+
+    @Option(
+        name: .customLong("argv0"),
+        help: ArgumentHelp(
+            "Override argv[0] passed to the WASI program",
+            valueName: "value"
+        ))
+    var argv0: String?
 
     enum ThreadingModel: String, ExpressibleByArgument, CaseIterable {
         #if !os(WASI)
@@ -141,15 +172,12 @@ package struct Run: AsyncParsableCommand {
         #if WasmDebuggingSupport
 
             if let debuggerPort {
-                guard !self.signpost && self.profileOutput == nil else {
-                    fatalError("Signpost logging and profiling are currently not supported while debugging Wasm modules.")
-                }
-
                 let debuggerServer = DebuggerServer(
                     port: debuggerPort,
                     logLevel: self.verbose ? .trace : .info,
                     wasmModulePath: FilePath(self.path),
-                    engineConfiguration: self.deriveRuntimeConfiguration()
+                    engineConfiguration: self.deriveRuntimeConfiguration(),
+                    wasiConfiguration: try self.deriveWASIConfiguration()
                 )
                 try await debuggerServer.run()
                 return
@@ -329,13 +357,52 @@ package struct Run: AsyncParsableCommand {
         )
     }
 
-    func instantiateWASI(module: Module, interceptor: EngineInterceptor?) throws -> () throws -> Void {
-        // Flatten environment variables into a dictionary (Respect the last value if a key is duplicated)
-        let environment = environment.reduce(into: [String: String]()) {
+    package func deriveEnvironment() -> [String: String] {
+        environment.reduce(into: [String: String]()) {
             $0[$1.key] = $1.value
         }
-        let preopens = directories.map { WASIBridgeToHost.Preopen(guestPath: $0, hostPath: $0) }
-        let wasi = try WASIBridgeToHost(args: [path] + arguments, environment: environment, preopens: preopens)
+    }
+
+    package func derivePreopens() throws -> [WASIBridgeToHost.Preopen] {
+        try directories.map { directory in
+            guard let paths = directory.paths else {
+                throw ValidationError(
+                    """
+                    The value '\(directory.argument)' for '--dir' contains more than one '::'. \
+                    Use at most one separator, as in 'host::guest'.
+                    """
+                )
+            }
+            return WASIBridgeToHost.Preopen(guestPath: paths.guestPath, hostPath: paths.hostPath)
+        }
+    }
+
+    package mutating func validate() throws {
+        _ = try derivePreopens()
+
+        #if WasmDebuggingSupport
+            if debuggerPort != nil, signpost || profileOutput != nil {
+                throw ValidationError(
+                    "Signpost logging and profiling are not supported while debugging Wasm modules."
+                )
+            }
+        #endif
+    }
+
+    package func deriveWASIArguments() -> [String] {
+        [argv0 ?? path] + arguments
+    }
+
+    package func deriveWASIConfiguration() throws -> WASIConfiguration {
+        WASIConfiguration(
+            arguments: deriveWASIArguments(),
+            environment: deriveEnvironment(),
+            preopens: try derivePreopens()
+        )
+    }
+
+    func instantiateWASI(module: Module, interceptor: EngineInterceptor?) throws -> () throws -> Void {
+        let wasi = try WASIBridgeToHost(configuration: deriveWASIConfiguration())
         let engine = Engine(configuration: deriveRuntimeConfiguration(), interceptor: interceptor)
         let store = Store(engine: engine)
         return {

--- a/Sources/SystemExtras/CMakeLists.txt
+++ b/Sources/SystemExtras/CMakeLists.txt
@@ -2,6 +2,7 @@ add_wasmkit_library(SystemExtras
   Vendor/Exports.swift
   Vendor/Utils.swift
   Vendor/WindowsSyscallAdapter.swift
+  CleanupFailure.swift
   Clock.swift
   Constants.swift
   FileAtOperations.swift

--- a/Sources/SystemExtras/CleanupFailure.swift
+++ b/Sources/SystemExtras/CleanupFailure.swift
@@ -1,0 +1,35 @@
+/// A failure raised by cleanup that ran while unwinding from another failure. Both stay visible.
+package struct CleanupFailure: Error, CustomStringConvertible {
+    package let underlying: any Error
+    package let cleanup: any Error
+
+    package var description: String {
+        "\(underlying) (cleanup also failed: \(cleanup))"
+    }
+
+    package init(underlying: any Error, cleanup: any Error) {
+        self.underlying = underlying
+        self.cleanup = cleanup
+    }
+
+    package static func preserving(_ error: any Error, cleanup: () throws -> Void) -> any Error {
+        do {
+            try cleanup()
+            return error
+        } catch let cleanupError {
+            return CleanupFailure(underlying: error, cleanup: cleanupError)
+        }
+    }
+
+    package static func preserving(
+        _ error: any Error,
+        cleanup: () async throws -> Void
+    ) async -> any Error {
+        do {
+            try await cleanup()
+            return error
+        } catch let cleanupError {
+            return CleanupFailure(underlying: error, cleanup: cleanupError)
+        }
+    }
+}

--- a/Sources/SystemExtras/ThrowingDefer.swift
+++ b/Sources/SystemExtras/ThrowingDefer.swift
@@ -10,52 +10,42 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Runs a cleanup closure (`deferred`) after a given `work` closure,
-/// making sure `deferred` is run also when `work` throws an error.
-/// - Parameters:
-///   - work: The work that should be performed. Will always be executed.
-///   - deferred: The cleanup that needs to be done in any case.
-/// - Throws: Any error thrown by `deferred` or `work` (in that order).
+/// Runs `deferred` after `work`, exactly once, also when `work` throws.
+/// - Throws: The error thrown by `work`, or by `deferred` when `work` succeeded. When both throw,
+///           a ``CleanupFailure`` carrying `work`'s error as ``CleanupFailure/underlying``.
 /// - Returns: The result of `work`.
-/// - Note: If `work` **and** `deferred` throw an error,
-///         the one thrown by `deferred` is thrown from this function.
 /// - SeeAlso: ``withAsyncThrowing(do:defer:)``
 @discardableResult
 package func withThrowing<T>(
     do work: () throws -> T,
     defer deferred: () throws -> Void
 ) throws -> T {
+    let result: T
     do {
-        let result = try work()
-        try deferred()
-        return result
+        result = try work()
     } catch {
-        try deferred()
-        throw error
+        throw CleanupFailure.preserving(error, cleanup: deferred)
     }
+    try deferred()
+    return result
 }
 
-/// Runs an async cleanup closure (`deferred`) after a given async `work` closure,
-/// making sure `deferred` is run also when `work` throws an error.
-/// - Parameters:
-///   - work: The work that should be performed. Will always be executed.
-///   - deferred: The cleanup that needs to be done in any case.
-/// - Throws: Any error thrown by `deferred` or `work` (in that order).
+/// Runs async `deferred` after async `work`, exactly once, also when `work` throws.
+/// - Throws: The error thrown by `work`, or by `deferred` when `work` succeeded. When both throw,
+///           a ``CleanupFailure`` carrying `work`'s error as ``CleanupFailure/underlying``.
 /// - Returns: The result of `work`.
-/// - Note: If `work` **and** `deferred` throw an error,
-///         the one thrown by `deferred` is thrown from this function.
 /// - SeeAlso: ``withThrowing(do:defer:)``
 @discardableResult
 package func withAsyncThrowing<T: Sendable>(
     do work: @Sendable () async throws -> T,
     defer deferred: @Sendable () async throws -> Void
 ) async throws -> T {
+    let result: T
     do {
-        let result = try await work()
-        try await deferred()
-        return result
+        result = try await work()
     } catch {
-        try await deferred()
-        throw error
+        throw await CleanupFailure.preserving(error, cleanup: deferred)
     }
+    try await deferred()
+    return result
 }

--- a/Sources/WASI/Platform/Directory.swift
+++ b/Sources/WASI/Platform/Directory.swift
@@ -99,7 +99,9 @@ extension DirEntry: WASIDir, FdWASIEntry {
                 try fd.setTimes(access: access, modification: modification)
             }
         } defer: {
-            try fd.close()
+            try WASIAbi.Errno.translatingPlatformErrno {
+                try fd.close()
+            }
         }
     }
 

--- a/Sources/WASI/Platform/HostFileSystem.swift
+++ b/Sources/WASI/Platform/HostFileSystem.swift
@@ -1,3 +1,4 @@
+import SystemExtras
 import SystemPackage
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
@@ -41,8 +42,12 @@ final class HostFileSystem: FileSystemImplementation, Sendable {
             }
         #endif
 
-        guard try fd.attributes().fileType.isDirectory else {
-            throw WASIAbi.Errno.ENOTDIR
+        do {
+            guard try fd.attributes().fileType.isDirectory else {
+                throw WASIAbi.Errno.ENOTDIR
+            }
+        } catch {
+            throw CleanupFailure.preserving(error, cleanup: fd.close)
         }
 
         return DirEntry(preopenPath: guestPath, fd: fd)

--- a/Sources/WASI/Platform/PlatformTypes.swift
+++ b/Sources/WASI/Platform/PlatformTypes.swift
@@ -164,6 +164,16 @@ extension WASIAbi.Errno {
         }
     }
 
+    /// Looks through a cleanup failure so a failing close still reports the operation's own errno
+    /// instead of trapping the guest.
+    static func reportable(for error: any Error) -> WASIAbi.Errno? {
+        switch error {
+        case let errno as WASIAbi.Errno: return errno
+        case let failure as CleanupFailure: return reportable(for: failure.underlying)
+        default: return nil
+        }
+    }
+
     init(platformErrno: CInt) throws {
         try self.init(platformErrno: SystemPackage.Errno(rawValue: platformErrno))
     }

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -822,7 +822,8 @@ extension WASIImplementation {
             return WASIHostFunction(type: type) { caller, arguments in
                 do {
                     return try implementation(caller, arguments)
-                } catch let errno as WASIAbi.Errno {
+                } catch {
+                    guard let errno = WASIAbi.Errno.reportable(for: error) else { throw error }
                     return [.i32(.init(errno.rawValue))]
                 }
             }

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -1,4 +1,5 @@
 import Synchronization
+import SystemExtras
 import SystemPackage
 
 /// A bridge that connects WebAssembly System Interface (WASI) calls to the host system.
@@ -125,14 +126,13 @@ public final class WASIBridgeToHost: Sendable {
     ///
     /// - Parameter body: A closure that receives the bridge and returns a value.
     /// - Returns: The value returned by `body`.
+    /// - Throws: `body`'s error, or the error from closing when `body` succeeded. When both fail, the
+    ///   error carries both failures.
     public func runAndClose<R>(_ body: (WASIBridgeToHost) throws -> R) throws -> R {
-        do {
-            let result = try body(self)
+        try withThrowing {
+            try body(self)
+        } defer: {
             try close()
-            return result
-        } catch {
-            try close()
-            throw error
         }
     }
 
@@ -156,7 +156,8 @@ public final class WASIBridgeToHost: Sendable {
     ///   - wallClock: Clock for wall-clock time queries. Defaults to `SystemWallClock()`.
     ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
     ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
-    /// - Throws: An error if the file system or preopens cannot be initialized.
+    /// - Throws: An error if the file system or preopens cannot be initialized. When releasing the
+    ///   descriptors opened so far also fails, the error carries both failures.
     @available(*, deprecated, message: "Use the ordered `preopens: [WASIBridgeToHost.Preopen]` initializer instead.")
     @_disfavoredOverload
     public convenience init(
@@ -199,7 +200,8 @@ public final class WASIBridgeToHost: Sendable {
     ///   - wallClock: Clock for wall-clock time queries. Defaults to `SystemWallClock()`.
     ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
     ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
-    /// - Throws: An error if the file system or preopens cannot be initialized.
+    /// - Throws: An error if the file system or preopens cannot be initialized. When releasing the
+    ///   descriptors opened so far also fails, the error carries both failures.
     public convenience init(
         args: [String] = [],
         environment: [String: String] = [:],
@@ -240,9 +242,14 @@ public final class WASIBridgeToHost: Sendable {
             monotonicClock: monotonicClock,
             randomGenerator: randomGenerator
         )
-        try underlying.fdTable.withLock { table in
-            try fileSystemOptions.initializeStdio?(&table)
-            try fileSystemOptions.initializePreopens?(fileSystem, &table)
+        do {
+            try underlying.fdTable.withLock { table in
+                try fileSystemOptions.initializeStdio?(&table)
+                try fileSystemOptions.initializePreopens?(fileSystem, &table)
+            }
+        } catch {
+            // A throw here runs `deinit`, whose precondition requires `close()`, so release what was opened.
+            throw CleanupFailure.preserving(error, cleanup: close)
         }
     }
 
@@ -254,7 +261,8 @@ public final class WASIBridgeToHost: Sendable {
     ///   - wallClock: Clock for wall-clock time queries. Defaults to `SystemWallClock()`.
     ///   - monotonicClock: Clock for monotonic time queries. Defaults to `SystemMonotonicClock()`.
     ///   - randomGenerator: Random number generator. Defaults to `SystemRandomNumberGenerator()`.
-    /// - Throws: An error if the file system or initialization fails.
+    /// - Throws: An error if the file system or initialization fails. When releasing the descriptors
+    ///   opened so far also fails, the error carries both failures.
     public convenience init(
         args: [String] = [],
         environment: [String: String] = [:],

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -16,7 +16,9 @@
     import Logging
     import NIOCore
     import NIOFileSystem
+    import SystemExtras
     import SystemPackage
+    import WASI
     import WasmKit
     import WasmKitWASI
 
@@ -63,6 +65,7 @@
         package init(
             moduleFilePath: FilePath,
             engineConfiguration: EngineConfiguration,
+            wasiConfiguration: WASIConfiguration,
             logger: Logger,
             allocator: ByteBufferAllocator
         ) async throws {
@@ -77,7 +80,7 @@
 
             let store = Store(engine: Engine(configuration: engineConfiguration))
             var imports = Imports()
-            let wasi = try WASIBridgeToHost()
+            let wasi = try WASIBridgeToHost(configuration: wasiConfiguration)
             wasi.link(to: &imports, store: store)
             self.wasi = wasi
 
@@ -89,8 +92,7 @@
                     throw Error.stoppingAtEntrypointFailed
                 }
             } catch {
-                try wasi.close()
-                throw error
+                throw CleanupFailure.preserving(error, cleanup: wasi.close)
             }
 
             self.memoryView = DebuggerMemoryView(allocator: allocator, wasmBinary: wasmBinary)

--- a/Sources/WasmKitWASI/CMakeLists.txt
+++ b/Sources/WasmKitWASI/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_wasmkit_library(WasmKitWASI
   WASIBridgeToHost+WasmKit.swift
+  WASIConfiguration.swift
 )
 
 target_link_wasmkit_libraries(WasmKitWASI PUBLIC

--- a/Sources/WasmKitWASI/WASIConfiguration.swift
+++ b/Sources/WasmKitWASI/WASIConfiguration.swift
@@ -1,0 +1,27 @@
+import WASI
+
+package struct WASIConfiguration: Sendable {
+    package let arguments: [String]
+    package let environment: [String: String]
+    package let preopens: [WASIBridgeToHost.Preopen]
+
+    package init(
+        arguments: [String],
+        environment: [String: String],
+        preopens: [WASIBridgeToHost.Preopen]
+    ) {
+        self.arguments = arguments
+        self.environment = environment
+        self.preopens = preopens
+    }
+}
+
+extension WASIBridgeToHost {
+    package convenience init(configuration: WASIConfiguration) throws {
+        try self.init(
+            args: configuration.arguments,
+            environment: configuration.environment,
+            preopens: configuration.preopens
+        )
+    }
+}

--- a/Tests/CLICommandsTests/DebuggerWASIConfigurationTests.swift
+++ b/Tests/CLICommandsTests/DebuggerWASIConfigurationTests.swift
@@ -1,0 +1,52 @@
+#if WasmDebuggingSupport && (os(macOS) || os(Linux))
+
+    import Foundation
+    import GDBRemoteProtocol
+    import Logging
+    import NIOCore
+    import SystemExtras
+    import SystemPackage
+    import Testing
+    import WAT
+    import WasmKit
+    import WasmKitGDBHandler
+    import WasmKitWASI
+
+    import CLICommands
+
+    @Suite struct DebuggerWASIConfigurationTests {
+        @Test func debuggeeSeesMappedPreopenAndOverriddenArgv0() async throws {
+            try await PreopenFixture.withProbeDirectory { directory in
+                let modulePath = directory.appendingPathComponent("fixture.wasm")
+                try Data(wat2wasm(PreopenFixture.fixtureSource())).write(to: modulePath)
+
+                let argv0 = "/cross-build/wasm32/python.wasm"
+                let run = try Run.parse([
+                    "--dir", "\(directory.path)::/",
+                    "--argv0", argv0,
+                    modulePath.path,
+                    argv0, "/", "probe.txt", PreopenFixture.fixtureContents,
+                ])
+                let handler = try await WasmKitGDBHandler(
+                    moduleFilePath: FilePath(modulePath.path),
+                    engineConfiguration: EngineConfiguration(),
+                    wasiConfiguration: try run.deriveWASIConfiguration(),
+                    logger: Logger(label: "org.swiftwasm.WasmKit.tests"),
+                    allocator: ByteBufferAllocator()
+                )
+                try await withAsyncThrowing {
+                    let response = try await handler.handle(
+                        command: GDBHostCommand(kind: .continue, arguments: "")
+                    )
+                    guard case .string(let payload) = response.kind else {
+                        Issue.record("unexpected response kind for a finished debuggee")
+                        return
+                    }
+                    #expect(payload == "W00")
+                } defer: {
+                    try await handler.close()
+                }
+            }
+        }
+    }
+#endif

--- a/Tests/CLICommandsTests/Fixtures/wasi-preopen-argv0.wat
+++ b/Tests/CLICommandsTests/Fixtures/wasi-preopen-argv0.wat
@@ -1,0 +1,90 @@
+(module
+  (import "wasi_snapshot_preview1" "args_sizes_get"
+    (func $args_sizes_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "args_get"
+    (func $args_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_prestat_get"
+    (func $fd_prestat_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_prestat_dir_name"
+    (func $fd_prestat_dir_name (param i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_read"
+    (func $fd_read (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $proc_exit (param i32)))
+  (memory (export "memory") 2)
+
+  ;; Expectations arrive as guest arguments: argv[1] expected argv[0], argv[2] expected preopen name
+  ;; of fd 3, argv[3] path to open under fd 3, argv[4] expected contents of that path.
+  ;; Exit codes: 1 args_sizes_get, 2 wrong argc, 3 args_get, 4 argv[0] mismatch, 5 fd_prestat_get,
+  ;; 6 fd_prestat_dir_name, 7 preopen name mismatch, 8 path_open, 9 fd_read, 10 contents mismatch,
+  ;; 11 preopen name too long for its buffer.
+  ;; Memory map: 0 iovec, 8 bytes read, 16 argc, 20 argv buffer size, 24 opened fd, 32 prestat,
+  ;; 64 argv pointers, 1024 preopen name, 2048 file contents, 4096 argv buffer.
+
+  (func $strlen (param $p i32) (result i32)
+    (local $n i32)
+    (block $done
+      (loop $next
+        (br_if $done (i32.eqz (i32.load8_u (i32.add (local.get $p) (local.get $n)))))
+        (local.set $n (i32.add (local.get $n) (i32.const 1)))
+        (br $next)))
+    (local.get $n))
+
+  (func $streq (param $a i32) (param $b i32) (result i32)
+    (local $ca i32) (local $cb i32)
+    (block $done
+      (loop $next
+        (local.set $ca (i32.load8_u (local.get $a)))
+        (local.set $cb (i32.load8_u (local.get $b)))
+        (br_if $done (i32.ne (local.get $ca) (local.get $cb)))
+        (if (i32.eqz (local.get $ca)) (then (return (i32.const 1))))
+        (local.set $a (i32.add (local.get $a) (i32.const 1)))
+        (local.set $b (i32.add (local.get $b) (i32.const 1)))
+        (br $next)))
+    (i32.const 0))
+
+  (func $argv (param $i i32) (result i32)
+    (i32.load (i32.add (i32.const 64) (i32.mul (local.get $i) (i32.const 4)))))
+
+  (func $fail (param $code i32)
+    (call $proc_exit (local.get $code))
+    (unreachable))
+
+  (func (export "_start")
+    (local $len i32) (local $fd i32) (local $nread i32)
+    (if (call $args_sizes_get (i32.const 16) (i32.const 20))
+      (then (call $fail (i32.const 1))))
+    (if (i32.ne (i32.load (i32.const 16)) (i32.const 5))
+      (then (call $fail (i32.const 2))))
+    (if (call $args_get (i32.const 64) (i32.const 4096))
+      (then (call $fail (i32.const 3))))
+    (if (i32.eqz (call $streq (call $argv (i32.const 0)) (call $argv (i32.const 1))))
+      (then (call $fail (i32.const 4))))
+    (if (call $fd_prestat_get (i32.const 3) (i32.const 32))
+      (then (call $fail (i32.const 5))))
+    (local.set $len (i32.load (i32.const 36)))
+    (if (i32.gt_u (local.get $len) (i32.const 1023))
+      (then (call $fail (i32.const 11))))
+    (if (call $fd_prestat_dir_name (i32.const 3) (i32.const 1024) (local.get $len))
+      (then (call $fail (i32.const 6))))
+    (i32.store8 (i32.add (i32.const 1024) (local.get $len)) (i32.const 0))
+    (if (i32.eqz (call $streq (i32.const 1024) (call $argv (i32.const 2))))
+      (then (call $fail (i32.const 7))))
+    (if (call $path_open
+          (i32.const 3) (i32.const 1)
+          (call $argv (i32.const 3)) (call $strlen (call $argv (i32.const 3)))
+          (i32.const 0) (i64.const 2) (i64.const 0) (i32.const 0)
+          (i32.const 24))
+      (then (call $fail (i32.const 8))))
+    (local.set $fd (i32.load (i32.const 24)))
+    (i32.store (i32.const 0) (i32.const 2048))
+    (i32.store (i32.const 4) (i32.const 1023))
+    (if (call $fd_read (local.get $fd) (i32.const 0) (i32.const 1) (i32.const 8))
+      (then (call $fail (i32.const 9))))
+    (local.set $nread (i32.load (i32.const 8)))
+    (i32.store8 (i32.add (i32.const 2048) (local.get $nread)) (i32.const 0))
+    (if (i32.eqz (call $streq (i32.const 2048) (call $argv (i32.const 4))))
+      (then (call $fail (i32.const 10)))))
+)

--- a/Tests/CLICommandsTests/PreopenFixture.swift
+++ b/Tests/CLICommandsTests/PreopenFixture.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SystemExtras
+import WASI
+import WAT
+import WasmKit
+
+enum PreopenFixture {
+    static let fixtureContents = "wasmkit-preopen-fixture"
+
+    static var fixturePath: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/wasi-preopen-argv0.wat")
+            .path
+    }
+
+    static func fixtureSource() throws -> String {
+        try String(contentsOfFile: fixturePath, encoding: .utf8)
+    }
+
+    static func fixtureModule() throws -> Module {
+        try WasmKit.parseWasm(bytes: wat2wasm(fixtureSource()))
+    }
+
+    static func withProbeDirectory<R>(_ body: (URL) throws -> R) throws -> R {
+        let directory = try makeProbeDirectory()
+        return try withThrowing {
+            try body(directory)
+        } defer: {
+            try FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    static func withProbeDirectory<R: Sendable>(
+        _ body: @Sendable (URL) async throws -> R
+    ) async throws -> R {
+        let directory = try makeProbeDirectory()
+        return try await withAsyncThrowing {
+            try await body(directory)
+        } defer: {
+            try FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    private static func makeProbeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wasmkit-cli-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(fixtureContents.utf8).write(to: directory.appendingPathComponent("probe.txt"))
+        return directory
+    }
+}

--- a/Tests/CLICommandsTests/PreopenFixtureTests.swift
+++ b/Tests/CLICommandsTests/PreopenFixtureTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SystemExtras
+import Testing
+
+enum FixtureProbeError: Error, Equatable {
+    case body
+}
+
+@Suite struct PreopenFixtureTests {
+    @Test func aFailingDirectoryRemovalIsReportedOnce() throws {
+        let error = #expect(throws: (any Error).self) {
+            try PreopenFixture.withProbeDirectory { directory in
+                try FileManager.default.removeItem(at: directory)
+            }
+        }
+        let thrown = try #require(error)
+        #expect(!(thrown is CleanupFailure))
+    }
+
+    @Test func theBodyErrorSurvivesTheCleanup() throws {
+        var probeDirectory: URL?
+        let error = #expect(throws: FixtureProbeError.self) {
+            try PreopenFixture.withProbeDirectory { directory in
+                probeDirectory = directory
+                throw FixtureProbeError.body
+            }
+        }
+        #expect(error == .body)
+        #expect(!FileManager.default.fileExists(atPath: try #require(probeDirectory).path))
+    }
+}

--- a/Tests/CLICommandsTests/RunOptionsTests.swift
+++ b/Tests/CLICommandsTests/RunOptionsTests.swift
@@ -1,0 +1,111 @@
+import ArgumentParser
+import CLICommands
+import Testing
+import WasmKitWASI
+
+@Suite struct RunOptionsTests {
+    @Test func identityDirGrantsTheSameGuestPath() throws {
+        let run = try Run.parse(["--dir", "/host/dir", "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.count == 1)
+        #expect(preopens.first?.hostPath == "/host/dir")
+        #expect(preopens.first?.guestPath == "/host/dir")
+    }
+
+    @Test func mappedDirSplitsHostFromGuest() throws {
+        let run = try Run.parse(["--dir", "/host/dir::/", "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.count == 1)
+        #expect(preopens.first?.hostPath == "/host/dir")
+        #expect(preopens.first?.guestPath == "/")
+    }
+
+    @Test func mappedDirAcceptsAnEmptyGuestPath() throws {
+        let run = try Run.parse(["--dir", "/host::", "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.first?.hostPath == "/host")
+        #expect(preopens.first?.guestPath == "")
+    }
+
+    @Test func dirWithMoreThanOneSeparatorIsRejected() throws {
+        let error = #expect(throws: (any Error).self) {
+            _ = try Run.parse(["--dir", "/host::/a::/b", "module.wasm"])
+        }
+        let thrown = try #require(error)
+        #expect(Run.exitCode(for: thrown) == .validationFailure)
+        let message = Run.message(for: thrown)
+        #expect(message.contains("'/host::/a::/b'"))
+        #expect(message.contains("more than one '::'"))
+    }
+
+    @Test func repeatedDirsKeepCommandLineOrder() throws {
+        let run = try Run.parse(["--dir", "/a::/x", "--dir", "/b::/y", "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.map(\.hostPath) == ["/a", "/b"])
+        #expect(preopens.map(\.guestPath) == ["/x", "/y"])
+    }
+
+    @Test func argv0DefaultsToTheModulePath() throws {
+        let run = try Run.parse(["module.wasm", "extra"])
+        #expect(run.deriveWASIArguments() == ["module.wasm", "extra"])
+    }
+
+    @Test func argv0OptionOverridesTheFirstWASIArgument() throws {
+        let run = try Run.parse(["--argv0", "/cross-build/wasm32/python.wasm", "module.wasm", "extra"])
+        #expect(run.deriveWASIArguments() == ["/cross-build/wasm32/python.wasm", "extra"])
+    }
+
+    @Test func emptyArgv0IsPassedThroughVerbatim() throws {
+        let run = try Run.parse(["--argv0", "", "module.wasm", "extra"])
+        #expect(run.deriveWASIArguments() == ["", "extra"])
+    }
+
+    @Test func emptyDirIsAnIdentityGrantOfAnEmptyPath() throws {
+        let run = try Run.parse(["--dir", "", "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.first?.hostPath == "")
+        #expect(preopens.first?.guestPath == "")
+    }
+
+    @Test func dirWithAnEmptyHostKeepsTheGuestPath() throws {
+        let run = try Run.parse(["--dir", "::/guest", "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.first?.hostPath == "")
+        #expect(preopens.first?.guestPath == "/guest")
+    }
+
+    @Test func windowsDriveLetterIsNotASeparator() throws {
+        let run = try Run.parse(["--dir", #"C:\dir::/mnt"#, "module.wasm"])
+        let preopens = try run.derivePreopens()
+        #expect(preopens.first?.hostPath == #"C:\dir"#)
+        #expect(preopens.first?.guestPath == "/mnt")
+    }
+
+    @Test func environmentValueKeepsInnerEqualsSigns() throws {
+        let run = try Run.parse(["--env", "LS_COLORS=di=1:ln=2", "module.wasm"])
+        #expect(run.deriveEnvironment() == ["LS_COLORS": "di=1:ln=2"])
+    }
+
+    @Test func lastEnvironmentValueWinsForADuplicateKey() throws {
+        let run = try Run.parse(["--env", "A=1", "--env", "A=2", "module.wasm"])
+        #expect(run.deriveEnvironment() == ["A": "2"])
+    }
+}
+
+#if WasmDebuggingSupport
+    @Suite struct RunDebuggerOptionTests {
+        @Test func debuggerPortWithSignpostIsRejectedAsAUsageError() throws {
+            let error = #expect(throws: (any Error).self) {
+                _ = try Run.parse(["--debugger-port", "4455", "--enable-signpost", "module.wasm"])
+            }
+            #expect(Run.exitCode(for: try #require(error)) == .validationFailure)
+        }
+
+        @Test func debuggerPortWithProfilingIsRejectedAsAUsageError() throws {
+            let error = #expect(throws: (any Error).self) {
+                _ = try Run.parse(["--debugger-port", "4455", "--profile", "/tmp/p.json", "module.wasm"])
+            }
+            #expect(Run.exitCode(for: try #require(error)) == .validationFailure)
+        }
+    }
+#endif

--- a/Tests/CLICommandsTests/RunWASIConfigurationTests.swift
+++ b/Tests/CLICommandsTests/RunWASIConfigurationTests.swift
@@ -1,0 +1,46 @@
+#if os(macOS) || os(Linux)
+
+    import Testing
+    import WasmKit
+    import WasmKitWASI
+
+    import CLICommands
+
+    @Suite struct RunWASIConfigurationTests {
+        private func runFixture(arguments: [String]) throws -> UInt32 {
+            let run = try Run.parse(arguments)
+            let bridge = try WASIBridgeToHost(configuration: run.deriveWASIConfiguration())
+            return try bridge.runAndClose { wasi in
+                let store = Store(engine: Engine())
+                var imports = Imports()
+                wasi.link(to: &imports, store: store)
+                let instance = try PreopenFixture.fixtureModule().instantiate(store: store, imports: imports)
+                return try wasi.start(instance)
+            }
+        }
+
+        @Test func guestSeesMappedPreopenAndOverriddenArgv0() throws {
+            try PreopenFixture.withProbeDirectory { directory in
+                let argv0 = "/cross-build/wasm32/python.wasm"
+                let exitCode = try runFixture(arguments: [
+                    "--dir", "\(directory.path)::/",
+                    "--argv0", argv0,
+                    PreopenFixture.fixturePath,
+                    argv0, "/", "probe.txt", PreopenFixture.fixtureContents,
+                ])
+                #expect(exitCode == 0)
+            }
+        }
+
+        @Test func guestSeesIdentityPreopenAndModulePathArgv0() throws {
+            try PreopenFixture.withProbeDirectory { directory in
+                let exitCode = try runFixture(arguments: [
+                    "--dir", directory.path,
+                    PreopenFixture.fixturePath,
+                    PreopenFixture.fixturePath, directory.path, "probe.txt", PreopenFixture.fixtureContents,
+                ])
+                #expect(exitCode == 0)
+            }
+        }
+    }
+#endif

--- a/Tests/SystemExtrasTests/CleanupFailureTests.swift
+++ b/Tests/SystemExtrasTests/CleanupFailureTests.swift
@@ -1,0 +1,32 @@
+import SystemExtras
+import Testing
+
+@Suite struct CleanupFailureTests {
+    @Test func successfulCleanupPreservesTheOriginalError() throws {
+        let result = CleanupFailure.preserving(ProbeError.body) {}
+        #expect(result as? ProbeError == .body)
+    }
+
+    @Test func failedCleanupSurfacesBothErrors() throws {
+        let result = CleanupFailure.preserving(ProbeError.body) { throw ProbeError.cleanup }
+        let combined = try #require(result as? CleanupFailure)
+        #expect(combined.underlying as? ProbeError == .body)
+        #expect(combined.cleanup as? ProbeError == .cleanup)
+        #expect(combined.description.contains("body"))
+        #expect(combined.description.contains("cleanup"))
+    }
+
+    @Test func successfulAsyncCleanupPreservesTheOriginalError() async throws {
+        let cleanup: () async throws -> Void = {}
+        let result = await CleanupFailure.preserving(ProbeError.body, cleanup: cleanup)
+        #expect(result as? ProbeError == .body)
+    }
+
+    @Test func failedAsyncCleanupSurfacesBothErrors() async throws {
+        let cleanup: () async throws -> Void = { throw ProbeError.cleanup }
+        let result = await CleanupFailure.preserving(ProbeError.body, cleanup: cleanup)
+        let combined = try #require(result as? CleanupFailure)
+        #expect(combined.underlying as? ProbeError == .body)
+        #expect(combined.cleanup as? ProbeError == .cleanup)
+    }
+}

--- a/Tests/SystemExtrasTests/ProbeError.swift
+++ b/Tests/SystemExtrasTests/ProbeError.swift
@@ -1,0 +1,4 @@
+enum ProbeError: Error, Equatable {
+    case body
+    case cleanup
+}

--- a/Tests/SystemExtrasTests/ThrowingDeferTests.swift
+++ b/Tests/SystemExtrasTests/ThrowingDeferTests.swift
@@ -1,0 +1,88 @@
+import SystemExtras
+import Testing
+
+@Suite struct ThrowingDeferTests {
+    private actor Counter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+
+    @Test func bodyErrorSurvivesAFailingCleanup() throws {
+        let error = #expect(throws: (any Error).self) {
+            try withThrowing {
+                throw ProbeError.body
+            } defer: {
+                throw ProbeError.cleanup
+            }
+        }
+        let thrown = try #require(error)
+        let combined = try #require(thrown as? CleanupFailure)
+        #expect(combined.underlying as? ProbeError == .body)
+        #expect(combined.cleanup as? ProbeError == .cleanup)
+    }
+
+    @Test func cleanupRunsOnceWhenTheBodySucceedsAndCleanupFails() throws {
+        var attempts = 0
+        let error = #expect(throws: ProbeError.self) {
+            try withThrowing {
+                ()
+            } defer: {
+                attempts += 1
+                throw ProbeError.cleanup
+            }
+        }
+        #expect(attempts == 1)
+        #expect(error == .cleanup)
+    }
+
+    @Test func cleanupRunsOnceWhenBothFail() throws {
+        var attempts = 0
+        _ = #expect(throws: CleanupFailure.self) {
+            try withThrowing {
+                throw ProbeError.body
+            } defer: {
+                attempts += 1
+                throw ProbeError.cleanup
+            }
+        }
+        #expect(attempts == 1)
+    }
+
+    @Test func resultAndCleanupBothRunOnSuccess() throws {
+        var attempts = 0
+        let value = try withThrowing {
+            7
+        } defer: {
+            attempts += 1
+        }
+        #expect(value == 7)
+        #expect(attempts == 1)
+    }
+
+    @Test func asyncBodyErrorSurvivesAFailingCleanup() async throws {
+        let error = await #expect(throws: (any Error).self) {
+            try await withAsyncThrowing {
+                throw ProbeError.body
+            } defer: {
+                throw ProbeError.cleanup
+            }
+        }
+        let thrown = try #require(error)
+        let combined = try #require(thrown as? CleanupFailure)
+        #expect(combined.underlying as? ProbeError == .body)
+    }
+
+    @Test func asyncCleanupRunsOnceWhenTheBodySucceedsAndCleanupFails() async throws {
+        let attempts = Counter()
+        let error = await #expect(throws: ProbeError.self) {
+            try await withAsyncThrowing {
+                ()
+            } defer: {
+                await attempts.increment()
+                throw ProbeError.cleanup
+            }
+        }
+        #expect(await attempts.value == 1)
+        #expect(error == .cleanup)
+    }
+}

--- a/Tests/WASITests/PlatformTypesTests.swift
+++ b/Tests/WASITests/PlatformTypesTests.swift
@@ -1,0 +1,19 @@
+import SystemExtras
+import Testing
+
+@testable import WASI
+
+@Suite struct PlatformTypesTests {
+    @Test func plainErrnoIsReportedAsItself() {
+        #expect(WASIAbi.Errno.reportable(for: WASIAbi.Errno.EBADF) == .EBADF)
+    }
+
+    @Test func cleanupFailureReportsTheOperationErrno() {
+        let failure = CleanupFailure(underlying: WASIAbi.Errno.ENOTDIR, cleanup: WASIAbi.Errno.EIO)
+        #expect(WASIAbi.Errno.reportable(for: failure) == .ENOTDIR)
+    }
+
+    @Test func anUnrelatedErrorHasNoErrnoToReport() {
+        #expect(WASIAbi.Errno.reportable(for: WASIError(description: "unrelated")) == nil)
+    }
+}

--- a/Tests/WASITests/TestSupport.swift
+++ b/Tests/WASITests/TestSupport.swift
@@ -16,6 +16,43 @@ import Foundation
 #endif
 enum TestSupport {
 
+    #if os(macOS) || os(Linux)
+        /// Comparing paths rather than descriptor counts keeps assertions immune to whatever tests
+        /// run in parallel.
+        static func openDescriptorPaths() throws -> Set<String> {
+            #if os(macOS)
+                let fdDirectory = "/dev/fd"
+            #else
+                let fdDirectory = "/proc/self/fd"
+            #endif
+            var paths: Set<String> = []
+            for entry in try FileManager.default.contentsOfDirectory(atPath: fdDirectory) {
+                var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+                #if os(macOS)
+                    guard let fd = Int32(entry), fcntl(fd, F_GETPATH, &buffer) != -1 else { continue }
+                #else
+                    let length = readlink("\(fdDirectory)/\(entry)", &buffer, buffer.count - 1)
+                    guard length > 0 else { continue }
+                    buffer[length] = 0
+                #endif
+                paths.insert(string(fromCString: buffer))
+            }
+            return paths
+        }
+
+        /// `realpath`, not `URL.resolvingSymlinksInPath()`: the latter leaves a macOS temp path under
+        /// `/var/folders`, while the kernel reports descriptors under `/private/var/folders`.
+        static func realPath(_ path: String) throws -> String {
+            var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+            guard realpath(path, &buffer) != nil else { throw Error(errno: errno) }
+            return string(fromCString: buffer)
+        }
+
+        private static func string(fromCString buffer: [CChar]) -> String {
+            String(decoding: buffer.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
+        }
+    #endif
+
     struct Error: Swift.Error, CustomStringConvertible {
         let description: String
 

--- a/Tests/WASITests/WASIBridgeToHostTests.swift
+++ b/Tests/WASITests/WASIBridgeToHostTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SystemExtras
+import Testing
+
+@testable import WASI
+
+enum BridgeProbeError: Error, Equatable {
+    case body
+}
+
+@Suite struct WASIBridgeToHostTests {
+    @Test func failedPreopenThrowsInsteadOfTrippingTheCloseCheck() throws {
+        // `HostFileSystem.preopenDirectory` reports a bad path as `WASIError` everywhere except Windows,
+        // where `FileDescriptor.open` fails with a `SystemPackage.Errno` first.
+        #if os(Windows)
+            #expect(throws: (any Error).self) {
+                _ = try WASIBridgeToHost(
+                    preopens: [WASIBridgeToHost.Preopen(guestPath: "/", hostPath: "/definitely-not-here")]
+                )
+            }
+        #else
+            #expect(throws: WASIError.self) {
+                _ = try WASIBridgeToHost(
+                    preopens: [WASIBridgeToHost.Preopen(guestPath: "/", hostPath: "/definitely-not-here")]
+                )
+            }
+        #endif
+    }
+
+    #if os(macOS) || os(Linux)
+        // Windows opens a preopen `.readWrite`, which fails for a directory, so the first preopen
+        // cannot succeed there and the second would not be the failure under test.
+        @Test func failedPreopenAfterASuccessfulOneReleasesTheFirst() throws {
+            let directory = try TestSupport.TemporaryDirectory()
+            let resolvedPath = try TestSupport.realPath(directory.path)
+
+            let error = #expect(throws: (any Error).self) {
+                _ = try WASIBridgeToHost(
+                    preopens: [
+                        WASIBridgeToHost.Preopen(guestPath: "/tmp", hostPath: directory.path),
+                        WASIBridgeToHost.Preopen(guestPath: "/", hostPath: "/definitely-not-here"),
+                    ]
+                )
+            }
+
+            // A `CleanupFailure` here would mean the release itself failed.
+            let thrown = try #require(error)
+            #expect(thrown is WASIError)
+            #expect(!(try TestSupport.openDescriptorPaths().contains(resolvedPath)))
+        }
+    #endif
+
+    @Test func runAndCloseSurfacesTheBodyErrorUnwrapped() throws {
+        let bridge = try WASIBridgeToHost()
+        let error = #expect(throws: (any Error).self) {
+            try bridge.runAndClose { _ in throw BridgeProbeError.body }
+        }
+        let thrown = try #require(error)
+        #expect(thrown as? BridgeProbeError == .body)
+    }
+}


### PR DESCRIPTION
`wasmkit run` could only grant a host directory under its own path and always passed the module path as argv[0]. `--dir` now takes an optional `host::guest` mapping and `--argv0` overrides `argv[0]`, which is what CPython's `python.wasm` needs. A failed preopen now releases what it opened instead of tripping `WASIBridgeToHost`'s close precondition.