### PR TITLE
Do not read a host callee as a wasm function when stepping

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -480,19 +480,31 @@
             return (0..<Int(op.count)).map { pc.advanced(by: Int(op.baseAddress[$0].offset)) }
         }
 
+        /// Resolves the entry PC of a call target, compiling it if needed.
+        ///
+        /// Returns `nil` when there is nothing to step into: a host function, or
+        /// a callee whose compilation fails. `call` is emitted for host
+        /// functions and for wasm functions in another instance, so neither
+        /// "is wasm" nor "is compiled" can be assumed here.
+        private mutating func calleeEntryPc(_ callee: InternalFunction) -> Pc? {
+            guard callee.isWasm else { return nil }
+            _ = try? callee.wasm.ensureCompiled(store: StoreRef(self.store))
+            guard let iseq = callee.compiledIseq() else { return nil }
+            return iseq.instructions.baseAddress
+        }
+
         mutating func predictNext_call(operandPc: Pc, sp: Sp) -> [Pc] {
             var pc = operandPc
             let op = Instruction.CallOperand.load(from: &pc)
-            let (iseq, _, _) = op.callee.assumeCompiled()
-            return [iseq.instructions.baseAddress!]
+            guard let entry = calleeEntryPc(op.callee) else { return [] }
+            return [entry]
         }
 
         mutating func predictNext_compilingCall(operandPc: Pc, sp: Sp) -> [Pc] {
             var pc = operandPc
             let op = Instruction.CallOperand.load(from: &pc)
-            _ = try? op.callee.wasm.ensureCompiled(store: StoreRef(self.store))
-            let (iseq, _, _) = op.callee.assumeCompiled()
-            return [iseq.instructions.baseAddress!]
+            guard let entry = calleeEntryPc(op.callee) else { return [] }
+            return [entry]
         }
 
         mutating func predictNext_internalCall(operandPc: Pc, sp: Sp) -> [Pc] {
@@ -518,10 +530,7 @@
                 case .function(let rawBitPattern?) = table.elements[elementIndex]
             else { return nil }
             let function = InternalFunction(bitPattern: rawBitPattern)
-            guard function.isWasm else { return nil }
-            _ = try? function.wasm.ensureCompiled(store: StoreRef(self.store))
-            let (iseq, _, _) = function.assumeCompiled()
-            return iseq.instructions.baseAddress!
+            return calleeEntryPc(function)
         }
 
         mutating func predictNext_callIndirect(operandPc: Pc, sp: Sp) -> [Pc] {
@@ -537,10 +546,8 @@
             var pc = operandPc
             let op = Instruction.ReturnCallOperand.load(from: &pc)
             let callee = op.callee
-            guard callee.isWasm else { return [] }
-            _ = try? callee.wasm.ensureCompiled(store: StoreRef(self.store))
-            let (iseq, _, _) = callee.assumeCompiled()
-            return [iseq.instructions.baseAddress!]
+            guard let entry = calleeEntryPc(callee) else { return [] }
+            return [entry]
         }
 
         mutating func predictNext_returnCallIndirect(operandPc: Pc, sp: Sp) -> [Pc] {

--- a/Sources/WasmKit/Execution/Function.swift
+++ b/Sources/WasmKit/Execution/Function.swift
@@ -214,6 +214,24 @@ extension InternalFunction {
         }
     }
 
+    /// The compiled instruction sequence, or `nil` when there is none to point
+    /// at: a host function, or a wasm function that has not been compiled yet.
+    ///
+    /// `InternalFunction` is a tagged pointer, so reading `wasm` for a host
+    /// function reinterprets a `HostFunctionEntity` allocation as a
+    /// `WasmFunctionEntity`. Callers that cannot guarantee a compiled wasm
+    /// callee must use this instead of ``assumeCompiled()``.
+    func compiledIseq() -> InstructionSequence? {
+        guard isWasm else { return nil }
+        switch self.wasm.code {
+        case .compiled(let iseq), .debuggable(_, let iseq): return iseq
+        case .uncompiled: return nil
+        }
+    }
+
+    /// - Precondition: the callee is a wasm function and is already compiled.
+    ///   Only the engine's `internalCall` path guarantees this, because
+    ///   `compilingCall` rewrites itself to `internalCall` after compiling.
     func assumeCompiled() -> (
         InstructionSequence,
         locals: Int,

--- a/Tests/WasmKitTests/DebuggerHostCallStepTests.swift
+++ b/Tests/WasmKitTests/DebuggerHostCallStepTests.swift
@@ -1,0 +1,55 @@
+#if WasmDebuggingSupport
+
+    import Testing
+    import WAT
+    import WasmParser
+
+    @testable import WasmKit
+
+    /// Calls an imported host function. The translator emits `call` (not
+    /// `compilingCall`) for any callee outside the current instance, which
+    /// includes every host function, so stepping here exercises the predictor's
+    /// handling of a non-wasm callee.
+    private let hostCallWAT = """
+        (module
+          (import "env" "host" (func $host (param i32) (result i32)))
+          (func (export "_start") (result i32)
+            (i32.const 7)
+            (call $host)))
+        """
+
+    @Suite
+    struct DebuggerHostCallStepTests {
+        /// Stepping over a call to a host function must not read the callee as a
+        /// wasm entity. `InternalFunction` is a tagged pointer, so interpreting a
+        /// `HostFunctionEntity` as a `WasmFunctionEntity` reads unrelated memory:
+        /// it either trips `assumeCompiled()`'s precondition or reads past the
+        /// allocation, which AddressSanitizer reports as a heap-buffer-overflow.
+        @Test func steppingOverAHostCallDoesNotReadTheCalleeAsWasm() throws {
+            let store = Store(engine: Engine())
+            let module = try parseWasm(bytes: try wat2wasm(hostCallWAT))
+
+            var imports = Imports()
+            imports.define(
+                module: "env", name: "host",
+                Function(store: store, parameters: [.i32], results: [.i32]) { _, args in
+                    [.i32(args[0].i32 &+ 1)]
+                })
+
+            var debugger = try Debugger(module: module, store: store, imports: imports)
+            let startBase = module.functions[0].code.originalAddress
+
+            // _start body: i32.const 7 (2 bytes) + call
+            let bp = try debugger.enableBreakpoint(address: startBase + 2)
+            try debugger.run()
+            guard case .stoppedAtBreakpoint(let stop) = debugger.state, stop.wasmPc == bp else {
+                Issue.record("expected to stop at the call site, got \(debugger.state)")
+                return
+            }
+
+            // The step itself is what predicts past the host call.
+            try debugger.step()
+        }
+    }
+
+#endif


### PR DESCRIPTION
`InternalFunction` packs host and wasm functions into one word, with bit 0 set
for host functions. `var host` masks that tag off; `var wasm` does not
(`bitPattern & ~0b0` clears nothing).

`Debugger.predictNext_call` called `op.callee.assumeCompiled()` without an
`isWasm` guard, unlike its sibling `predictNext_returnCall`. The translator
emits `call` for host functions and for wasm functions in another instance
(`Translator.swift:1747`), so stepping over a call to an imported host function
read `WasmFunctionEntity.code` out of a `HostFunctionEntity` allocation.

What that produced depended on the memory it landed on:

- decoded as `.uncompiled`, tripping `assumeCompiled()`'s `preconditionFailure()`
  and aborting with `WasmKit/Function.swift:227: Fatal error`
- read past the smaller host allocation, which AddressSanitizer reports as a
  heap-buffer-overflow

Both showed up in CI as flaky `CLICommandsTests` failures on unrelated pull
requests, with signal 4, 5 or 6.

Neither operand of `call` is guaranteed compiled, and that is by design: the
engine compiles lazily in `invoke()` (`Execution.swift:684`). Only
`internalCall` carries the "already compiled" guarantee, because `compilingCall`
compiles the callee and then rewrites itself to `internalCall`.

### Fix

Add a non-trapping `InternalFunction.compiledIseq()`, and route every debugger
predictor through one `calleeEntryPc(_:)` helper that checks `isWasm`, compiles
on demand, and returns no prediction when there is nothing to step into.

This also closes a second way to reach the trap: `try? ensureCompiled(...)`
followed by `assumeCompiled()` swallowed a compilation error and then hit the
precondition. `assumeCompiled()` now remains only on the engine's `internalCall`
path, and documents the invariant it depends on.

### Verification

`DebuggerHostCallStepTests` steps over a call to an imported host function. It
crashes on every run against unpatched sources and passes with this change.

Running the full suite in a loop reproduced the crash on run 7 of 20 before the
fix, and 20 of 20 runs are clean after it.
