### PR TITLE
Fix the 32-bit wasm memory page limit on 32-bit hosts

### DIFF
--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -463,7 +463,10 @@ struct MemoryEntity: ~Copyable {
     static let pageSize = 64 * 1024
 
     static func maxPageCount(isMemory64: Bool) -> UInt64 {
-        isMemory64 ? UInt64.max : UInt64(1 << 32) / UInt64(pageSize)
+        // Shift in the UInt64 domain: `1 << 32` would be evaluated as `Int`,
+        // which is 32 bits wide on targets like riscv32, wrapping to zero and
+        // rejecting every guest that declares a memory.
+        isMemory64 ? UInt64.max : (UInt64(1) << 32) / UInt64(pageSize)
     }
 
     private struct MallocStorage {

--- a/Tests/WasmKitTests/MemoryPageLimitTests.swift
+++ b/Tests/WasmKitTests/MemoryPageLimitTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import WasmKit
+
+@Suite struct MemoryPageLimitTests {
+    /// A 32-bit wasm memory addresses 4 GiB, which is 65536 pages of 64 KiB.
+    ///
+    /// Regression guard: computing this as `UInt64(1 << 32)` evaluates the
+    /// shift as `Int`, which is 32 bits wide on targets like riscv32. It wraps
+    /// to zero there, so the validator rejected every guest that declared a
+    /// memory -- while remaining correct on 64-bit hosts, where this test runs.
+    /// Keep the shift in the UInt64 domain.
+    @Test func aThirtyTwoBitMemoryAllowsTheFullPageRange() {
+        #expect(MemoryEntity.maxPageCount(isMemory64: false) == 65536)
+    }
+
+    @Test func aSixtyFourBitMemoryIsUnbounded() {
+        #expect(MemoryEntity.maxPageCount(isMemory64: true) == UInt64.max)
+    }
+}


### PR DESCRIPTION
`maxPageCount` computed the 4 GiB range as `UInt64(1 << 32)`. The shift is
evaluated as `Int`, which is 32 bits wide on targets like `riscv32`, so it
wrapped to zero. Every guest that declared a memory was then rejected during
validation with "size minimum must not be greater than 0".

Keep the shift in the `UInt64` domain.

The existing ESP32 example did not catch this because its demo module has no
memory. It surfaced when running a WASI guest on emulated hardware.

`MemoryPageLimitTests` pins the expected value. The test passes either way on a
64-bit host, so it documents intent rather than reproducing the bug; the
regression guard that actually exercises it is the QEMU smoke test later in this
stack.

This is independent of the rest of the stack and can merge on its own.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #401 Fix the 32-bit wasm memory page limit on 32-bit hosts **← this PR**
1. #402 Drop the async withThrowing/CleanupFailure overloads from WASI
1. #403 Use a PlatformMutex in WASI instead of Synchronization.Mutex
1. #404 Decouple WASIFile from GuestMemory

Six more branches continue this work locally (selective WASI linking, the
embedded CI change, and running WASI plus the GDB stub on emulated hardware).
They will be opened once these land, or sooner if that helps review.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
