### PR TITLE
Decouple WASIFile from GuestMemory

### DIFF
--- a/Sources/WASI/CMakeLists.txt
+++ b/Sources/WASI/CMakeLists.txt
@@ -24,6 +24,7 @@ add_wasmkit_library(WASI
   MemoryFileSystem/MemoryFileEntry.swift
   FileSystem.swift
   GuestMemorySupport.swift
+  GuestBuffers.swift
   Clock.swift
   Poll.swift
   RandomBufferGenerator.swift

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -31,10 +31,17 @@ import WasmTypes
         offset: WASIAbi.FileSize, length: WASIAbi.FileSize, advice: WASIAbi.Advice
     ) throws
     func close() throws
+
+    /// The host file descriptor backing this entry, if it has one.
+    ///
+    /// `poll_oneoff` can only wait on real descriptors; entries without one
+    /// (in-memory files, devices) report `nil`.
+    var hostFileDescriptor: CInt? { get }
 }
 
 extension WASIEntry {
     @_spi(WASIPlatform) public var isBorrowed: Bool { false }
+    @_spi(WASIPlatform) public var hostFileDescriptor: CInt? { nil }
 }
 
 /// A file-like resource (regular file, stdio stream, device, ...) exposed
@@ -49,18 +56,10 @@ extension WASIEntry {
     func tell() throws -> WASIAbi.FileSize
     func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize
 
-    func write<M: GuestMemory, Buffer: Sequence>(
-        vectored buffer: Buffer, memory: M
-    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
-    func pwrite<M: GuestMemory, Buffer: Sequence>(
-        vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize
-    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
-    func read<M: GuestMemory, Buffer: Sequence>(
-        into buffer: Buffer, memory: M
-    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
-    func pread<M: GuestMemory, Buffer: Sequence>(
-        into buffer: Buffer, memory: M, offset: WASIAbi.FileSize
-    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec
+    func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size
+    func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size
+    func read(into buffers: GuestBuffers) throws -> WASIAbi.Size
+    func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size
 }
 
 /// A directory-like resource exposed to WASI guests.

--- a/Sources/WASI/GuestBuffers.swift
+++ b/Sources/WASI/GuestBuffers.swift
@@ -1,0 +1,40 @@
+import WasmTypes
+
+/// A vector of guest buffers (WASI iovecs), resolved against guest memory on
+/// demand.
+///
+/// File implementations receive this instead of a `GuestMemory` so that
+/// ``WASIFile`` stays free of generic requirements. Embedded Swift forbids a
+/// protocol used as an existential from carrying generic methods, and
+/// ``FdEntry`` stores files as `any WASIFile`, so the concrete memory type is
+/// erased here -- at the WASI call boundary, where it is still statically
+/// known -- rather than threaded through the file protocol.
+///
+/// Each buffer is resolved inside its own guest-memory access scope, one at a
+/// time, matching how vectored I/O was performed before the erasure existed.
+@_spi(WASIPlatform) public struct GuestBuffers {
+    /// The number of buffers in the vector.
+    public let count: Int
+
+    private let access: (Int, (UnsafeMutableRawBufferPointer) throws -> Int) throws -> Int
+
+    init<M: GuestMemory>(iovs: UnsafeGuestBufferPointer<WASIAbi.IOVec>, memory: M) {
+        self.count = Int(iovs.count)
+        self.access = { index, body in
+            let iovec = iovs.read(at: UInt32(index), in: memory)
+            return try iovec.withHostBufferPointer(in: memory) { try body($0) }
+        }
+    }
+
+    /// Calls `body` with the host buffer backing the buffer at `index`.
+    ///
+    /// - Parameter body: Returns the number of bytes it transferred.
+    /// - Returns: Whatever `body` returned.
+    @discardableResult
+    public func withHostBuffer(
+        at index: Int,
+        _ body: (UnsafeMutableRawBufferPointer) throws -> Int
+    ) throws -> Int {
+        try access(index, body)
+    }
+}

--- a/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFSNodes.swift
@@ -254,25 +254,26 @@ final class MemoryFileNode: MemFSNode {
         }
     }
 
-    func read<M: GuestMemory, Buffer: Sequence>(
-        into buffer: Buffer, memory: M, position: Int
-    ) throws -> (count: WASIAbi.Size, newPosition: Int) where Buffer.Element == WASIAbi.IOVec {
-        let (count, newPosition, handle): (WASIAbi.Size, Int, FileDescriptor?) = state.withLock { s in
+    func read(
+        into buffers: GuestBuffers, position: Int
+    ) throws -> (count: WASIAbi.Size, newPosition: Int) {
+        let (count, newPosition, handle): (WASIAbi.Size, Int, FileDescriptor?) = try state.withLock { s in
             switch s.content {
             case .bytes(let bytes):
                 var cur = position
                 var total: UInt32 = 0
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                for index in 0..<buffers.count {
+                    try buffers.withHostBuffer(at: index) { bufferPtr in
                         let available = max(0, bytes.count - cur)
                         let toRead = min(bufferPtr.count, available)
-                        guard toRead > 0 else { return }
+                        guard toRead > 0 else { return 0 }
                         bytes.withUnsafeBytes { contentBytes in
                             bufferPtr.baseAddress!.copyMemory(
                                 from: contentBytes.baseAddress!.advanced(by: cur), byteCount: toRead)
                         }
                         cur += toRead
                         total += UInt32(toRead)
+                        return toRead
                     }
                 }
                 s.atim = WASIAbi.Timestamp.currentWallClock()
@@ -284,8 +285,8 @@ final class MemoryFileNode: MemFSNode {
         guard let handle else { return (count, newPosition) }
         var currentOffset = Int64(position)
         var total: UInt32 = 0
-        for iovec in buffer {
-            let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+        for index in 0..<buffers.count {
+            let nread = try buffers.withHostBuffer(at: index) { bufferPtr in
                 try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
             }
             currentOffset += Int64(nread)
@@ -294,25 +295,26 @@ final class MemoryFileNode: MemFSNode {
         return (total, Int(currentOffset))
     }
 
-    func pread<M: GuestMemory, Buffer: Sequence>(
-        into buffer: Buffer, memory: M, offset: Int
-    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
-        let (count, handle): (WASIAbi.Size, FileDescriptor?) = state.withLock { s in
+    func pread(
+        into buffers: GuestBuffers, offset: Int
+    ) throws -> WASIAbi.Size {
+        let (count, handle): (WASIAbi.Size, FileDescriptor?) = try state.withLock { s in
             switch s.content {
             case .bytes(let bytes):
                 var cur = offset
                 var total: UInt32 = 0
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                for index in 0..<buffers.count {
+                    try buffers.withHostBuffer(at: index) { bufferPtr in
                         let available = max(0, bytes.count - cur)
                         let toRead = min(bufferPtr.count, available)
-                        guard toRead > 0 else { return }
+                        guard toRead > 0 else { return 0 }
                         bytes.withUnsafeBytes { contentBytes in
                             bufferPtr.baseAddress!.copyMemory(
                                 from: contentBytes.baseAddress!.advanced(by: cur), byteCount: toRead)
                         }
                         cur += toRead
                         total += UInt32(toRead)
+                        return toRead
                     }
                 }
                 s.atim = WASIAbi.Timestamp.currentWallClock()
@@ -324,8 +326,8 @@ final class MemoryFileNode: MemFSNode {
         guard let handle else { return count }
         var currentOffset = Int64(offset)
         var total: UInt32 = 0
-        for iovec in buffer {
-            let nread = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+        for index in 0..<buffers.count {
+            let nread = try buffers.withHostBuffer(at: index) { bufferPtr in
                 try handle.read(fromAbsoluteOffset: currentOffset, into: bufferPtr)
             }
             currentOffset += Int64(nread)
@@ -334,16 +336,16 @@ final class MemoryFileNode: MemFSNode {
         return total
     }
 
-    func write<M: GuestMemory, Buffer: Sequence>(
-        vectored buffer: Buffer, memory: M, position: Int
-    ) throws -> (count: WASIAbi.Size, newPosition: Int) where Buffer.Element == WASIAbi.IOVec {
-        let (count, newPosition, handle): (WASIAbi.Size, Int, FileDescriptor?) = state.withLock { s in
+    func write(
+        vectored buffers: GuestBuffers, position: Int
+    ) throws -> (count: WASIAbi.Size, newPosition: Int) {
+        let (count, newPosition, handle): (WASIAbi.Size, Int, FileDescriptor?) = try state.withLock { s in
             switch s.content {
             case .bytes(var bytes):
                 var cur = position
                 var total: UInt32 = 0
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                for index in 0..<buffers.count {
+                    try buffers.withHostBuffer(at: index) { bufferPtr in
                         let bytesToWrite = bufferPtr.count
                         let requiredSize = cur + bytesToWrite
                         if requiredSize > bytes.count {
@@ -352,6 +354,7 @@ final class MemoryFileNode: MemFSNode {
                         bytes.replaceSubrange(cur..<(cur + bytesToWrite), with: bufferPtr)
                         cur += bytesToWrite
                         total += UInt32(bytesToWrite)
+                        return bytesToWrite
                     }
                 }
                 s.content = .bytes(bytes)
@@ -366,8 +369,8 @@ final class MemoryFileNode: MemFSNode {
         guard let handle else { return (count, newPosition) }
         var currentOffset = Int64(position)
         var total: UInt32 = 0
-        for iovec in buffer {
-            let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+        for index in 0..<buffers.count {
+            let nwritten = try buffers.withHostBuffer(at: index) { bufferPtr in
                 try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
             }
             currentOffset += Int64(nwritten)
@@ -376,16 +379,16 @@ final class MemoryFileNode: MemFSNode {
         return (total, Int(currentOffset))
     }
 
-    func pwrite<M: GuestMemory, Buffer: Sequence>(
-        vectored buffer: Buffer, memory: M, offset: Int
-    ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
-        let (count, handle): (WASIAbi.Size, FileDescriptor?) = state.withLock { s in
+    func pwrite(
+        vectored buffers: GuestBuffers, offset: Int
+    ) throws -> WASIAbi.Size {
+        let (count, handle): (WASIAbi.Size, FileDescriptor?) = try state.withLock { s in
             switch s.content {
             case .bytes(var bytes):
                 var cur = offset
                 var total: UInt32 = 0
-                for iovec in buffer {
-                    iovec.withHostBufferPointer(in: memory) { bufferPtr in
+                for index in 0..<buffers.count {
+                    try buffers.withHostBuffer(at: index) { bufferPtr in
                         let bytesToWrite = bufferPtr.count
                         let requiredSize = cur + bytesToWrite
                         if requiredSize > bytes.count {
@@ -394,6 +397,7 @@ final class MemoryFileNode: MemFSNode {
                         bytes.replaceSubrange(cur..<(cur + bytesToWrite), with: bufferPtr)
                         cur += bytesToWrite
                         total += UInt32(bytesToWrite)
+                        return bytesToWrite
                     }
                 }
                 s.content = .bytes(bytes)
@@ -408,8 +412,8 @@ final class MemoryFileNode: MemFSNode {
         guard let handle else { return count }
         var currentOffset = Int64(offset)
         var total: UInt32 = 0
-        for iovec in buffer {
-            let nwritten = try iovec.withHostBufferPointer(in: memory) { bufferPtr in
+        for index in 0..<buffers.count {
+            let nwritten = try buffers.withHostBuffer(at: index) { bufferPtr in
                 try handle.writeAll(toAbsoluteOffset: currentOffset, bufferPtr)
             }
             currentOffset += Int64(nwritten)
@@ -522,7 +526,7 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         throw WASIAbi.Errno.ESPIPE
     }
 
-    func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -530,20 +534,21 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         switch deviceNode.kind {
         case .null:
             var totalBytes: UInt32 = 0
-            for iovec in buffer {
-                iovec.withHostBufferPointer(in: memory) { bufferPtr in
+            for index in 0..<buffers.count {
+                try buffers.withHostBuffer(at: index) { bufferPtr in
                     totalBytes += UInt32(bufferPtr.count)
+                    return bufferPtr.count
                 }
             }
             return totalBytes
         }
     }
 
-    func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
         throw WASIAbi.Errno.ESPIPE
     }
 
-    func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func read(into buffers: GuestBuffers) throws -> WASIAbi.Size {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
@@ -554,7 +559,7 @@ final class MemoryCharacterDeviceEntry: WASIFile {
         }
     }
 
-    func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
         throw WASIAbi.Errno.ESPIPE
     }
 }

--- a/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryFileEntry.swift
@@ -173,39 +173,39 @@ final class MemoryFileEntry: WASIFile {
         }
     }
 
-    func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
         return try position.withLock { pos in
-            let result = try fileNode.write(vectored: buffer, memory: memory, position: pos)
+            let result = try fileNode.write(vectored: buffers, position: pos)
             pos = result.newPosition
             return result.count
         }
     }
 
-    func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
-        return try fileNode.pwrite(vectored: buffer, memory: memory, offset: Int(offset))
+        return try fileNode.pwrite(vectored: buffers, offset: Int(offset))
     }
 
-    func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func read(into buffers: GuestBuffers) throws -> WASIAbi.Size {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
         return try position.withLock { pos in
-            let result = try fileNode.read(into: buffer, memory: memory, position: pos)
+            let result = try fileNode.read(into: buffers, position: pos)
             pos = result.newPosition
             return result.count
         }
     }
 
-    func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
         guard accessMode.contains(.read) else {
             throw WASIAbi.Errno.EBADF
         }
-        return try fileNode.pread(into: buffer, memory: memory, offset: Int(offset))
+        return try fileNode.pread(into: buffers, offset: Int(offset))
     }
 }

--- a/Sources/WASI/Platform/File.swift
+++ b/Sources/WASI/Platform/File.swift
@@ -4,6 +4,10 @@ protocol FdWASIEntry: WASIEntry {
     var fd: FileDescriptor { get }
 }
 
+extension FdWASIEntry {
+    var hostFileDescriptor: CInt? { fd.rawValue }
+}
+
 protocol FdWASIFile: WASIFile, FdWASIEntry {
     var accessMode: FileAccessMode { get }
 }
@@ -33,52 +37,56 @@ extension FdWASIFile {
     }
 
     @inlinable
-    func write<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size {
         guard accessMode.contains(.write) else {
             throw WASIAbi.Errno.EBADF
         }
         // TODO: Use `writev`
         var bytesWritten: UInt32 = 0
-        for iovec in buffer {
-            bytesWritten += try iovec.withHostBufferPointer(in: memory) {
-                UInt32(try fd.write(UnsafeRawBufferPointer($0)))
-            }
+        for index in 0..<buffers.count {
+            bytesWritten += UInt32(
+                try buffers.withHostBuffer(at: index) {
+                    try fd.write(UnsafeRawBufferPointer($0))
+                })
         }
         return bytesWritten
     }
 
     @inlinable
-    func pwrite<M: GuestMemory, Buffer: Sequence>(vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
         // TODO: Use `pwritev`
         var currentOffset: Int64 = Int64(offset)
-        for iovec in buffer {
-            currentOffset += try iovec.withHostBufferPointer(in: memory) {
-                Int64(try fd.writeAll(toAbsoluteOffset: currentOffset, $0))
-            }
+        for index in 0..<buffers.count {
+            currentOffset += Int64(
+                try buffers.withHostBuffer(at: index) {
+                    try fd.writeAll(toAbsoluteOffset: currentOffset, $0)
+                })
         }
         let nwritten = WASIAbi.FileSize(currentOffset) - offset
         return WASIAbi.Size(nwritten)
     }
 
     @inlinable
-    func read<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func read(into buffers: GuestBuffers) throws -> WASIAbi.Size {
         var nread: UInt32 = 0
-        for iovec in buffer {
-            nread += try iovec.withHostBufferPointer(in: memory) {
-                try UInt32(fd.read(into: $0))
-            }
+        for index in 0..<buffers.count {
+            nread += UInt32(
+                try buffers.withHostBuffer(at: index) {
+                    try fd.read(into: $0)
+                })
         }
         return nread
     }
 
     @inlinable
-    func pread<M: GuestMemory, Buffer: Sequence>(into buffer: Buffer, memory: M, offset: WASIAbi.FileSize) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+    func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
         // TODO: Use `preadv`
         var nread: UInt32 = 0
-        for iovec in buffer {
-            nread += try iovec.withHostBufferPointer(in: memory) {
-                try UInt32(fd.read(fromAbsoluteOffset: Int64(offset + UInt64(nread)), into: $0))
-            }
+        for index in 0..<buffers.count {
+            nread += UInt32(
+                try buffers.withHostBuffer(at: index) {
+                    try fd.read(fromAbsoluteOffset: Int64(offset + UInt64(nread)), into: $0)
+                })
         }
         return nread
     }

--- a/Sources/WASI/Poll.swift
+++ b/Sources/WASI/Poll.swift
@@ -2,11 +2,11 @@ import WasmTypes
 
 extension FdTable {
     fileprivate func hostFileDescriptor(fd: WASIAbi.Fd) throws -> CInt {
-        guard case .file(let entry) = self[fd], let fd = (entry as? FdWASIEntry)?.fd else {
+        guard case .file(let entry) = self[fd], let hostFd = entry.hostFileDescriptor else {
             throw WASIAbi.Errno.EBADF
         }
 
-        return fd.rawValue
+        return hostFd
     }
 }
 

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1648,7 +1648,7 @@ final class WASIImplementation: Sendable {
             }
             return fileEntry
         }
-        return try fileEntry.pread(into: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory, offset: offset)
+        return try fileEntry.pread(into: GuestBuffers(iovs: iovs, memory: memory), offset: offset)
     }
 
     /// Return a description of the given preopened file descriptor.
@@ -1697,7 +1697,7 @@ final class WASIImplementation: Sendable {
             }
             return fileEntry
         }
-        return try fileEntry.pwrite(vectored: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory, offset: offset)
+        return try fileEntry.pwrite(vectored: GuestBuffers(iovs: iovs, memory: memory), offset: offset)
     }
 
     /// Read from a file descriptor.
@@ -1712,7 +1712,7 @@ final class WASIImplementation: Sendable {
             }
             return fileEntry
         }
-        return try fileEntry.read(into: (0..<iovs.count).map { iovs.read(at: $0, in: memory) }, memory: memory)
+        return try fileEntry.read(into: GuestBuffers(iovs: iovs, memory: memory))
     }
 
     /// Read directory entries from a directory.
@@ -1843,7 +1843,7 @@ final class WASIImplementation: Sendable {
             }
             return entry
         }
-        return try entry.write(vectored: (0..<ioVectors.count).map { ioVectors.read(at: $0, in: memory) }, memory: memory)
+        return try entry.write(vectored: GuestBuffers(iovs: ioVectors, memory: memory))
     }
 
     /// Create a directory.

--- a/Tests/WASITests/CustomPlatformInjectionTests.swift
+++ b/Tests/WASITests/CustomPlatformInjectionTests.swift
@@ -40,28 +40,20 @@ struct CustomPlatformInjectionTests {
         func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize {
             throw WASIAbi.Errno.ESPIPE
         }
-        func write<M: GuestMemory, Buffer: Sequence>(
-            vectored buffer: Buffer, memory: M
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size {
             throw WASIAbi.Errno.EROFS
         }
-        func pwrite<M: GuestMemory, Buffer: Sequence>(
-            vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
             throw WASIAbi.Errno.EROFS
         }
-        func read<M: GuestMemory, Buffer: Sequence>(
-            into buffer: Buffer, memory: M
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
-            try pread(into: buffer, memory: memory, offset: 0)
+        func read(into buffers: GuestBuffers) throws -> WASIAbi.Size {
+            try pread(into: buffers, offset: 0)
         }
-        func pread<M: GuestMemory, Buffer: Sequence>(
-            into buffer: Buffer, memory: M, offset: WASIAbi.FileSize
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
             var cursor = Int(offset)
             var total: WASIAbi.Size = 0
-            for iovec in buffer {
-                let count: Int = iovec.withHostBufferPointer(in: memory) { destination in
+            for index in 0..<buffers.count {
+                let count: Int = try buffers.withHostBuffer(at: index) { destination in
                     let available = max(0, bytes.count - cursor)
                     let toRead = min(destination.count, available)
                     guard toRead > 0 else { return 0 }
@@ -104,31 +96,24 @@ struct CustomPlatformInjectionTests {
         func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize {
             throw WASIAbi.Errno.ESPIPE
         }
-        func write<M: GuestMemory, Buffer: Sequence>(
-            vectored buffer: Buffer, memory: M
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size {
             var total: WASIAbi.Size = 0
-            for iovec in buffer {
-                iovec.withHostBufferPointer(in: memory) { source in
+            for index in 0..<buffers.count {
+                try buffers.withHostBuffer(at: index) { source in
                     captured.withLock { $0.append(contentsOf: source.bindMemory(to: UInt8.self)) }
                     total += WASIAbi.Size(source.count)
+                    return source.count
                 }
             }
             return total
         }
-        func pwrite<M: GuestMemory, Buffer: Sequence>(
-            vectored buffer: Buffer, memory: M, offset: WASIAbi.FileSize
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
             throw WASIAbi.Errno.ESPIPE
         }
-        func read<M: GuestMemory, Buffer: Sequence>(
-            into buffer: Buffer, memory: M
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func read(into buffers: GuestBuffers) throws -> WASIAbi.Size {
             throw WASIAbi.Errno.EBADF
         }
-        func pread<M: GuestMemory, Buffer: Sequence>(
-            into buffer: Buffer, memory: M, offset: WASIAbi.FileSize
-        ) throws -> WASIAbi.Size where Buffer.Element == WASIAbi.IOVec {
+        func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
             throw WASIAbi.Errno.EBADF
         }
     }


### PR DESCRIPTION
Embedded Swift does not allow a protocol used as an existential to carry generic
methods, and `FdEntry` stores files as `any WASIFile`. The vectored I/O
requirements were generic over both the guest memory and the iovec sequence.

They also tripped a compiler assertion. `swift-frontend` hit
`!type.hasPrimaryArchetype()` in `MandatoryPerformanceOptimizations` at both
`-Onone` and `-Osize`, and still does on snapshot `2026-07-11-a`. That pass is
what emits the Embedded diagnostics, so the crash masked them entirely and the
module appeared to type-check cleanly.

Erase the memory behind `GuestBuffers` at the WASI call boundary, where the
concrete type is still known, and let files work in host buffers. Each buffer is
still resolved in its own guest-memory access scope, one at a time, so vectored
I/O semantics are unchanged and `MemoryFileNode` keeps its state lock across the
whole vector.

`WASIEntry` gains a `hostFileDescriptor` requirement so `poll_oneoff` no longer
needs a dynamic cast, which Embedded also rejects.

`WASI` still does not compile for Embedded after this change. The remaining 23
errors are all in `_hostModules`, whose closures take `any GuestMemory`; the next
PR in the stack addresses them.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #404 Decouple WASIFile from GuestMemory **← this PR**
1. #406 Make the WASI host module table generic over guest memory
1. #407 Allow linking a subset of the WASI preview1 surface
1. #408 Decouple WASIDir from its associated iterator type
1. #409 Cover WASI in the embedded check and strip unused code
1. #410 Run a WASI guest on emulated hardware in the ESP32 example

#401, #402 and #403 were the first three layers and are merged.

One more branch continues this locally: running the GDB stub on emulated
hardware and driving it with a real lldb. It will be opened once these land.

Unrelated but worth landing first: #405 fixes a debugger crash that makes
`CLICommandsTests` fail intermittently on Linux. It is the cause of the red
runs these PRs will otherwise keep hitting.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
