### PR TITLE
Drop the async withThrowing/CleanupFailure overloads from WASI

### DIFF
--- a/Sources/WASI/CleanupFailure.swift
+++ b/Sources/WASI/CleanupFailure.swift
@@ -20,16 +20,4 @@ package struct CleanupFailure: Error, CustomStringConvertible {
             return CleanupFailure(underlying: error, cleanup: cleanupError)
         }
     }
-
-    package static func preserving(
-        _ error: any Error,
-        cleanup: () async throws -> Void
-    ) async -> any Error {
-        do {
-            try await cleanup()
-            return error
-        } catch let cleanupError {
-            return CleanupFailure(underlying: error, cleanup: cleanupError)
-        }
-    }
 }

--- a/Sources/WASI/ThrowingDefer.swift
+++ b/Sources/WASI/ThrowingDefer.swift
@@ -14,7 +14,6 @@
 /// - Throws: The error thrown by `work`, or by `deferred` when `work` succeeded. When both throw,
 ///           a ``CleanupFailure`` carrying `work`'s error as ``CleanupFailure/underlying``.
 /// - Returns: The result of `work`.
-/// - SeeAlso: ``withAsyncThrowing(do:defer:)``
 @discardableResult
 package func withThrowing<T>(
     do work: () throws -> T,
@@ -27,25 +26,5 @@ package func withThrowing<T>(
         throw CleanupFailure.preserving(error, cleanup: deferred)
     }
     try deferred()
-    return result
-}
-
-/// Runs async `deferred` after async `work`, exactly once, also when `work` throws.
-/// - Throws: The error thrown by `work`, or by `deferred` when `work` succeeded. When both throw,
-///           a ``CleanupFailure`` carrying `work`'s error as ``CleanupFailure/underlying``.
-/// - Returns: The result of `work`.
-/// - SeeAlso: ``withThrowing(do:defer:)``
-@discardableResult
-package func withAsyncThrowing<T: Sendable>(
-    do work: @Sendable () async throws -> T,
-    defer deferred: @Sendable () async throws -> Void
-) async throws -> T {
-    let result: T
-    do {
-        result = try await work()
-    } catch {
-        throw await CleanupFailure.preserving(error, cleanup: deferred)
-    }
-    try await deferred()
     return result
 }

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -463,7 +463,10 @@ struct MemoryEntity: ~Copyable {
     static let pageSize = 64 * 1024
 
     static func maxPageCount(isMemory64: Bool) -> UInt64 {
-        isMemory64 ? UInt64.max : UInt64(1 << 32) / UInt64(pageSize)
+        // Shift in the UInt64 domain: `1 << 32` would be evaluated as `Int`,
+        // which is 32 bits wide on targets like riscv32, wrapping to zero and
+        // rejecting every guest that declares a memory.
+        isMemory64 ? UInt64.max : (UInt64(1) << 32) / UInt64(pageSize)
     }
 
     private struct MallocStorage {

--- a/Tests/CLICommandsTests/AsyncThrowingDefer.swift
+++ b/Tests/CLICommandsTests/AsyncThrowingDefer.swift
@@ -1,0 +1,34 @@
+import WASI
+
+/// Async counterpart of ``withThrowing(do:defer:)`` for tests.
+///
+/// `WASI` itself has no async callers, so this deliberately lives in the test
+/// target rather than shipping as package API. It mirrors the synchronous
+/// helper's semantics: `deferred` runs exactly once, and when both closures
+/// throw the failure surfaces as a ``CleanupFailure``.
+@discardableResult
+func withAsyncThrowing<T: Sendable>(
+    do work: @Sendable () async throws -> T,
+    defer deferred: @Sendable () async throws -> Void
+) async throws -> T {
+    let result: T
+    do {
+        result = try await work()
+    } catch {
+        throw await preservingError(error, cleanup: deferred)
+    }
+    try await deferred()
+    return result
+}
+
+private func preservingError(
+    _ error: any Error,
+    cleanup: () async throws -> Void
+) async -> any Error {
+    do {
+        try await cleanup()
+        return error
+    } catch let cleanupError {
+        return CleanupFailure(underlying: error, cleanup: cleanupError)
+    }
+}

--- a/Tests/WASITests/CleanupFailureTests.swift
+++ b/Tests/WASITests/CleanupFailureTests.swift
@@ -15,18 +15,4 @@ import WASI
         #expect(combined.description.contains("body"))
         #expect(combined.description.contains("cleanup"))
     }
-
-    @Test func successfulAsyncCleanupPreservesTheOriginalError() async throws {
-        let cleanup: () async throws -> Void = {}
-        let result = await CleanupFailure.preserving(ProbeError.body, cleanup: cleanup)
-        #expect(result as? ProbeError == .body)
-    }
-
-    @Test func failedAsyncCleanupSurfacesBothErrors() async throws {
-        let cleanup: () async throws -> Void = { throw ProbeError.cleanup }
-        let result = await CleanupFailure.preserving(ProbeError.body, cleanup: cleanup)
-        let combined = try #require(result as? CleanupFailure)
-        #expect(combined.underlying as? ProbeError == .body)
-        #expect(combined.cleanup as? ProbeError == .cleanup)
-    }
 }

--- a/Tests/WASITests/ThrowingDeferTests.swift
+++ b/Tests/WASITests/ThrowingDeferTests.swift
@@ -2,11 +2,6 @@ import Testing
 import WASI
 
 @Suite struct ThrowingDeferTests {
-    private actor Counter {
-        private(set) var value = 0
-        func increment() { value += 1 }
-    }
-
     @Test func bodyErrorSurvivesAFailingCleanup() throws {
         let error = #expect(throws: (any Error).self) {
             try withThrowing {
@@ -57,32 +52,5 @@ import WASI
         }
         #expect(value == 7)
         #expect(attempts == 1)
-    }
-
-    @Test func asyncBodyErrorSurvivesAFailingCleanup() async throws {
-        let error = await #expect(throws: (any Error).self) {
-            try await withAsyncThrowing {
-                throw ProbeError.body
-            } defer: {
-                throw ProbeError.cleanup
-            }
-        }
-        let thrown = try #require(error)
-        let combined = try #require(thrown as? CleanupFailure)
-        #expect(combined.underlying as? ProbeError == .body)
-    }
-
-    @Test func asyncCleanupRunsOnceWhenTheBodySucceedsAndCleanupFails() async throws {
-        let attempts = Counter()
-        let error = await #expect(throws: ProbeError.self) {
-            try await withAsyncThrowing {
-                ()
-            } defer: {
-                await attempts.increment()
-                throw ProbeError.cleanup
-            }
-        }
-        #expect(await attempts.value == 1)
-        #expect(error == .cleanup)
     }
 }

--- a/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
+++ b/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
@@ -252,18 +252,35 @@ import Testing
     }
 }
 
-/// Runs an async cleanup closure (`deferred`) after a given async `work`
-/// closure, making sure `deferred` also runs when `work` throws.
+/// Async counterpart of ``withThrowing(do:defer:)`` for tests.
+///
+/// `WASI` itself has no async callers, so this deliberately lives in the test
+/// target rather than shipping as package API. It mirrors the synchronous
+/// helper's semantics: `deferred` runs exactly once, and when both closures
+/// throw the failure surfaces as a ``CleanupFailure`` rather than silently
+/// discarding the cleanup error.
 private func withAsyncThrowing<T: Sendable>(
     do work: @Sendable () async throws -> T,
     defer deferred: @Sendable () async throws -> Void
 ) async throws -> T {
+    let result: T
     do {
-        let result = try await work()
-        try await deferred()
-        return result
+        result = try await work()
     } catch {
-        try await deferred()
-        throw error
+        throw await preservingError(error, cleanup: deferred)
+    }
+    try await deferred()
+    return result
+}
+
+private func preservingError(
+    _ error: any Error,
+    cleanup: () async throws -> Void
+) async -> any Error {
+    do {
+        try await cleanup()
+        return error
+    } catch let cleanupError {
+        return CleanupFailure(underlying: error, cleanup: cleanupError)
     }
 }

--- a/Tests/WasmKitTests/MemoryPageLimitTests.swift
+++ b/Tests/WasmKitTests/MemoryPageLimitTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import WasmKit
+
+@Suite struct MemoryPageLimitTests {
+    /// A 32-bit wasm memory addresses 4 GiB, which is 65536 pages of 64 KiB.
+    ///
+    /// Regression guard: computing this as `UInt64(1 << 32)` evaluates the
+    /// shift as `Int`, which is 32 bits wide on targets like riscv32. It wraps
+    /// to zero there, so the validator rejected every guest that declared a
+    /// memory -- while remaining correct on 64-bit hosts, where this test runs.
+    /// Keep the shift in the UInt64 domain.
+    @Test func aThirtyTwoBitMemoryAllowsTheFullPageRange() {
+        #expect(MemoryEntity.maxPageCount(isMemory64: false) == 65536)
+    }
+
+    @Test func aSixtyFourBitMemoryIsUnbounded() {
+        #expect(MemoryEntity.maxPageCount(isMemory64: true) == UInt64.max)
+    }
+}


### PR DESCRIPTION
`withAsyncThrowing` and the async `CleanupFailure.preserving` had no callers in
`Sources/`. Every `withThrowing` and `preserving` call site is synchronous,
including the one inside `WasmKitGDBHandler`.

The only users were two test helpers, and `WASIMemoryFileSystemConcurrencyTests`
already carried its own private copy with different semantics: it ran the
cleanup on the throwing path but discarded the cleanup error, so it never
produced a `CleanupFailure`.

Move the async helper into the two test targets that need it, matching the
synchronous helper's behaviour, and drop the package API.

This also removes a `_Concurrency` dependency, which bare-metal Embedded Swift
targets do not have. That matters for the rest of this stack, which makes `WASI`
compile for `riscv32-none-none-eabi`.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #401 Fix the 32-bit wasm memory page limit on 32-bit hosts
1. #402 Drop the async withThrowing/CleanupFailure overloads from WASI **← this PR**
1. #403 Use a PlatformMutex in WASI instead of Synchronization.Mutex
1. #404 Decouple WASIFile from GuestMemory

Six more branches continue this work locally (selective WASI linking, the
embedded CI change, and running WASI plus the GDB stub on emulated hardware).
They will be opened once these land, or sooner if that helps review.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
