### PR TITLE
Drop swift-system dependency from WasmParser and WasmKit

### DIFF
--- a/Benchmarks/Benchmarks/MacroPlugin/MacroPlugin.swift
+++ b/Benchmarks/Benchmarks/MacroPlugin/MacroPlugin.swift
@@ -156,7 +156,7 @@ let benchmarks: @Sendable () -> () = {
             init(filePath: FilePath, expandMessage: String) throws {
                 let engine = Engine()
                 let store = Store(engine: engine)
-                let module = try parseWasm(filePath: filePath)
+                let module = try parseWasm(filePath: filePath.string)
 
                 let hostToPluginPipes = try FileDescriptor.pipe()
                 let pluginToHostPipes = try FileDescriptor.pipe()

--- a/Benchmarks/Benchmarks/WishYouWereFast/WishYouWereFast.swift
+++ b/Benchmarks/Benchmarks/WishYouWereFast/WishYouWereFast.swift
@@ -28,7 +28,7 @@ let benchmarks: @Sendable () -> () = {
             let engine = Engine()
             let store = Store(engine: engine)
             let module = try parseWasm(
-                filePath: FilePath(wishYouWereFast.appendingPathComponent(file).path)
+                filePath: wishYouWereFast.appendingPathComponent(file).path
             )
             let wasi = try WASIBridgeToHost(fileSystem: .host().withStdio(stdout: devNull, stderr: devNull))
             _ = try wasi.runAndClose { wasi in

--- a/Package.swift
+++ b/Package.swift
@@ -67,8 +67,6 @@ let package = Package(
                 "_CWasmKit",
                 "WasmParser",
                 "WasmTypes",
-                "SystemExtras",
-                .product(name: "SystemPackage", package: "swift-system"),
                 .target(
                     name: "ComponentModel",
                     condition: .when(traits: ["ComponentModel"])
@@ -123,10 +121,6 @@ let package = Package(
             name: "WasmParser",
             dependencies: [
                 "WasmTypes",
-                .product(
-                    name: "SystemPackage", package: "swift-system",
-                    condition: .when(traits: ["FileSystem"])
-                ),
                 .target(
                     name: "ComponentModel",
                     condition: .when(traits: ["ComponentModel"])

--- a/Sources/CLICommands/Explore.swift
+++ b/Sources/CLICommands/Explore.swift
@@ -1,5 +1,4 @@
 import ArgumentParser
-import SystemPackage
 @_spi(OnlyForCLI) import WasmKit
 
 package struct Explore: ParsableCommand {
@@ -25,7 +24,7 @@ package struct Explore: ParsableCommand {
     package init() {}
 
     package func run() throws {
-        let module = try parseWasm(filePath: FilePath(path))
+        let module = try parseWasm(filePath: path)
         // Instruction dumping requires token threading model for now
         let configuration = EngineConfiguration(threadingModel: .token)
         let engine = Engine(configuration: configuration)

--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -197,7 +197,7 @@ package struct Run: AsyncParsableCommand {
                     if fileType == .component {
                         log("Detected component binary, parsing component...", verbose: true)
                         _ = try fileHandle.seek(offset: 0, from: .start)
-                        parsedComponent = try parseComponent(fileHandle: fileHandle)
+                        parsedComponent = try parseComponent(fileHandle: fileHandle.rawValue)
                         return nil
                     }
                 #endif
@@ -208,7 +208,7 @@ package struct Run: AsyncParsableCommand {
 
                 _ = try fileHandle.seek(offset: 0, from: .start)
                 let (parsedModule, parseTime) = try measure {
-                    try WasmKit.parseWasm(fileHandle: fileHandle)
+                    try WasmKit.parseWasm(fileHandle: fileHandle.rawValue)
                 }
                 log("Finished parsing module: \(parseTime)", verbose: true)
                 return parsedModule

--- a/Sources/WasmKit/CMakeLists.txt
+++ b/Sources/WasmKit/CMakeLists.txt
@@ -64,4 +64,4 @@ target_compile_options(WasmKit PRIVATE
   $<$<COMPILE_LANGUAGE:Swift>:-DDisassembler>)
 
 target_link_wasmkit_libraries(WasmKit PUBLIC
-  _CWasmKit WasmParser SystemExtras WasmTypes SystemPackage)
+  _CWasmKit WasmParser WasmTypes)

--- a/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
+++ b/Sources/WasmKit/Execution/ParsedComponentBuilder.swift
@@ -598,14 +598,14 @@
 #endif
 
 #if ComponentModel && FileSystem
-    import struct SystemPackage.FileDescriptor
-
-    /// Parse a component binary file from a caller-owned file descriptor.
+    /// Parse a component binary from a caller-owned platform file descriptor.
     ///
-    /// The descriptor is consumed from its current offset and is not closed by
-    /// this function.
+    /// The descriptor must be opened for reading in binary mode. This function
+    /// *borrows* it: ownership stays with the caller, who must close it after
+    /// the call returns. Bytes are consumed starting from the descriptor's
+    /// current offset.
     public func parseComponent(
-        fileHandle: FileDescriptor,
+        fileHandle: CInt,
         features: WasmFeatureSet = .default
     ) throws -> ParsedComponent {
         let stream = try FileHandleStreamSource(fileHandle: fileHandle)

--- a/Sources/WasmKit/Execution/Profiler.swift
+++ b/Sources/WasmKit/Execution/Profiler.swift
@@ -1,7 +1,8 @@
 // The profiler writes its trace to a file, so it requires the FileSystem trait.
 #if FileSystem
-    import SystemExtras
-    import SystemPackage
+    #if canImport(Darwin)
+        import Darwin
+    #endif
 
     /// A simple time-profiler for guest process to emit `chrome://tracing` format
     /// This profiler works only when WasmKit is built with debug configuration (`swift build -c debug`)
@@ -25,10 +26,22 @@
         private var output: (_ line: String) -> Void
         private var hasFirstEvent: Bool = false
 
-        #if swift(>=5.7) && os(Windows)
-            // We can use ContinuousClock on platforms that doesn't ship stdlib as stable ABI
-            // Once we drop macOS 12.3, iOS 15.4, watchOS 8.5, and tvOS 15.4 support, we can remove
-            // this conditional compilation
+        #if canImport(Darwin)
+            // ContinuousClock requires a macOS 13+ deployment target, which builds
+            // outside SwiftPM (e.g. the CMake toolchain build) don't guarantee, so
+            // use the always-available raw-monotonic clock on Darwin.
+            private typealias Instant = UInt64
+
+            private static func getTimestamp() -> UInt64 {
+                clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) / 1_000
+            }
+
+            private func getDurationSinceStart() -> Int {
+                Int(Self.getTimestamp() - startTime)
+            }
+
+        #else
+
             private typealias Instant = ContinuousClock.Instant
 
             private static func getTimestamp() -> Instant {
@@ -40,28 +53,6 @@
                 let (seconds, attoseconds) = duration.components
                 // Convert to microseconds
                 return Int(seconds * 1_000_000 + attoseconds / 1_000_000_000_000)
-            }
-
-        #else
-
-            private typealias Instant = UInt64
-
-            private static func getTimestamp() -> UInt64 {
-                let clock: SystemExtras.Clock
-                #if os(Linux) || os(Android)
-                    clock = .boottime
-                #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-                    clock = .rawMonotonic
-                #elseif os(OpenBSD) || os(FreeBSD) || os(WASI)
-                    clock = .monotonic
-                #else
-                    #error("Unsupported platform")
-                #endif
-                let timeSpec = try! clock.currentTime()
-                return UInt64(timeSpec.nanoseconds / 1_000 + timeSpec.seconds * 1_000_000)
-            }
-            private func getDurationSinceStart() -> Int {
-                Int(Self.getTimestamp() - startTime)
             }
         #endif
 

--- a/Sources/WasmKit/ModuleParser+FileSystem.swift
+++ b/Sources/WasmKit/ModuleParser+FileSystem.swift
@@ -1,36 +1,20 @@
 #if FileSystem
     import WasmParser
-    import SystemExtras
-    import SystemPackage
-
-    #if os(Windows)
-        import ucrt
-    #endif
 
     /// Parse a given file as a WebAssembly binary format file
     /// > Note: <https://webassembly.github.io/spec/core/binary/index.html>
-    public func parseWasm(filePath: FilePath, features: WasmFeatureSet = .default) throws -> Module {
-        #if os(Windows)
-            // TODO: Upstream `O_BINARY` to `SystemPackage
-            let accessMode = FileDescriptor.AccessMode(
-                rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
-            )
-        #else
-            let accessMode: FileDescriptor.AccessMode = .readOnly
-        #endif
-        let fileHandle = try FileDescriptor.open(filePath, accessMode)
-        return try withThrowing {
-            try parseWasm(fileHandle: fileHandle, features: features)
-        } defer: {
-            try fileHandle.close()
-        }
+    public func parseWasm(filePath: String, features: WasmFeatureSet = .default) throws -> Module {
+        let parser = try WasmParser.Parser(filePath: filePath, features: features)
+        return try parseModule(parser: parser, features: features)
     }
 
-    /// Parse a WebAssembly binary file from a caller-owned file descriptor.
+    /// Parse a WebAssembly binary from a caller-owned platform file descriptor.
     ///
-    /// The descriptor is consumed from its current offset and is not closed by
-    /// this function.
-    public func parseWasm(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws -> Module {
+    /// The descriptor must be opened for reading in binary mode. This function
+    /// *borrows* it: ownership stays with the caller, who must close it after
+    /// the call returns. Bytes are consumed starting from the descriptor's
+    /// current offset.
+    public func parseWasm(fileHandle: CInt, features: WasmFeatureSet = .default) throws -> Module {
         let parser = try WasmParser.Parser(fileHandle: fileHandle, features: features)
         let module = try parseModule(parser: parser, features: features)
         return module

--- a/Sources/WasmParser/CMakeLists.txt
+++ b/Sources/WasmParser/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_wasmkit_library(WasmParser
+  Platform/FileIO.swift
   Stream/ByteStream.swift
   Stream/FileHandleStream.swift
   BinaryInstructionDecoder.swift
@@ -16,7 +17,5 @@ target_link_wasmkit_libraries(WasmParser PUBLIC
 if(WASMKIT_ENABLE_FILESYSTEM)
   target_compile_options(WasmParser PRIVATE
     $<$<COMPILE_LANGUAGE:Swift>:-DFileSystem>)
-  target_link_wasmkit_libraries(WasmParser PUBLIC
-    SystemPackage)
 endif()
 

--- a/Sources/WasmParser/Platform/FileIO.swift
+++ b/Sources/WasmParser/Platform/FileIO.swift
@@ -1,0 +1,92 @@
+// Minimal platform shim for the read-only file access needed by
+// `FileHandleStreamSource`. Not a general-purpose file API: WasmParser only
+// ever opens a binary for sequential reading.
+#if FileSystem
+
+    #if canImport(Darwin)
+        import Darwin
+    #elseif canImport(Glibc)
+        import Glibc
+    #elseif canImport(Musl)
+        import Musl
+    #elseif canImport(Android)
+        import Android
+    #elseif canImport(WASILibc)
+        import WASILibc
+    #elseif os(Windows)
+        import ucrt
+    #endif
+
+    enum FileIO {
+        /// Opens the file at `path` for reading in binary mode and returns a
+        /// platform file descriptor owned by the caller.
+        static func openForReading(path: String) throws(WasmParserError) -> CInt {
+            #if os(Windows)
+                var fd: CInt = -1
+                let error = path.withCString(encodedAs: UTF16.self) { widePath in
+                    _wsopen_s(&fd, widePath, _O_RDONLY | _O_BINARY, _SH_DENYNO, 0)
+                }
+                guard error == 0 else {
+                    throw WasmParserError("failed to open file \(path): \(errorMessage(error))", offset: 0)
+                }
+                return fd
+            #else
+                while true {
+                    let fd = path.withCString { open($0, O_RDONLY) }
+                    if fd >= 0 { return fd }
+                    if errno == EINTR { continue }
+                    throw WasmParserError("failed to open file \(path): \(errorMessage(errno))", offset: 0)
+                }
+            #endif
+        }
+
+        /// Reads up to `maxLength` bytes from the current offset of `fd`.
+        /// A result shorter than `maxLength` means end-of-file was reached.
+        static func readBytes(_ fd: CInt, upToCount maxLength: Int) throws(WasmParserError) -> [UInt8] {
+            var result = [UInt8](repeating: 0, count: maxLength)
+            let readCount = result.withUnsafeMutableBytes { rawRead(fd, into: $0) }
+            guard readCount >= 0 else {
+                throw WasmParserError("I/O error: \(errorMessage(CInt(-readCount)))", offset: 0)
+            }
+            result.removeLast(maxLength - readCount)
+            return result
+        }
+
+        /// Returns the number of bytes read (>= 0), or a negative errno value
+        /// on failure.
+        private static func rawRead(_ fd: CInt, into buffer: UnsafeMutableRawBufferPointer) -> Int {
+            guard let base = buffer.baseAddress, buffer.count > 0 else { return 0 }
+            #if os(Windows)
+                let count = _read(fd, base, UInt32(min(buffer.count, Int(Int32.max))))
+                if count >= 0 { return Int(count) }
+                var error: CInt = 0
+                _get_errno(&error)
+                return -Int(error)
+            #else
+                while true {
+                    let count = read(fd, base, buffer.count)
+                    if count >= 0 { return Int(count) }
+                    if errno == EINTR { continue }
+                    return -Int(errno)
+                }
+            #endif
+        }
+
+        /// Closes a file descriptor previously returned by `openForReading`.
+        /// Errors are ignored; the descriptor was opened read-only, so no
+        /// buffered data can be lost.
+        static func closeFile(_ fd: CInt) {
+            #if os(Windows)
+                _ = _close(fd)
+            #else
+                _ = close(fd)
+            #endif
+        }
+
+        private static func errorMessage(_ error: CInt) -> String {
+            guard let message = strerror(error) else { return "errno \(error)" }
+            return String(cString: message)
+        }
+    }
+
+#endif

--- a/Sources/WasmParser/Stream/FileHandleStream.swift
+++ b/Sources/WasmParser/Stream/FileHandleStream.swift
@@ -1,56 +1,71 @@
 // "FileSystem" trait can be turned off to support embedded platforms
 #if FileSystem
 
-    import struct SystemPackage.FileDescriptor
-    import struct SystemPackage.FilePath
-
-    #if os(Windows)
-        import ucrt
-    #endif
-
     extension Parser where Source == FileHandleStreamSource {
 
         /// Initialize a new parser with the given file handle
         ///
         /// - Parameters:
-        ///   - fileHandle: The file handle to the WebAssembly binary file to parse
+        ///   - fileHandle: A platform file descriptor for the WebAssembly binary to
+        ///     parse, opened for reading in binary mode. The parser *borrows* the
+        ///     descriptor: ownership stays with the caller, who must keep it open
+        ///     while the parser is in use and close it afterwards. Bytes are
+        ///     consumed starting from the descriptor's current offset.
         ///   - features: Enabled WebAssembly features for parsing
-        public init(fileHandle: FileDescriptor, features: WasmFeatureSet = .default) throws {
+        public init(fileHandle: CInt, features: WasmFeatureSet = .default) throws {
             self.init(stream: try FileHandleStreamSource(fileHandle: fileHandle), features: features)
         }
 
         /// Initialize a new parser with the given file path
         ///
+        /// The file is opened by the parser and closed when the underlying stream
+        /// source is deallocated.
+        ///
         /// - Parameters:
         ///   - filePath: The file path to the WebAssembly binary file to parse
         ///   - features: Enabled WebAssembly features for parsing
-        public init(filePath: FilePath, features: WasmFeatureSet = .default) throws {
-            #if os(Windows)
-                // TODO: Upstream `O_BINARY` to `SystemPackage
-                let accessMode = FileDescriptor.AccessMode(
-                    rawValue: FileDescriptor.AccessMode.readOnly.rawValue | O_BINARY
-                )
-            #else
-                let accessMode: FileDescriptor.AccessMode = .readOnly
-            #endif
-            let fileHandle = try FileDescriptor.open(filePath, accessMode)
-            self.init(stream: try FileHandleStreamSource(fileHandle: fileHandle), features: features)
+        public init(filePath: String, features: WasmFeatureSet = .default) throws {
+            let fileHandle = try FileIO.openForReading(path: filePath)
+            self.init(stream: try FileHandleStreamSource(fileHandle: fileHandle, ownsHandle: true), features: features)
         }
     }
 
     public final class FileHandleStreamSource: ByteStreamSource {
-        private let fileHandle: FileDescriptor
+        private let fileHandle: CInt
+        /// Whether this source is responsible for closing `fileHandle`.
+        /// True only when the source opened the file itself.
+        private let ownsHandle: Bool
         private let bufferLength: Int
 
         private var bufferEndOffset: Int = 0
         private var bufferStartOffset: Int = 0
         private var bytes: [UInt8] = []
 
-        public init(fileHandle: FileDescriptor, bufferLength: Int = 1024 * 8) throws {
+        /// Initialize a new stream source with the given file handle
+        ///
+        /// - Parameters:
+        ///   - fileHandle: A platform file descriptor opened for reading in binary
+        ///     mode. The stream source *borrows* the descriptor: ownership stays
+        ///     with the caller, who must keep it open for the lifetime of this
+        ///     source and close it afterwards. Bytes are consumed starting from
+        ///     the descriptor's current offset.
+        ///   - bufferLength: The size of the internal read buffer
+        public convenience init(fileHandle: CInt, bufferLength: Int = 1024 * 8) throws {
+            try self.init(fileHandle: fileHandle, ownsHandle: false, bufferLength: bufferLength)
+        }
+
+        init(fileHandle: CInt, ownsHandle: Bool, bufferLength: Int = 1024 * 8) throws {
             self.fileHandle = fileHandle
+            self.ownsHandle = ownsHandle
             self.bufferLength = bufferLength
 
             try readMoreIfNeeded(offset: 0)
+        }
+
+        deinit {
+            if ownsHandle {
+                FileIO.closeFile(fileHandle)
+            }
         }
 
         public func readByte(at offset: Int) throws(WasmParserError) -> UInt8? {
@@ -67,19 +82,14 @@
             let bytesToRead = endOffset - bufferEndOffset
 
             if bytesToRead > 0 {
-                let data: [UInt8]
-                do {
-                    data = try fileHandle.read(upToCount: bytesToRead)
-                } catch {
-                    throw WasmParserError("I/O error: \(error)", offset: startOffset)
-                }
+                let data = try read(upToCount: bytesToRead)
                 // Fewer bytes than requested means the stream ended early; that is
                 // an out-of-range read, which `ByteStream` reports as needed.
                 guard data.count == bytesToRead else {
                     return nil
                 }
 
-                bytes.append(contentsOf: [UInt8](data))
+                bytes.append(contentsOf: data)
                 bufferEndOffset = bufferEndOffset + data.count
             }
 
@@ -94,22 +104,12 @@
             guard Int(bufferEndOffset) == offset else { return }
             bufferStartOffset = offset
 
-            do {
-                let data = try fileHandle.read(upToCount: bufferLength)
-
-                bytes = [UInt8](data)
-            } catch {
-                throw WasmParserError("I/O error: \(error)", offset: offset)
-            }
+            bytes = try read(upToCount: bufferLength)
             bufferEndOffset = bufferStartOffset + bytes.count
         }
-    }
 
-    extension FileDescriptor {
-        fileprivate func read(upToCount maxLength: Int) throws -> [UInt8] {
-            try [UInt8](unsafeUninitializedCapacity: maxLength) { buffer, outCount in
-                outCount = try read(into: UnsafeMutableRawBufferPointer(buffer))
-            }
+        private func read(upToCount maxLength: Int) throws(WasmParserError) -> [UInt8] {
+            try FileIO.readBytes(fileHandle, upToCount: maxLength)
         }
     }
 

--- a/Sources/WasmTools/WasmTools.swift
+++ b/Sources/WasmTools/WasmTools.swift
@@ -146,7 +146,7 @@ package func runWasmTools(
         var imports = Imports()
         wasi.link(to: &imports, store: store)
 
-        let module = try parseWasm(filePath: FilePath(wasmToolsPath))
+        let module = try parseWasm(filePath: wasmToolsPath)
         let instance = try module.instantiate(store: store, imports: imports)
         return try wasi.start(instance)
     }

--- a/Tests/WASITests/IntegrationTests.swift
+++ b/Tests/WASITests/IntegrationTests.swift
@@ -199,7 +199,7 @@ struct IntegrationTests {
             let store = Store(engine: engine)
             var imports = Imports()
             wasi.link(to: &imports, store: store)
-            let module = try parseWasm(filePath: FilePath(path.path))
+            let module = try parseWasm(filePath: path.path)
             let instance = try module.instantiate(store: store, imports: imports)
             let exitCode = try wasi.start(instance)
             #expect(exitCode == manifest.exitCode ?? 0, "\(path.path)")

--- a/Tests/WITOverlayGeneratorTests/Runtime/RuntimeTestHarness.swift
+++ b/Tests/WITOverlayGeneratorTests/Runtime/RuntimeTestHarness.swift
@@ -150,7 +150,7 @@ struct RuntimeTestHarness {
                 wasi.link(to: &imports, store: store)
                 link(&imports, store)
 
-                let module = try parseWasm(filePath: .init(compiled.path))
+                let module = try parseWasm(filePath: compiled.path)
                 let instance = try module.instantiate(store: store, imports: imports)
                 try run(instance)
             }

--- a/Tests/WasmKitTests/Spectest/Spectest.swift
+++ b/Tests/WasmKitTests/Spectest/Spectest.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SystemPackage
 import WAT
 import WasmKit
 

--- a/Tests/WasmKitTests/Spectest/TestCase.swift
+++ b/Tests/WasmKitTests/Spectest/TestCase.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SystemPackage
 import WAT
 import WasmKit
 import WasmParser
@@ -27,9 +26,8 @@ package struct TestCase: CustomStringConvertible {
         let fileManager = FileManager.default
         var filePaths: [URL] = []
         for path in path {
-            let filePath = FilePath(path)
-            if isDirectory(filePath) {
-                filePaths += try self.computeTestSources(inDirectory: filePath, fileManager: fileManager).map {
+            if isDirectory(path) {
+                filePaths += try self.computeTestSources(inDirectory: path, fileManager: fileManager).map {
                     URL(fileURLWithPath: path).appendingPathComponent($0)
                 }
             } else if fileManager.isReadableFile(atPath: path) {
@@ -70,8 +68,8 @@ package struct TestCase: CustomStringConvertible {
     }
 
     /// Returns list of `.json` paths recursively found under `rootPath`. They are relative to `rootPath`.
-    static func computeTestSources(inDirectory rootPath: FilePath, fileManager: FileManager) throws -> [String] {
-        return try fileManager.contentsOfDirectory(atPath: rootPath.string).filter {
+    static func computeTestSources(inDirectory rootPath: String, fileManager: FileManager) throws -> [String] {
+        return try fileManager.contentsOfDirectory(atPath: rootPath).filter {
             $0.hasSuffix(".wast")
         }
     }
@@ -129,7 +127,7 @@ extension TestCase {
             return
         }
         var configuration = configuration
-        let rootPath = FilePath(path).removingLastComponent()
+        let rootPath = URL(fileURLWithPath: path).deletingLastPathComponent().path
         let features = WastRunContext.deriveFeatureSet(rootPath: rootPath)
         configuration.features = features
 
@@ -138,7 +136,7 @@ extension TestCase {
         let spectestInstance = try spectestModule.instantiate(store: store)
 
         var content = try parseWAST(String(data: data, encoding: .utf8)!, features: features)
-        let context = WastRunContext(store: store, rootPath: rootPath.string)
+        let context = WastRunContext(store: store, rootPath: rootPath)
         context.importsSpace.define(module: "spectest", spectestInstance.exports)
 
         // Add shared_memory export for threads proposal tests. Skip it where shared memory is
@@ -386,34 +384,32 @@ extension WastRunContext {
         return try function.invoke(args)
     }
 
-    static func deriveFeatureSet(rootPath: FilePath) -> WasmFeatureSet {
+    static func deriveFeatureSet(rootPath: String) -> WasmFeatureSet {
         var features = WasmFeatureSet.default
-        if rootPath.ends(with: "proposals/memory64") {
+        if rootPath.hasSuffix("proposals/memory64") {
             features.insert(.memory64)
         }
         features.insert(.simd)
-        if rootPath.ends(with: "proposals/threads") {
+        if rootPath.hasSuffix("proposals/threads") {
             // Threads proposal tests should not enable reference types by default
             // as they test core WebAssembly features without reference types
             features.remove(.referenceTypes)
             features.insert(.threads)
         }
-        if rootPath.ends(with: "proposals/exception-handling") {
+        if rootPath.hasSuffix("proposals/exception-handling") {
             features.insert(.exceptionHandling)
         }
         return features
     }
 
     private func parseModule(rootPath: String, filename: String) throws -> Module {
-        let rootPath = FilePath(rootPath)
-        let path = rootPath.appending(filename)
+        let path = URL(fileURLWithPath: rootPath).appendingPathComponent(filename).path
 
         let module = try parseWasm(filePath: path, features: Self.deriveFeatureSet(rootPath: rootPath))
         return module
     }
 
     private func parseModule(rootPath: String, moduleSource: ModuleSource) throws -> Module {
-        let rootPath = FilePath(rootPath)
         let binary: [UInt8]
         switch moduleSource {
         case .text(let watModule):
@@ -541,19 +537,8 @@ extension Swift.Error {
     }
 }
 
-#if os(Windows)
-    import WinSDK
-#endif
-internal func isDirectory(_ path: FilePath) -> Bool {
-    #if os(Windows)
-        return path.withPlatformString {
-            let result = GetFileAttributesW($0)
-            return result != INVALID_FILE_ATTRIBUTES && result & DWORD(FILE_ATTRIBUTE_DIRECTORY) != 0
-        }
-    #else
-        let fd = try? FileDescriptor.open(path, FileDescriptor.AccessMode.readOnly, options: .directory)
-        let isDirectory = fd != nil
-        try? fd?.close()
-        return isDirectory
-    #endif
+internal func isDirectory(_ path: String) -> Bool {
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+    return exists && isDirectory.boolValue
 }


### PR DESCRIPTION
Part 1 of removing the swift-system / SystemExtras dependency in favor of thin per-module platform shims. This PR removes it from `WasmParser` and `WasmKit`; follow-ups will cover WASI (absorbing SystemExtras) and the GDB debugger stack (dropping NIO).

## Public API changes

`SystemPackage.FilePath` / `FileDescriptor` no longer appear in public signatures:

- `parseWasm(filePath: String)`, `parseWasm(fileHandle: CInt)`
- `parseComponent(fileHandle: CInt)`
- `Parser(filePath: String)`, `Parser(fileHandle: CInt)`, `FileHandleStreamSource(fileHandle: CInt)`

All descriptor-taking APIs now document ownership explicitly: the descriptor is **borrowed** — the caller must keep it open while in use and close it afterwards; bytes are consumed from the descriptor's current offset. (`CInt` is a CRT file descriptor on Windows, so the type is uniform across platforms.)

## Implementation notes

- New internal `Sources/WasmParser/Platform/FileIO.swift` (trait-gated by `FileSystem`): `open`/`read`/`close` with `EINTR` retry on POSIX, `_wsopen_s`/`_read` with `_O_BINARY` on Windows.
- Fixes a descriptor leak: `Parser(filePath:)` opened a file that was never closed. The stream source now closes descriptors it opened itself; borrowed ones are left alone.
- `GuestTimeProfiler` uses `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)` on Darwin and `ContinuousClock` elsewhere. On Linux this switches the clock from `CLOCK_BOOTTIME` to `CLOCK_MONOTONIC` (suspend time no longer counted), which is inconsequential for a tracing profiler.
- Spectest test helpers migrate from `FilePath` to Foundation path handling.
- CMake targets updated accordingly; `SystemExtras`/`SystemPackage` remain for WASI, CLICommands, and WasmKitGDBHandler until the follow-ups land.