### PR TITLE
Remove ImportError and restrict ResourceLimiter to class types

### DIFF
--- a/FuzzTesting/Sources/WasmKitFuzzing/WasmKitFuzzing.swift
+++ b/FuzzTesting/Sources/WasmKitFuzzing/WasmKitFuzzing.swift
@@ -3,7 +3,7 @@
 @_spi(Fuzzing) import WasmKit
 
 /// A resource limiter that restricts allocations to fuzzer limits.
-public struct FuzzerResourceLimiter: ResourceLimiter {
+public final class FuzzerResourceLimiter: ResourceLimiter {
     public init() {}
 
     public func limitMemoryGrowth(to desired: Int) throws -> Bool {

--- a/Sources/WasmKit/Execution/Errors.swift
+++ b/Sources/WasmKit/Execution/Errors.swift
@@ -178,23 +178,9 @@ extension TrapReason.Message {
     }
 }
 
-package struct ImportError: Error {
-    package struct Message {
-        package let text: String
-
-        init(_ text: String) {
-            self.text = text
-        }
-    }
-
-    package let message: Message
-
-    init(_ message: Message) {
-        self.message = message
-    }
-}
-
-extension ImportError.Message {
+// Import-resolution failures raised during instantiation and module
+// registration.
+extension WasmKitError.Message {
     static func missing(moduleName: String, externalName: String) -> Self {
         Self("unknown import \(moduleName).\(externalName)")
     }

--- a/Sources/WasmKit/Execution/Runtime.swift
+++ b/Sources/WasmKit/Execution/Runtime.swift
@@ -55,7 +55,7 @@ public final class Runtime {
     /// Legacy compatibility method to register a module instance with a name.
     public func register(_ instance: Instance, as name: String) throws {
         guard availableExports[name] == nil else {
-            throw ImportError(.moduleInstanceAlreadyRegistered(name))
+            throw WasmKitError(message: .moduleInstanceAlreadyRegistered(name))
         }
 
         availableExports[name] = Dictionary(uniqueKeysWithValues: instance.exports.map { ($0, $1) })
@@ -64,7 +64,7 @@ public final class Runtime {
     /// Legacy compatibility method to register a host module with a name.
     public func register(_ hostModule: HostModule, as name: String) throws {
         guard availableExports[name] == nil else {
-            throw ImportError(.moduleInstanceAlreadyRegistered(name))
+            throw WasmKitError(message: .moduleInstanceAlreadyRegistered(name))
         }
 
         registerUniqueHostModule(hostModule, as: name, engine: engine)
@@ -101,7 +101,7 @@ public final class Runtime {
 
         for i in module.imports {
             guard let moduleExports = availableExports[i.module], let external = moduleExports[i.name] else {
-                throw ImportError(.missing(moduleName: i.module, externalName: i.name))
+                throw WasmKitError(message: .missing(moduleName: i.module, externalName: i.name))
             }
             result.define(i, external)
         }

--- a/Sources/WasmKit/Execution/StoreAllocator.swift
+++ b/Sources/WasmKit/Execution/StoreAllocator.swift
@@ -292,10 +292,10 @@ extension StoreAllocator {
         // local to to the module are added.
         for importEntry in module.imports {
             guard let (external, allocator) = imports.lookup(module: importEntry.module, name: importEntry.name) else {
-                throw ImportError(.missing(moduleName: importEntry.module, externalName: importEntry.name))
+                throw WasmKitError(message: .missing(moduleName: importEntry.module, externalName: importEntry.name))
             }
             guard allocator === self else {
-                throw ImportError(.importedEntityFromDifferentStore(importEntry))
+                throw WasmKitError(message: .importedEntityFromDifferentStore(importEntry))
             }
 
             switch (importEntry.descriptor, external) {
@@ -307,13 +307,13 @@ extension StoreAllocator {
                 let expected = module.types[Int(typeIndex)]
                 guard engine.internType(expected) == type else {
                     let actual = engine.resolveType(type)
-                    throw ImportError(.incompatibleFunctionType(importEntry, actual: actual, expected: expected))
+                    throw WasmKitError(message: .incompatibleFunctionType(importEntry, actual: actual, expected: expected))
                 }
                 importedFunctions.append(externalFunc)
 
             case (.table(let tableType), .table(let table)):
                 if let max = table.limits.max, max < tableType.limits.min {
-                    throw ImportError(.incompatibleTableType(importEntry, actual: tableType, expected: table.tableType))
+                    throw WasmKitError(message: .incompatibleTableType(importEntry, actual: tableType, expected: table.tableType))
                 }
                 importedTables.append(table)
 
@@ -322,29 +322,29 @@ extension StoreAllocator {
 
                 // Check shared flag matches
                 guard memoryType.shared == limit.shared else {
-                    throw ImportError(.incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
+                    throw WasmKitError(message: .incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
                 }
                 // Check memory64 flag matches
                 guard memoryType.isMemory64 == limit.isMemory64 else {
-                    throw ImportError(.incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
+                    throw WasmKitError(message: .incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
                 }
                 // Check limits compatibility: provided memory must satisfy imported memory type requirements.
                 // Note: The memory may have grown already, so compare against the current size.
                 let currentSizeInPages = UInt64(memory.withValue { $0.byteCount }) / UInt64(MemoryEntity.pageSize)
                 guard currentSizeInPages >= memoryType.min else {
-                    throw ImportError(.incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
+                    throw WasmKitError(message: .incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
                 }
                 // If the imported memory type has a max, the provided memory must have a max and be <= imported max.
                 if let importedMax = memoryType.max {
                     guard let providedMax = limit.max, providedMax <= importedMax else {
-                        throw ImportError(.incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
+                        throw WasmKitError(message: .incompatibleMemoryType(importEntry, actual: memoryType, expected: limit))
                     }
                 }
                 importedMemories.append(memory)
 
             case (.global(let globalType), .global(let global)):
                 guard globalType == global.globalType else {
-                    throw ImportError(.incompatibleGlobalType(importEntry, actual: global.globalType, expected: globalType))
+                    throw WasmKitError(message: .incompatibleGlobalType(importEntry, actual: global.globalType, expected: globalType))
                 }
                 importedGlobals.append(global)
 
@@ -354,12 +354,12 @@ extension StoreAllocator {
                 }
                 let expected = module.types[Int(typeIndex)]
                 guard engine.internType(expected) == tag.type else {
-                    throw ImportError(.incompatibleFunctionType(importEntry, actual: engine.resolveType(tag.type), expected: expected))
+                    throw WasmKitError(message: .incompatibleFunctionType(importEntry, actual: engine.resolveType(tag.type), expected: expected))
                 }
                 importedTags.append(tag)
 
             default:
-                throw ImportError(.incompatibleType(importEntry, entity: external))
+                throw WasmKitError(message: .incompatibleType(importEntry, entity: external))
             }
         }
 

--- a/Sources/WasmKit/ResourceLimiter.swift
+++ b/Sources/WasmKit/ResourceLimiter.swift
@@ -1,5 +1,8 @@
 /// A protocol for limiting resource allocation.
-public protocol ResourceLimiter: Sendable {
+///
+/// Class-constrained so that `any ResourceLimiter` remains available under
+/// Embedded Swift, which supports only class-bound existentials.
+public protocol ResourceLimiter: AnyObject, Sendable {
     /// Limit the memory growth of the process to the specified number of bytes.
     ///
     /// - Parameter desired: The desired size of the memory in bytes.
@@ -26,4 +29,4 @@ extension ResourceLimiter {
 }
 
 /// A default resource limiter that doesn't limit resource growth.
-struct DefaultResourceLimiter: ResourceLimiter {}
+final class DefaultResourceLimiter: ResourceLimiter {}

--- a/Tests/WasmKitTests/Spectest/TestCase.swift
+++ b/Tests/WasmKitTests/Spectest/TestCase.swift
@@ -327,9 +327,9 @@ extension WastRunContext {
 
             do {
                 _ = try instantiate(module: module)
-            } catch let error as ImportError {
-                guard error.message.text.contains(message) else {
-                    return .failed("assertion mismatch: expected: \(message), actual: \(error.message.text)")
+            } catch let error as WasmKitError {
+                guard error.description.contains(message) else {
+                    return .failed("assertion mismatch: expected: \(message), actual: \(error.description)")
                 }
             } catch {
                 return .failed("\(error)")


### PR DESCRIPTION
Part of the incremental upstreaming of Embedded Swift support (#357). Follows #391.

Two preparatory changes for the instantiation path:

- **Remove `ImportError` in favor of `WasmKitError` messages.** Import-resolution and module-registration failures are ordinary instantiation errors, so they are reported as `WasmKitError` messages instead of maintaining a separate error type. Error messages are unchanged.
- **Restrict `ResourceLimiter` to class types.** Embedded Swift supports only class-bound existentials, so the protocol is constrained to `AnyObject`. This keeps `any ResourceLimiter` usable on every platform with no generic parameters or per-configuration storage. `DefaultResourceLimiter` and the fuzzer's limiter become final classes.