### PR TITLE
Use a PlatformMutex in WASI instead of Synchronization.Mutex

### DIFF
--- a/Sources/WASI/CMakeLists.txt
+++ b/Sources/WASI/CMakeLists.txt
@@ -2,6 +2,7 @@ add_wasmkit_library(WASI
   CleanupFailure.swift
   ThrowingDefer.swift
   Platform/GuestPath.swift
+  Platform/PlatformMutex.swift
   Platform/PAL/PALClock.swift
   Platform/PAL/PALFileDescriptor.swift
   Platform/PAL/PALTypes.swift

--- a/Sources/WASI/CleanupFailure.swift
+++ b/Sources/WASI/CleanupFailure.swift
@@ -20,16 +20,4 @@ package struct CleanupFailure: Error, CustomStringConvertible {
             return CleanupFailure(underlying: error, cleanup: cleanupError)
         }
     }
-
-    package static func preserving(
-        _ error: any Error,
-        cleanup: () async throws -> Void
-    ) async -> any Error {
-        do {
-            try await cleanup()
-            return error
-        } catch let cleanupError {
-            return CleanupFailure(underlying: error, cleanup: cleanupError)
-        }
-    }
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
@@ -1,4 +1,3 @@
-import Synchronization
 import WasmTypes
 
 /// Base protocol for file system nodes.
@@ -30,11 +29,12 @@ package final class MemoryDirectoryNode: MemFSNode {
         var ctim: WASIAbi.Timestamp
     }
 
-    private let state: Mutex<State>
+    // See `WASIImplementation.fdTable` for why this is a `nonisolated(unsafe) var`.
+    nonisolated(unsafe) private var state: PlatformMutex<State>
 
     init() {
         let now = WASIAbi.Timestamp.currentWallClock()
-        self.state = Mutex(State(atim: now, mtim: now, ctim: now))
+        self.state = PlatformMutex(State(atim: now, mtim: now, ctim: now))
     }
 
     var timestamps: (atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp, ctim: WASIAbi.Timestamp) {
@@ -137,11 +137,12 @@ final class MemoryFileNode: MemFSNode {
         var ctim: WASIAbi.Timestamp
     }
 
-    private let state: Mutex<State>
+    // See `WASIImplementation.fdTable` for why this is a `nonisolated(unsafe) var`.
+    nonisolated(unsafe) private var state: PlatformMutex<State>
 
     init(content: FileContent) {
         let now = WASIAbi.Timestamp.currentWallClock()
-        self.state = Mutex(State(content: content, atim: now, mtim: now, ctim: now))
+        self.state = PlatformMutex(State(content: content, atim: now, mtim: now, ctim: now))
     }
 
     convenience init(bytes: some Sequence<UInt8>) {

--- a/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
@@ -1,4 +1,3 @@
-import Synchronization
 import WasmTypes
 
 /// A `WASIFile` for regular files.
@@ -10,13 +9,14 @@ final class MemoryFileEntry: WASIFile {
     let fileNode: MemoryFileNode
     let fileSystem: MemoryFileSystem
     let accessMode: FileAccessMode
-    let position: Mutex<Int>
+    // See `WASIImplementation.fdTable` for why this is a `nonisolated(unsafe) var`.
+    nonisolated(unsafe) var position: PlatformMutex<Int>
 
     init(fileNode: MemoryFileNode, fileSystem: MemoryFileSystem, accessMode: FileAccessMode, position: Int = 0) {
         self.fileNode = fileNode
         self.fileSystem = fileSystem
         self.accessMode = accessMode
-        self.position = Mutex(position)
+        self.position = PlatformMutex(position)
     }
 
     // MARK: - WASIEntry

--- a/Sources/WASI/Platform/PlatformMutex.swift
+++ b/Sources/WASI/Platform/PlatformMutex.swift
@@ -1,0 +1,47 @@
+/// A mutual-exclusion wrapper around a piece of state.
+///
+/// With the `MultiThread` package trait enabled (the default), this is backed
+/// by `Synchronization.Mutex`. With the trait disabled -- for single-threaded
+/// environments such as bare-metal Embedded Swift targets, where the
+/// `Synchronization` module provides no `Mutex` -- it degrades to plain
+/// unsynchronized storage with the same non-copyable shape.
+///
+/// This mirrors `WasmKit`'s `PlatformMutex`. The two are deliberately
+/// duplicated rather than shared: `WASI` depends only on `WasmTypes`, so
+/// hoisting the type into a common module would either put a concurrency
+/// primitive in a module about wasm type definitions or add a target that every
+/// embedded consumer has to wire up as a separate build unit.
+#if MultiThread
+    import Synchronization
+
+    struct PlatformMutex<State>: ~Copyable, Sendable {
+        private let inner: Mutex<State>
+
+        init(_ initial: consuming sending State) {
+            self.inner = Mutex(initial)
+        }
+
+        borrowing func withLock<Result, E: Error>(
+            _ body: (inout sending State) throws(E) -> sending Result
+        ) throws(E) -> sending Result {
+            try inner.withLock(body)
+        }
+    }
+#else
+    /// Single-threaded fallback: disabling the `MultiThread` trait is a promise
+    /// that the process never accesses WASI state from more than one thread,
+    /// so plain storage without a lock is enough.
+    struct PlatformMutex<State>: ~Copyable, @unchecked Sendable {
+        private var state: State
+
+        init(_ initial: consuming State) {
+            self.state = initial
+        }
+
+        mutating func withLock<Result, E: Error>(
+            _ body: (inout State) throws(E) -> Result
+        ) throws(E) -> Result {
+            try body(&state)
+        }
+    }
+#endif

--- a/Sources/WASI/ThrowingDefer.swift
+++ b/Sources/WASI/ThrowingDefer.swift
@@ -14,7 +14,6 @@
 /// - Throws: The error thrown by `work`, or by `deferred` when `work` succeeded. When both throw,
 ///           a ``CleanupFailure`` carrying `work`'s error as ``CleanupFailure/underlying``.
 /// - Returns: The result of `work`.
-/// - SeeAlso: ``withAsyncThrowing(do:defer:)``
 @discardableResult
 package func withThrowing<T>(
     do work: () throws -> T,
@@ -27,25 +26,5 @@ package func withThrowing<T>(
         throw CleanupFailure.preserving(error, cleanup: deferred)
     }
     try deferred()
-    return result
-}
-
-/// Runs async `deferred` after async `work`, exactly once, also when `work` throws.
-/// - Throws: The error thrown by `work`, or by `deferred` when `work` succeeded. When both throw,
-///           a ``CleanupFailure`` carrying `work`'s error as ``CleanupFailure/underlying``.
-/// - Returns: The result of `work`.
-/// - SeeAlso: ``withThrowing(do:defer:)``
-@discardableResult
-package func withAsyncThrowing<T: Sendable>(
-    do work: @Sendable () async throws -> T,
-    defer deferred: @Sendable () async throws -> Void
-) async throws -> T {
-    let result: T
-    do {
-        result = try await work()
-    } catch {
-        throw await CleanupFailure.preserving(error, cleanup: deferred)
-    }
-    try await deferred()
     return result
 }

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1,4 +1,3 @@
-import Synchronization
 import WasmTypes
 
 @_spi(WASIPlatform) public enum WASIAbi {
@@ -1385,8 +1384,11 @@ final class WASIImplementation: Sendable {
     private let environment: [String: String]
     private let wallClock: WallClock
     private let monotonicClock: MonotonicClock
-    private let randomGenerator: Mutex<any RandomBufferGenerator>
-    internal let fdTable: Mutex<FdTable>
+    // `var` because the single-threaded PlatformMutex fallback mutates in
+    // place; `nonisolated(unsafe)` because the lock, not the compiler, is what
+    // makes the access safe.
+    nonisolated(unsafe) private var randomGenerator: PlatformMutex<any RandomBufferGenerator>
+    nonisolated(unsafe) internal var fdTable: PlatformMutex<FdTable>
     internal let fileSystem: FileSystemImplementation
 
     init(
@@ -1401,10 +1403,10 @@ final class WASIImplementation: Sendable {
         self.environment = environment
         self.fileSystem = fileSystem
 
-        self.fdTable = Mutex(FdTable())
+        self.fdTable = PlatformMutex(FdTable())
         self.wallClock = wallClock
         self.monotonicClock = monotonicClock
-        self.randomGenerator = Mutex(randomGenerator)
+        self.randomGenerator = PlatformMutex(randomGenerator)
     }
 
     /// Closes all owned file descriptors (skipping borrowed ones like stdio).

--- a/Sources/WASI/WASIBridgeToHost.swift
+++ b/Sources/WASI/WASIBridgeToHost.swift
@@ -1,4 +1,3 @@
-import Synchronization
 import WasmTypes
 
 /// A bridge that connects WebAssembly System Interface (WASI) calls to the host system.
@@ -21,7 +20,8 @@ import WasmTypes
 /// ```
 public final class WASIBridgeToHost: Sendable {
     internal let underlying: WASIImplementation
-    private let isClosed = Mutex(false)
+    // See `WASIImplementation.fdTable` for why this is a `nonisolated(unsafe) var`.
+    nonisolated(unsafe) private var isClosed = PlatformMutex(false)
 
     /// A preopened directory mapping from a guest path to a host path.
     ///

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -463,7 +463,10 @@ struct MemoryEntity: ~Copyable {
     static let pageSize = 64 * 1024
 
     static func maxPageCount(isMemory64: Bool) -> UInt64 {
-        isMemory64 ? UInt64.max : UInt64(1 << 32) / UInt64(pageSize)
+        // Shift in the UInt64 domain: `1 << 32` would be evaluated as `Int`,
+        // which is 32 bits wide on targets like riscv32, wrapping to zero and
+        // rejecting every guest that declares a memory.
+        isMemory64 ? UInt64.max : (UInt64(1) << 32) / UInt64(pageSize)
     }
 
     private struct MallocStorage {

--- a/Tests/CLICommandsTests/AsyncThrowingDefer.swift
+++ b/Tests/CLICommandsTests/AsyncThrowingDefer.swift
@@ -1,0 +1,34 @@
+import WASI
+
+/// Async counterpart of ``withThrowing(do:defer:)`` for tests.
+///
+/// `WASI` itself has no async callers, so this deliberately lives in the test
+/// target rather than shipping as package API. It mirrors the synchronous
+/// helper's semantics: `deferred` runs exactly once, and when both closures
+/// throw the failure surfaces as a ``CleanupFailure``.
+@discardableResult
+func withAsyncThrowing<T: Sendable>(
+    do work: @Sendable () async throws -> T,
+    defer deferred: @Sendable () async throws -> Void
+) async throws -> T {
+    let result: T
+    do {
+        result = try await work()
+    } catch {
+        throw await preservingError(error, cleanup: deferred)
+    }
+    try await deferred()
+    return result
+}
+
+private func preservingError(
+    _ error: any Error,
+    cleanup: () async throws -> Void
+) async -> any Error {
+    do {
+        try await cleanup()
+        return error
+    } catch let cleanupError {
+        return CleanupFailure(underlying: error, cleanup: cleanupError)
+    }
+}

--- a/Tests/WASITests/CleanupFailureTests.swift
+++ b/Tests/WASITests/CleanupFailureTests.swift
@@ -15,18 +15,4 @@ import WASI
         #expect(combined.description.contains("body"))
         #expect(combined.description.contains("cleanup"))
     }
-
-    @Test func successfulAsyncCleanupPreservesTheOriginalError() async throws {
-        let cleanup: () async throws -> Void = {}
-        let result = await CleanupFailure.preserving(ProbeError.body, cleanup: cleanup)
-        #expect(result as? ProbeError == .body)
-    }
-
-    @Test func failedAsyncCleanupSurfacesBothErrors() async throws {
-        let cleanup: () async throws -> Void = { throw ProbeError.cleanup }
-        let result = await CleanupFailure.preserving(ProbeError.body, cleanup: cleanup)
-        let combined = try #require(result as? CleanupFailure)
-        #expect(combined.underlying as? ProbeError == .body)
-        #expect(combined.cleanup as? ProbeError == .cleanup)
-    }
 }

--- a/Tests/WASITests/ThrowingDeferTests.swift
+++ b/Tests/WASITests/ThrowingDeferTests.swift
@@ -2,11 +2,6 @@ import Testing
 import WASI
 
 @Suite struct ThrowingDeferTests {
-    private actor Counter {
-        private(set) var value = 0
-        func increment() { value += 1 }
-    }
-
     @Test func bodyErrorSurvivesAFailingCleanup() throws {
         let error = #expect(throws: (any Error).self) {
             try withThrowing {
@@ -57,32 +52,5 @@ import WASI
         }
         #expect(value == 7)
         #expect(attempts == 1)
-    }
-
-    @Test func asyncBodyErrorSurvivesAFailingCleanup() async throws {
-        let error = await #expect(throws: (any Error).self) {
-            try await withAsyncThrowing {
-                throw ProbeError.body
-            } defer: {
-                throw ProbeError.cleanup
-            }
-        }
-        let thrown = try #require(error)
-        let combined = try #require(thrown as? CleanupFailure)
-        #expect(combined.underlying as? ProbeError == .body)
-    }
-
-    @Test func asyncCleanupRunsOnceWhenTheBodySucceedsAndCleanupFails() async throws {
-        let attempts = Counter()
-        let error = await #expect(throws: ProbeError.self) {
-            try await withAsyncThrowing {
-                ()
-            } defer: {
-                await attempts.increment()
-                throw ProbeError.cleanup
-            }
-        }
-        #expect(await attempts.value == 1)
-        #expect(error == .cleanup)
     }
 }

--- a/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
+++ b/Tests/WASITests/WASIMemoryFileSystemConcurrencyTests.swift
@@ -252,18 +252,35 @@ import Testing
     }
 }
 
-/// Runs an async cleanup closure (`deferred`) after a given async `work`
-/// closure, making sure `deferred` also runs when `work` throws.
+/// Async counterpart of ``withThrowing(do:defer:)`` for tests.
+///
+/// `WASI` itself has no async callers, so this deliberately lives in the test
+/// target rather than shipping as package API. It mirrors the synchronous
+/// helper's semantics: `deferred` runs exactly once, and when both closures
+/// throw the failure surfaces as a ``CleanupFailure`` rather than silently
+/// discarding the cleanup error.
 private func withAsyncThrowing<T: Sendable>(
     do work: @Sendable () async throws -> T,
     defer deferred: @Sendable () async throws -> Void
 ) async throws -> T {
+    let result: T
     do {
-        let result = try await work()
-        try await deferred()
-        return result
+        result = try await work()
     } catch {
-        try await deferred()
-        throw error
+        throw await preservingError(error, cleanup: deferred)
+    }
+    try await deferred()
+    return result
+}
+
+private func preservingError(
+    _ error: any Error,
+    cleanup: () async throws -> Void
+) async -> any Error {
+    do {
+        try await cleanup()
+        return error
+    } catch let cleanupError {
+        return CleanupFailure(underlying: error, cleanup: cleanupError)
     }
 }

--- a/Tests/WasmKitTests/MemoryPageLimitTests.swift
+++ b/Tests/WasmKitTests/MemoryPageLimitTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import WasmKit
+
+@Suite struct MemoryPageLimitTests {
+    /// A 32-bit wasm memory addresses 4 GiB, which is 65536 pages of 64 KiB.
+    ///
+    /// Regression guard: computing this as `UInt64(1 << 32)` evaluates the
+    /// shift as `Int`, which is 32 bits wide on targets like riscv32. It wraps
+    /// to zero there, so the validator rejected every guest that declared a
+    /// memory -- while remaining correct on 64-bit hosts, where this test runs.
+    /// Keep the shift in the UInt64 domain.
+    @Test func aThirtyTwoBitMemoryAllowsTheFullPageRange() {
+        #expect(MemoryEntity.maxPageCount(isMemory64: false) == 65536)
+    }
+
+    @Test func aSixtyFourBitMemoryIsUnbounded() {
+        #expect(MemoryEntity.maxPageCount(isMemory64: true) == UInt64.max)
+    }
+}


### PR DESCRIPTION
`Synchronization` provides no `Mutex` on bare-metal Embedded Swift targets, so
`WASI` could not compile there.

Mirror `WasmKit`'s `PlatformMutex`, which is backed by `Synchronization.Mutex`
when the `MultiThread` trait is on and degrades to unsynchronized storage when it
is off. The two copies are deliberately duplicated rather than shared: `WASI`
depends only on `WasmTypes`, so hoisting the type would either put a concurrency
primitive in a module about wasm type definitions or add a target that every
embedded consumer has to wire up as a separate build unit.

The single-threaded fallback's `withLock` is `mutating`, so the six mutex fields
become `nonisolated(unsafe) var`. That matches what `StoreAllocator` already
does. The cost is that those six fields lose compiler-enforced `Sendable`
checking in the default multi-threaded build, where `let` plus
`Synchronization.Mutex` had provided it.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #401 Fix the 32-bit wasm memory page limit on 32-bit hosts
1. #402 Drop the async withThrowing/CleanupFailure overloads from WASI
1. #403 Use a PlatformMutex in WASI instead of Synchronization.Mutex **← this PR**
1. #404 Decouple WASIFile from GuestMemory

Six more branches continue this work locally (selective WASI linking, the
embedded CI change, and running WASI plus the GDB stub on emulated hardware).
They will be opened once these land, or sooner if that helps review.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
