### PR TITLE
Decouple WASIDir from its associated iterator type

### DIFF
--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -64,8 +64,7 @@ extension WASIEntry {
 
 /// A directory-like resource exposed to WASI guests.
 @_spi(WASIPlatform) public protocol WASIDir: WASIEntry {
-    typealias ReaddirElement = (dirent: WASIAbi.Dirent, name: String)
-    associatedtype ReadEntriesResult: WASIReaddirIterator where ReadEntriesResult.Element == ReaddirElement
+    typealias ReaddirElement = WASIReaddirElement
 
     var preopenPath: String? { get }
 
@@ -76,13 +75,45 @@ extension WASIEntry {
     func removeFile(atPath path: String) throws
     func symlink(from sourcePath: String, to destPath: String) throws
     func rename(from sourcePath: String, toDir newDir: any WASIDir, to destPath: String) throws
-    func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult
+    func readEntries(cookie: WASIAbi.DirCookie) throws -> WASIReaddirEntries
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat
     func setFilestatTimes(
         path: String,
         atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags, symlinkFollow: Bool
     ) throws
+}
+
+/// A single directory entry.
+@_spi(WASIPlatform) public typealias WASIReaddirElement = (dirent: WASIAbi.Dirent, name: String)
+
+/// A type-erased iterator over directory entries.
+///
+/// Concrete rather than an associated type so that ``WASIDir`` carries no
+/// generic requirements. ``FdEntry`` stores directories as `any WASIDir`, and
+/// Embedded Swift cannot specialise a generic method reached through an
+/// existential.
+@_spi(WASIPlatform) public struct WASIReaddirEntries {
+    private final class Box<I: WASIReaddirIterator> where I.Element == WASIReaddirElement {
+        var iterator: I
+        init(_ iterator: I) { self.iterator = iterator }
+    }
+
+    private let nextEntry: () -> Result<WASIReaddirElement, any Error>?
+    private let closeIterator: () -> Void
+
+    public init<I: WASIReaddirIterator>(_ iterator: I) where I.Element == WASIReaddirElement {
+        let box = Box(iterator)
+        self.nextEntry = { box.iterator.next() }
+        self.closeIterator = { box.iterator.close() }
+    }
+
+    public mutating func next() -> Result<WASIReaddirElement, any Error>? { nextEntry() }
+
+    /// Closes the iterator and releases any owned resources.
+    ///
+    /// Callers must invoke this exactly once after iteration completes.
+    public mutating func close() { closeIterator() }
 }
 
 /// An iterator over directory entries produced by ``WASIDir/readEntries(cookie:)``.

--- a/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
@@ -1,6 +1,6 @@
 /// A WASIDir implementation backed by an in-memory directory node.
 struct MemoryDirEntry: WASIDir {
-    struct ReadEntriesResult: WASIReaddirIterator {
+    struct MemoryDirectoryIterator: WASIReaddirIterator {
         let children: [String]
         let fileSystem: MemoryFileSystem
         let basePath: String
@@ -130,13 +130,14 @@ struct MemoryDirEntry: WASIDir {
         )
     }
 
-    func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult {
-        ReadEntriesResult(
-            children: dirNode.listChildren(),
-            fileSystem: fileSystem,
-            basePath: path,
-            nextIndex: Int(cookie)
-        )
+    func readEntries(cookie: WASIAbi.DirCookie) throws -> WASIReaddirEntries {
+        WASIReaddirEntries(
+            MemoryDirectoryIterator(
+                children: dirNode.listChildren(),
+                fileSystem: fileSystem,
+                basePath: path,
+                nextIndex: Int(cookie)
+            ))
     }
 
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat {

--- a/Sources/WASI/Platform/Directory.swift
+++ b/Sources/WASI/Platform/Directory.swift
@@ -152,7 +152,7 @@ extension DirEntry: WASIDir, FdWASIEntry {
         }
     }
 
-    struct ReadEntriesResult: WASIReaddirIterator {
+    struct HostDirectoryIterator: WASIReaddirIterator {
         let fd: FileDescriptor
         let stream: FileDescriptor.DirectoryStream
         var entryIndex: Int
@@ -205,8 +205,8 @@ extension DirEntry: WASIDir, FdWASIEntry {
     }
     func readEntries(
         cookie: WASIAbi.DirCookie
-    ) throws -> ReadEntriesResult {
-        return try ReadEntriesResult(fd: fd, cookie: cookie)
+    ) throws -> WASIReaddirEntries {
+        return WASIReaddirEntries(try HostDirectoryIterator(fd: fd, cookie: cookie))
     }
 
     func createDirectory(atPath path: String) throws {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1144,8 +1144,8 @@ final class WASIImplementation: Sendable {
         cookie: WASIAbi.DirCookie,
         memory: M
     ) throws -> WASIAbi.Size {
-        func readDirectoryEntries<D: WASIDir>(
-            from dirEntry: D
+        func readDirectoryEntries(
+            from dirEntry: any WASIDir
         ) throws -> WASIAbi.Size {
             var entries = try dirEntry.readEntries(cookie: cookie)
             defer { entries.close() }

--- a/Tests/WASITests/CustomPlatformInjectionTests.swift
+++ b/Tests/WASITests/CustomPlatformInjectionTests.swift
@@ -147,7 +147,7 @@ struct CustomPlatformInjectionTests {
                 throw WASIAbi.Errno.EROFS
             }
 
-            struct ReadEntriesResult: WASIReaddirIterator {
+            struct FixedEntryIterator: WASIReaddirIterator {
                 var entries: [(WASIAbi.Dirent, String)]
                 var index = 0
                 mutating func next() -> Result<(dirent: WASIAbi.Dirent, name: String), any Error>? {
@@ -158,7 +158,7 @@ struct CustomPlatformInjectionTests {
                 mutating func close() {}
             }
 
-            func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult {
+            func readEntries(cookie: WASIAbi.DirCookie) throws -> WASIReaddirEntries {
                 let entries = files.keys.sorted().enumerated().map { index, name in
                     (
                         WASIAbi.Dirent(
@@ -167,7 +167,7 @@ struct CustomPlatformInjectionTests {
                         name
                     )
                 }
-                return ReadEntriesResult(entries: Array(entries.dropFirst(Int(cookie))))
+                return WASIReaddirEntries(FixedEntryIterator(entries: Array(entries.dropFirst(Int(cookie)))))
             }
 
             func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat {


### PR DESCRIPTION
`fd_readdir` called `readEntries` on `any WASIDir`, whose result was an
associated type, so the call could not be specialized for Embedded.

This only surfaced when compiling `WasmKitWASI`. Specialization happens at the
use site, so `WASI` on its own compiled cleanly and hid it. Worth remembering
when checking embedded support: compiling the library proves less than compiling
its consumer.

Erase the iterator behind a concrete `WASIReaddirEntries`, keeping
`WASIReaddirIterator` as the shape implementers conform to.

With the associated type gone, the `ReadEntriesResult` types were named after a
requirement that no longer exists, so they are renamed for what they are:
`HostDirectoryIterator` and `MemoryDirectoryIterator`.

With this the whole stack compiles for `riscv32-none-none-eabi`: `WasmTypes`,
`WasmParser`, `WasmKit`, `WASI`, `WasmKitWASI`.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #404 Decouple WASIFile from GuestMemory
1. #406 Make the WASI host module table generic over guest memory
1. #407 Allow linking a subset of the WASI preview1 surface
1. #408 Decouple WASIDir from its associated iterator type **← this PR**
1. #409 Cover WASI in the embedded check and strip unused code
1. #410 Run a WASI guest on emulated hardware in the ESP32 example

#401, #402 and #403 were the first three layers and are merged.

One more branch continues this locally: running the GDB stub on emulated
hardware and driving it with a real lldb. It will be opened once these land.

Unrelated but worth landing first: #405 fixes a debugger crash that makes
`CLICommandsTests` fail intermittently on Linux. It is the cause of the red
runs these PRs will otherwise keep hitting.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
