### PR TITLE
Cover WASI in the embedded check and strip unused code

### DIFF
--- a/Examples/embedded-esp32/README.md
+++ b/Examples/embedded-esp32/README.md
@@ -42,6 +42,21 @@ idf.py -B build.c6 -D SDKCONFIG=sdkconfig.c6 -p /dev/cu.usbmodem* flash monitor
 
 - The default 512 KiB WasmKit value stack does not fit in on-chip SRAM, so
   `Main.swift` sets `EngineConfiguration.stackSize` to 64 KiB.
+- Each component is compiled with `-Xfrontend -function-sections`. `swiftc`
+  otherwise emits a single `.text` section per module, and ESP-IDF's
+  `--gc-sections` can only strip whole sections -- so without the flag nothing
+  the firmware does not call can be dropped. Objects grow by roughly a quarter
+  before linking; the linker reclaims it.
+- WASI is available on this target. Link only the parts you use:
+
+  ```swift
+  var imports = Imports()
+  try bridge.link(to: &imports, store: store, capabilities: [.stdio, .clocks, .random])
+  ```
+
+  Unnamed capabilities stay unreferenced and are stripped. Functions the guest
+  imports but no linked capability provides are registered as `ENOSYS` stubs,
+  so the module still instantiates -- pass `stubUnlinked: false` to opt out.
 - The QEMU run uses the ESP32-C3 machine because Espressif's QEMU has no
   ESP32-C6 model; both chips are RV32IMC-class cores running the same code
   paths.

--- a/Examples/embedded-esp32/components/wasmkit/CMakeLists.txt
+++ b/Examples/embedded-esp32/components/wasmkit/CMakeLists.txt
@@ -22,6 +22,9 @@ set_target_properties(${COMPONENT_LIB} PROPERTIES
 )
 # -I for the WasmTypes/WasmParser swiftmodules; -Xcc -I so the Clang importer
 # finds _CWasmKit's module.modulemap.
+# `-Xfrontend -function-sections` puts each function in its own section so
+# ESP-IDF's `--gc-sections` can drop what the firmware never calls. Without it
+# swiftc emits one `.text` per module and none of it can be stripped.
 target_compile_options(${COMPONENT_LIB} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -Xcc -I${WASMKIT_ROOT}/Sources/_CWasmKit/include -package-name wasmkit>")
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -Xcc -I${WASMKIT_ROOT}/Sources/_CWasmKit/include -Xfrontend -function-sections -package-name wasmkit>")
 add_dependencies(${COMPONENT_LIB} __idf_wasmtypes __idf_wasmparser)

--- a/Examples/embedded-esp32/components/wasmparser/CMakeLists.txt
+++ b/Examples/embedded-esp32/components/wasmparser/CMakeLists.txt
@@ -20,6 +20,9 @@ set_target_properties(${COMPONENT_LIB} PROPERTIES
     Swift_MODULE_NAME WasmParser
     Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift-modules
 )
+# `-Xfrontend -function-sections` puts each function in its own section so
+# ESP-IDF's `--gc-sections` can drop what the firmware never calls. Without it
+# swiftc emits one `.text` per module and none of it can be stripped.
 target_compile_options(${COMPONENT_LIB} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -package-name wasmkit>")
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -Xfrontend -function-sections -package-name wasmkit>")
 add_dependencies(${COMPONENT_LIB} __idf_wasmtypes)

--- a/Examples/embedded-esp32/components/wasmtypes/CMakeLists.txt
+++ b/Examples/embedded-esp32/components/wasmtypes/CMakeLists.txt
@@ -16,8 +16,11 @@ idf_component_register_swift(
     BRIDGING_HEADER ${CMAKE_CURRENT_LIST_DIR}/Empty.h
     SRCS ${wasmtypes_srcs}
 )
+# `-Xfrontend -function-sections` puts each function in its own section so
+# ESP-IDF's `--gc-sections` can drop what the firmware never calls. Without it
+# swiftc emits one `.text` per module and none of it can be stripped.
 target_compile_options(${COMPONENT_LIB} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name wasmkit>")
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -function-sections -package-name wasmkit>")
 set_target_properties(${COMPONENT_LIB} PROPERTIES
     Swift_MODULE_NAME WasmTypes
     Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift-modules

--- a/Sources/WASI/FileSystem.swift
+++ b/Sources/WASI/FileSystem.swift
@@ -64,8 +64,7 @@ extension WASIEntry {
 
 /// A directory-like resource exposed to WASI guests.
 @_spi(WASIPlatform) public protocol WASIDir: WASIEntry {
-    typealias ReaddirElement = (dirent: WASIAbi.Dirent, name: String)
-    associatedtype ReadEntriesResult: WASIReaddirIterator where ReadEntriesResult.Element == ReaddirElement
+    typealias ReaddirElement = WASIReaddirElement
 
     var preopenPath: String? { get }
 
@@ -76,13 +75,45 @@ extension WASIEntry {
     func removeFile(atPath path: String) throws
     func symlink(from sourcePath: String, to destPath: String) throws
     func rename(from sourcePath: String, toDir newDir: any WASIDir, to destPath: String) throws
-    func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult
+    func readEntries(cookie: WASIAbi.DirCookie) throws -> WASIReaddirEntries
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat
     func setFilestatTimes(
         path: String,
         atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp,
         fstFlags: WASIAbi.FstFlags, symlinkFollow: Bool
     ) throws
+}
+
+/// A single directory entry.
+@_spi(WASIPlatform) public typealias WASIReaddirElement = (dirent: WASIAbi.Dirent, name: String)
+
+/// A type-erased iterator over directory entries.
+///
+/// Concrete rather than an associated type so that ``WASIDir`` carries no
+/// generic requirements. ``FdEntry`` stores directories as `any WASIDir`, and
+/// Embedded Swift cannot specialise a generic method reached through an
+/// existential.
+@_spi(WASIPlatform) public struct WASIReaddirEntries {
+    private final class Box<I: WASIReaddirIterator> where I.Element == WASIReaddirElement {
+        var iterator: I
+        init(_ iterator: I) { self.iterator = iterator }
+    }
+
+    private let nextEntry: () -> Result<WASIReaddirElement, any Error>?
+    private let closeIterator: () -> Void
+
+    public init<I: WASIReaddirIterator>(_ iterator: I) where I.Element == WASIReaddirElement {
+        let box = Box(iterator)
+        self.nextEntry = { box.iterator.next() }
+        self.closeIterator = { box.iterator.close() }
+    }
+
+    public mutating func next() -> Result<WASIReaddirElement, any Error>? { nextEntry() }
+
+    /// Closes the iterator and releases any owned resources.
+    ///
+    /// Callers must invoke this exactly once after iteration completes.
+    public mutating func close() { closeIterator() }
 }
 
 /// An iterator over directory entries produced by ``WASIDir/readEntries(cookie:)``.

--- a/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
+++ b/Sources/WASI/MemoryFileSystem/MemoryDirEntry.swift
@@ -1,6 +1,6 @@
 /// A WASIDir implementation backed by an in-memory directory node.
 struct MemoryDirEntry: WASIDir {
-    struct ReadEntriesResult: WASIReaddirIterator {
+    struct MemoryDirectoryIterator: WASIReaddirIterator {
         let children: [String]
         let fileSystem: MemoryFileSystem
         let basePath: String
@@ -130,13 +130,14 @@ struct MemoryDirEntry: WASIDir {
         )
     }
 
-    func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult {
-        ReadEntriesResult(
-            children: dirNode.listChildren(),
-            fileSystem: fileSystem,
-            basePath: path,
-            nextIndex: Int(cookie)
-        )
+    func readEntries(cookie: WASIAbi.DirCookie) throws -> WASIReaddirEntries {
+        WASIReaddirEntries(
+            MemoryDirectoryIterator(
+                children: dirNode.listChildren(),
+                fileSystem: fileSystem,
+                basePath: path,
+                nextIndex: Int(cookie)
+            ))
     }
 
     func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat {

--- a/Sources/WASI/Platform/Directory.swift
+++ b/Sources/WASI/Platform/Directory.swift
@@ -152,7 +152,7 @@ extension DirEntry: WASIDir, FdWASIEntry {
         }
     }
 
-    struct ReadEntriesResult: WASIReaddirIterator {
+    struct HostDirectoryIterator: WASIReaddirIterator {
         let fd: FileDescriptor
         let stream: FileDescriptor.DirectoryStream
         var entryIndex: Int
@@ -205,8 +205,8 @@ extension DirEntry: WASIDir, FdWASIEntry {
     }
     func readEntries(
         cookie: WASIAbi.DirCookie
-    ) throws -> ReadEntriesResult {
-        return try ReadEntriesResult(fd: fd, cookie: cookie)
+    ) throws -> WASIReaddirEntries {
+        return WASIReaddirEntries(try HostDirectoryIterator(fd: fd, cookie: cookie))
     }
 
     func createDirectory(atPath path: String) throws {

--- a/Sources/WASI/WASI.swift
+++ b/Sources/WASI/WASI.swift
@@ -1144,8 +1144,8 @@ final class WASIImplementation: Sendable {
         cookie: WASIAbi.DirCookie,
         memory: M
     ) throws -> WASIAbi.Size {
-        func readDirectoryEntries<D: WASIDir>(
-            from dirEntry: D
+        func readDirectoryEntries(
+            from dirEntry: any WASIDir
         ) throws -> WASIAbi.Size {
             var entries = try dirEntry.readEntries(cookie: cookie)
             defer { entries.close() }

--- a/Tests/WASITests/CustomPlatformInjectionTests.swift
+++ b/Tests/WASITests/CustomPlatformInjectionTests.swift
@@ -147,7 +147,7 @@ struct CustomPlatformInjectionTests {
                 throw WASIAbi.Errno.EROFS
             }
 
-            struct ReadEntriesResult: WASIReaddirIterator {
+            struct FixedEntryIterator: WASIReaddirIterator {
                 var entries: [(WASIAbi.Dirent, String)]
                 var index = 0
                 mutating func next() -> Result<(dirent: WASIAbi.Dirent, name: String), any Error>? {
@@ -158,7 +158,7 @@ struct CustomPlatformInjectionTests {
                 mutating func close() {}
             }
 
-            func readEntries(cookie: WASIAbi.DirCookie) throws -> ReadEntriesResult {
+            func readEntries(cookie: WASIAbi.DirCookie) throws -> WASIReaddirEntries {
                 let entries = files.keys.sorted().enumerated().map { index, name in
                     (
                         WASIAbi.Dirent(
@@ -167,7 +167,7 @@ struct CustomPlatformInjectionTests {
                         name
                     )
                 }
-                return ReadEntriesResult(entries: Array(entries.dropFirst(Int(cookie))))
+                return WASIReaddirEntries(FixedEntryIterator(entries: Array(entries.dropFirst(Int(cookie)))))
             }
 
             func attributes(path: String, symlinkFollow: Bool) throws -> WASIAbi.Filestat {

--- a/Utilities/build-embedded.sh
+++ b/Utilities/build-embedded.sh
@@ -13,10 +13,15 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD="${ROOT}/.build/embedded-check"
 mkdir -p "$BUILD"
 
+# `-function-sections` is what lets `--gc-sections` drop code the firmware
+# never calls: without it swiftc emits one monolithic `.text` per module and
+# stripping becomes all-or-nothing. Embedded consumers are expected to build
+# this way, so the check does too.
 common=(
     -target "$TARGET"
     -enable-experimental-feature Embedded
     -wmo -parse-as-library -Osize
+    -Xfrontend -function-sections
     -package-name wasmkit
     -I "$BUILD"
 )
@@ -36,6 +41,8 @@ compile_module() {
 compile_module WasmTypes
 compile_module WasmParser
 compile_module WasmKit -Xcc "-I$ROOT/Sources/_CWasmKit/include"
+compile_module WASI
+compile_module WasmKitWASI -Xcc "-I$ROOT/Sources/_CWasmKit/include"
 compile_module GDBRemoteProtocol
 
-echo "OK: WasmKit compiles for $TARGET with Embedded Swift"
+echo "OK: WasmKit and WASI compile for $TARGET with Embedded Swift"


### PR DESCRIPTION
Compile `WASI` and `WasmKitWASI` in `build-embedded.sh` so embedded support stays
working. `WasmKitWASI` matters on its own: generic specialization happens at the
use site, so `WASI` can compile cleanly in isolation while still failing where it
is actually used.

Build with `-Xfrontend -function-sections` here and in the ESP32 example.
`swiftc` otherwise emits one `.text` section per module, and `--gc-sections`
strips whole sections, so the selective linking added earlier in this stack would
not have removed anything from the image. Objects grow by roughly a quarter
before linking, which the linker then reclaims.

Flag forms that do not work, for the record: `-Xllvm -function-sections` is
accepted but has no effect, and `-Xfrontend -data-sections` is not a valid
argument, so `.rodata` stays coarse.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #404 Decouple WASIFile from GuestMemory
1. #406 Make the WASI host module table generic over guest memory
1. #407 Allow linking a subset of the WASI preview1 surface
1. #408 Decouple WASIDir from its associated iterator type
1. #409 Cover WASI in the embedded check and strip unused code **← this PR**
1. #410 Run a WASI guest on emulated hardware in the ESP32 example

#401, #402 and #403 were the first three layers and are merged.

One more branch continues this locally: running the GDB stub on emulated
hardware and driving it with a real lldb. It will be opened once these land.

Unrelated but worth landing first: #405 fixes a debugger crash that makes
`CLICommandsTests` fail intermittently on Linux. It is the cause of the red
runs these PRs will otherwise keep hitting.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
