### PR TITLE
Run a WASI guest on emulated hardware in the ESP32 example

### DIFF
--- a/Examples/embedded-esp32/README.md
+++ b/Examples/embedded-esp32/README.md
@@ -57,6 +57,27 @@ idf.py -B build.c6 -D SDKCONFIG=sdkconfig.c6 -p /dev/cu.usbmodem* flash monitor
   Unnamed capabilities stay unreferenced and are stripped. Functions the guest
   imports but no linked capability provides are registered as `ENOSYS` stubs,
   so the module still instantiates -- pass `stubUnlinked: false` to opt out.
+
+  Measured on this example (esp32c6, `-Osize`), linking `[.stdio, .process]`
+  against the whole surface:
+
+  | Firmware | `.bin` size |
+  | --- | --- |
+  | `[.stdio, .process]` | 672,528 B |
+  | `WASICapability.all` | 699,648 B |
+
+  27 KB smaller. The saving is real stripping, not accounting: the
+  `WASIImplementation.path_open` symbol is absent from the subset image
+  entirely, and only the `PATH_OPEN` rights constant remains. Rebuild the
+  comparison with:
+
+  ```sh
+  WASMKIT_EXAMPLE_SWIFT_FLAGS=-DWASMKIT_LINK_ALL_WASI ./smoke-test.sh
+  ```
+- The guest's linear memory and each engine's value stack are separate
+  allocations, and a failed allocation faults rather than throwing. Budget
+  them together: this example runs a second engine with a 16 KiB stack
+  alongside the 64 KiB one.
 - The QEMU run uses the ESP32-C3 machine because Espressif's QEMU has no
   ESP32-C6 model; both chips are RV32IMC-class cores running the same code
   paths.

--- a/Examples/embedded-esp32/components/wasi/CMakeLists.txt
+++ b/Examples/embedded-esp32/components/wasi/CMakeLists.txt
@@ -1,0 +1,26 @@
+if(DEFINED ENV{WASMKIT_ROOT})
+    set(WASMKIT_ROOT $ENV{WASMKIT_ROOT})
+else()
+    get_filename_component(WASMKIT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+endif()
+if(WIN32)
+  set(devnull NUL)
+else()
+  set(devnull /dev/null)
+endif()
+idf_component_register(SRCS ${devnull} PRIV_REQUIRES idf_swift wasmtypes)
+
+file(GLOB_RECURSE wasi_srcs ${WASMKIT_ROOT}/Sources/WASI/*.swift)
+idf_component_register_swift(
+    ${COMPONENT_LIB}
+    BRIDGING_HEADER ${CMAKE_CURRENT_LIST_DIR}/Empty.h
+    SRCS ${wasi_srcs}
+)
+set_target_properties(${COMPONENT_LIB} PROPERTIES
+    Swift_MODULE_NAME WASI
+    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift-modules
+)
+# See the wasmtypes component for why -function-sections is required here.
+target_compile_options(${COMPONENT_LIB} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -Xfrontend -function-sections -package-name wasmkit>")
+add_dependencies(${COMPONENT_LIB} __idf_wasmtypes)

--- a/Examples/embedded-esp32/components/wasi/Empty.h
+++ b/Examples/embedded-esp32/components/wasi/Empty.h
@@ -1,0 +1,1 @@
+// Intentionally empty bridging header.

--- a/Examples/embedded-esp32/components/wasmkitwasi/CMakeLists.txt
+++ b/Examples/embedded-esp32/components/wasmkitwasi/CMakeLists.txt
@@ -1,0 +1,26 @@
+if(DEFINED ENV{WASMKIT_ROOT})
+    set(WASMKIT_ROOT $ENV{WASMKIT_ROOT})
+else()
+    get_filename_component(WASMKIT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+endif()
+if(WIN32)
+  set(devnull NUL)
+else()
+  set(devnull /dev/null)
+endif()
+idf_component_register(SRCS ${devnull} PRIV_REQUIRES idf_swift wasmtypes wasmparser cwasmkit wasmkit wasi)
+
+file(GLOB_RECURSE wasmkitwasi_srcs ${WASMKIT_ROOT}/Sources/WasmKitWASI/*.swift)
+idf_component_register_swift(
+    ${COMPONENT_LIB}
+    BRIDGING_HEADER ${CMAKE_CURRENT_LIST_DIR}/Empty.h
+    SRCS ${wasmkitwasi_srcs}
+)
+set_target_properties(${COMPONENT_LIB} PROPERTIES
+    Swift_MODULE_NAME WasmKitWASI
+    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift-modules
+)
+# See the wasmtypes component for why -function-sections is required here.
+target_compile_options(${COMPONENT_LIB} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -Xcc -I${WASMKIT_ROOT}/Sources/_CWasmKit/include -Xfrontend -function-sections -package-name wasmkit>")
+add_dependencies(${COMPONENT_LIB} __idf_wasmtypes __idf_wasmparser __idf_wasmkit __idf_wasi)

--- a/Examples/embedded-esp32/components/wasmkitwasi/Empty.h
+++ b/Examples/embedded-esp32/components/wasmkitwasi/Empty.h
@@ -1,0 +1,1 @@
+// Intentionally empty bridging header.

--- a/Examples/embedded-esp32/main/CMakeLists.txt
+++ b/Examples/embedded-esp32/main/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 idf_component_register(
     SRCS ${devnull}
     PRIV_INCLUDE_DIRS "."
-    PRIV_REQUIRES idf_swift wasmkit
+    PRIV_REQUIRES idf_swift wasmkit wasi wasmkitwasi
 )
 
 idf_component_register_swift(
@@ -15,8 +15,8 @@ idf_component_register_swift(
     SRCS Main.swift
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules>")
-add_dependencies(${COMPONENT_LIB} __idf_wasmkit)
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-I ${CMAKE_BINARY_DIR}/swift-modules -Xfrontend -function-sections $ENV{WASMKIT_EXAMPLE_SWIFT_FLAGS}>")
+add_dependencies(${COMPONENT_LIB} __idf_wasmkit __idf_wasi __idf_wasmkitwasi)
 
 # String hashing/comparison in embedded Swift needs the Unicode data tables.
 if(DEFINED ENV{SWIFT_EMBEDDED_LIB_DIR})

--- a/Examples/embedded-esp32/main/Main.swift
+++ b/Examples/embedded-esp32/main/Main.swift
@@ -1,4 +1,6 @@
+@_spi(WASIPlatform) import WASI
 import WasmKit
+import WasmKitWASI
 
 // (module
 //   (import "host" "mul" (func $mul (param i32 i32) (result i32)))
@@ -30,6 +32,121 @@ let demoWasm: [UInt8] = [
 /// rethrow it with its identity intact.
 struct DemoHostError: Error {
     let code: UInt32
+}
+
+
+/// The WASI guest: writes a string to fd 1 via `fd_write`.
+///
+/// (module
+///   (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+///   (memory (export "memory") 1)
+///   (data (i32.const 64) "WASI guest says hello\n")
+///   (func (export "_start") ... ))
+let wasiGuestWasm: [UInt8] = [
+    0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0C, 0x02, 0x60,
+    0x04, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x7F, 0x60, 0x00, 0x00, 0x02, 0x23,
+    0x01, 0x16, 0x77, 0x61, 0x73, 0x69, 0x5F, 0x73, 0x6E, 0x61, 0x70, 0x73,
+    0x68, 0x6F, 0x74, 0x5F, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31,
+    0x08, 0x66, 0x64, 0x5F, 0x77, 0x72, 0x69, 0x74, 0x65, 0x00, 0x00, 0x03,
+    0x02, 0x01, 0x01, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x13, 0x02, 0x06,
+    0x6D, 0x65, 0x6D, 0x6F, 0x72, 0x79, 0x02, 0x00, 0x06, 0x5F, 0x73, 0x74,
+    0x61, 0x72, 0x74, 0x00, 0x01, 0x0A, 0x1E, 0x01, 0x1C, 0x00, 0x41, 0x00,
+    0x41, 0xC0, 0x00, 0x36, 0x02, 0x00, 0x41, 0x04, 0x41, 0x16, 0x36, 0x02,
+    0x00, 0x41, 0x01, 0x41, 0x00, 0x41, 0x01, 0x41, 0x08, 0x10, 0x00, 0x1A,
+    0x0B, 0x0B, 0x1D, 0x01, 0x00, 0x41, 0xC0, 0x00, 0x0B, 0x16, 0x57, 0x41,
+    0x53, 0x49, 0x20, 0x67, 0x75, 0x65, 0x73, 0x74, 0x20, 0x73, 0x61, 0x79,
+    0x73, 0x20, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x0A, 0x00, 0x12, 0x04, 0x6E,
+    0x61, 0x6D, 0x65, 0x01, 0x0B, 0x01, 0x00, 0x08, 0x66, 0x64, 0x5F, 0x77,
+    0x72, 0x69, 0x74, 0x65,
+]
+
+/// Routes a WASI stream onto the ESP-IDF console.
+///
+/// Bare-metal targets have no host file descriptors, so stdio is injected as a
+/// `WASIFile` instead. This is the seam an embedded consumer uses to point WASI
+/// at a UART.
+struct ConsoleFile: WASIFile {
+    var isBorrowed: Bool { true }
+
+    func attributes() throws -> WASIAbi.Filestat {
+        WASIAbi.Filestat(
+            dev: 0, ino: 0, filetype: .CHARACTER_DEVICE,
+            nlink: 0, size: 0, atim: 0, mtim: 0, ctim: 0)
+    }
+    func fileType() throws -> WASIAbi.FileType { .CHARACTER_DEVICE }
+    func status() throws -> WASIAbi.Fdflags { [] }
+    func setTimes(atim: WASIAbi.Timestamp, mtim: WASIAbi.Timestamp, fstFlags: WASIAbi.FstFlags) throws {}
+    func advise(offset: WASIAbi.FileSize, length: WASIAbi.FileSize, advice: WASIAbi.Advice) throws {}
+    func close() throws {}
+
+    func fdStat() throws -> WASIAbi.FdStat {
+        WASIAbi.FdStat(
+            fsFileType: .CHARACTER_DEVICE, fsFlags: [],
+            fsRightsBase: [.FD_WRITE], fsRightsInheriting: [])
+    }
+    func setFdStatFlags(_ flags: WASIAbi.Fdflags) throws {}
+    func setFilestatSize(_ size: WASIAbi.FileSize) throws {}
+    func sync() throws {}
+    func datasync() throws {}
+    func tell() throws -> WASIAbi.FileSize { 0 }
+    func seek(offset: WASIAbi.FileDelta, whence: WASIAbi.Whence) throws -> WASIAbi.FileSize {
+        throw WASIAbi.Errno.ESPIPE
+    }
+
+    func write(vectored buffers: GuestBuffers) throws -> WASIAbi.Size {
+        var total: WASIAbi.Size = 0
+        for index in 0..<buffers.count {
+            try buffers.withHostBuffer(at: index) { bytes in
+                var line = ""
+                for byte in bytes.bindMemory(to: UInt8.self) where byte != 0x0A {
+                    line.append(Character(UnicodeScalar(byte)))
+                }
+                print(line)
+                total += WASIAbi.Size(bytes.count)
+                return bytes.count
+            }
+        }
+        return total
+    }
+    func pwrite(vectored buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
+        throw WASIAbi.Errno.ESPIPE
+    }
+    func read(into buffers: GuestBuffers) throws -> WASIAbi.Size { 0 }
+    func pread(into buffers: GuestBuffers, offset: WASIAbi.FileSize) throws -> WASIAbi.Size {
+        throw WASIAbi.Errno.ESPIPE
+    }
+}
+
+/// Runs the WASI guest, linking only the capabilities it needs.
+///
+/// Set WASMKIT_LINK_ALL_WASI to link the whole preview1 surface instead, which
+/// is how the size difference between the two is measured.
+func runWASIGuest() throws {
+    // A second engine runs alongside the demo one above, and the guest's linear
+    // memory costs another 64 KiB, so keep this VM stack small: the C3 has only
+    // a few hundred KiB of DRAM and a failed allocation faults rather than
+    // throwing.
+    var configuration = EngineConfiguration()
+    configuration.stackSize = 16 * 1024
+    let store = Store(engine: Engine(configuration: configuration))
+    let bridge = try WASIBridgeToHost(
+        fileSystem: .memory(MemoryFileSystem())
+            .withStdio(stdin: ConsoleFile(), stdout: ConsoleFile(), stderr: ConsoleFile()))
+
+    // runAndClose closes the bridge even when the body throws; the bridge
+    // traps in deinit if it was never closed.
+    try bridge.runAndClose { bridge in
+        var imports = Imports()
+        #if WASMKIT_LINK_ALL_WASI
+            bridge.link(to: &imports, store: store, capabilities: WasmKitWASI.WASICapability.all)
+        #else
+            bridge.link(to: &imports, store: store, capabilities: [.stdio, .process])
+        #endif
+
+        let module = try parseWasm(bytes: wasiGuestWasm)
+        let instance = try module.instantiate(store: store, imports: imports)
+        _ = try bridge.start(instance)
+    }
 }
 
 @_cdecl("app_main")
@@ -77,6 +194,19 @@ func app_main() {
             _ = try callBoom()
         } catch let error as DemoHostError {
             print("host error \(error.code)")
+        }
+
+        // WASI guest, linked with only the capabilities it uses.
+        do {
+            try runWASIGuest()
+        } catch let error as WASIAbi.Errno {
+            print("wasi errno \(error.rawValue)")
+        } catch let error as WASIError {
+            print("wasi host error: \(error.description)")
+        } catch let error as WasmKitError {
+            print("wasmkit error: \(error.description)")
+        } catch {
+            print("wasi error (unknown type)")
         }
     } catch {
         print("wasm error")

--- a/Examples/embedded-esp32/smoke-test.sh
+++ b/Examples/embedded-esp32/smoke-test.sh
@@ -3,8 +3,9 @@
 #
 # Builds this example for ESP32-C6 and, with --qemu, also builds it for
 # ESP32-C3 and boots it in Espressif's QEMU, checking that the guest wasm
-# module actually executes ("2 + 3 = 5" on the serial console; QEMU has no
-# ESP32-C6 machine, hence the C3 run).
+# module actually executes ("2 + 3 = 5" on the serial console) and that a WASI
+# guest reaches the console through fd_write ("WASI guest says hello"). QEMU has
+# no ESP32-C6 machine, hence the C3 run.
 #
 # Requirements:
 #   - ESP-IDF v5.5+ installed and its tools provisioned (`install.sh esp32c6`).
@@ -147,7 +148,11 @@ echo "----------------------"
 if [ $result -eq 0 ]; then
     grep -q '2 + 3 = 5' "$qemu_out" && grep -q '7 \* 3 = 21' "$qemu_out" \
         || die "smoke test FAILED: incomplete output (see $qemu_out)"
-    log "SMOKE TEST PASSED: wasm + host functions executed on emulated ESP32"
+    # Compiling WASI is not the same as running it: this catches link-time and
+    # runtime failures that a compile-only check cannot see.
+    grep -q 'WASI guest says hello' "$qemu_out" \
+        || die "smoke test FAILED: WASI guest did not reach the console (see $qemu_out)"
+    log "SMOKE TEST PASSED: wasm, host functions and a WASI guest ran on emulated ESP32"
 else
     die "smoke test FAILED: expected '2 + 3 = 5' in serial output (see $qemu_out)"
 fi

--- a/Sources/WASI/RandomBufferGenerator.swift
+++ b/Sources/WASI/RandomBufferGenerator.swift
@@ -44,7 +44,19 @@ extension RandomBufferGenerator where Self: RandomNumberGenerator {
 extension SystemRandomNumberGenerator: RandomBufferGenerator {
     public mutating func fill(buffer: UnsafeMutableBufferPointer<UInt8>) {
         guard let baseAddress = buffer.baseAddress else { return }
-        // Directly call underlying C function of SystemRandomNumberGenerator
-        swift_stdlib_random(baseAddress, Int(buffer.count))
+        #if $Embedded
+            // Bare-metal targets have no `swift_stdlib_random`, and
+            // `SystemRandomNumberGenerator.next()` bottoms out in the same
+            // symbol, so there is nothing to fall back to. Refuse loudly rather
+            // than hand a guest predictable bytes it believes are random.
+            //
+            // This is only reached if a guest actually calls `random_get`
+            // without a generator having been injected; supply one backed by
+            // the SoC's hardware RNG via `WASIBridgeToHost.init`.
+            fatalError("WASI: no system entropy source on this platform; inject a RandomBufferGenerator")
+        #else
+            // Directly call underlying C function of SystemRandomNumberGenerator
+            swift_stdlib_random(baseAddress, Int(buffer.count))
+        #endif
     }
 }

--- a/Tests/WASITests/WASICapabilityIntegrationTests.swift
+++ b/Tests/WASITests/WASICapabilityIntegrationTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+import WasmKit
+import WasmKitWASI
+
+// The guests come from `Vendor/wasi-testsuite`, which the Android job does not
+// check out: it runs the suite on an emulator without the repository tree.
+// `IntegrationTests` skips itself on Android for the same reason.
+#if !os(Android)
+
+    /// End-to-end checks that selective linking actually runs real guests, and --
+    /// just as importantly -- that leaving a capability out is observable. A
+    /// subset that silently behaved like a full link would pass every functional
+    /// test while defeating the entire point of the API.
+    @Suite struct WASICapabilityIntegrationTests {
+        /// Imports exactly environ_get, environ_sizes_get, fd_write and proc_exit,
+        /// so it spans `.environment`, `.stdio` and `.process`.
+        static let environGuest = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent(
+                "Vendor/wasi-testsuite/tests/assemblyscript/testsuite/environ_get-multiple-variables.wasm")
+
+        private static let environment = ["a": "text", "b": "escap \" ing", "c": "new\nline"]
+
+        private func run(
+            _ path: URL,
+            capabilities: [WASICapability],
+            stubUnlinked: Bool = true
+        ) throws -> UInt32 {
+            let wasi = try WASIBridgeToHost(
+                args: [path.path],
+                environment: Self.environment,
+                fileSystem: .host().withStdio()
+            )
+            return try wasi.runAndClose { wasi in
+                let store = Store(engine: Engine())
+                var imports = Imports()
+                wasi.link(to: &imports, store: store, capabilities: capabilities, stubUnlinked: stubUnlinked)
+                let module = try parseWasm(filePath: path.path)
+                let instance = try module.instantiate(store: store, imports: imports)
+                return try wasi.start(instance)
+            }
+        }
+
+        @Test func aSubsetCoveringTheGuestRunsIt() throws {
+            let exitCode = try run(Self.environGuest, capabilities: [.environment, .stdio, .process])
+            #expect(exitCode == 0)
+        }
+
+        @Test func theSameGuestStillRunsUnderAFullLink() throws {
+            let exitCode = try run(Self.environGuest, capabilities: WASICapability.all)
+            #expect(exitCode == 0)
+        }
+
+        /// The load-bearing negative: dropping `.environment` must actually change
+        /// behaviour. If this passes with exit code 0, capabilities are not
+        /// restricting anything.
+        @Test func omittingANeededCapabilityIsObservable() throws {
+            // Guard against a vacuous pass: this must fail for want of
+            // .environment, not because the fixture moved.
+            #expect(FileManager.default.fileExists(atPath: Self.environGuest.path))
+
+            let outcome = Result {
+                try run(Self.environGuest, capabilities: [.stdio, .process])
+            }
+            switch outcome {
+            case .success(let exitCode):
+                // environ_get is stubbed to ENOSYS, so the guest cannot succeed.
+                #expect(exitCode != 0, "the guest should not succeed without .environment")
+            case .failure:
+                break  // trapping is an equally valid observation
+            }
+        }
+
+        /// Guests import a fixed list regardless of what they call, so stubbing is
+        /// what makes a subset usable at all.
+        @Test func stubbingSatisfiesImportsNoCapabilityProvides() throws {
+            let store = Store(engine: Engine())
+            let wasi = try WASIBridgeToHost(fileSystem: .host().withStdio())
+            try wasi.runAndClose { wasi in
+                var imports = Imports()
+                wasi.link(to: &imports, store: store, capabilities: [.stdio], stubUnlinked: true)
+                let module = try parseWasm(filePath: Self.environGuest.path)
+                // environ_get/environ_sizes_get come from stubs, not .stdio.
+                _ = try module.instantiate(store: store, imports: imports)
+            }
+        }
+
+        @Test func withoutStubbingAnUnprovidedImportFailsToInstantiate() throws {
+            let store = Store(engine: Engine())
+            let wasi = try WASIBridgeToHost(fileSystem: .host().withStdio())
+            try wasi.runAndClose { wasi in
+                var imports = Imports()
+                wasi.link(to: &imports, store: store, capabilities: [.stdio], stubUnlinked: false)
+                let module = try parseWasm(filePath: Self.environGuest.path)
+                #expect(throws: (any Error).self) {
+                    _ = try module.instantiate(store: store, imports: imports)
+                }
+            }
+        }
+    }
+
+#endif


### PR DESCRIPTION
Compiling WASI for the target says nothing about linking or running it. Two
failures were invisible to the compile-only check:

`SystemRandomNumberGenerator`'s conformance calls `swift_stdlib_random`, which
does not exist on bare metal, and it is the default argument for every
`WASIBridgeToHost` initialiser. Linking WASI into firmware failed with an
undefined reference even though no guest called `random_get`. It now traps on
Embedded instead. `next()` bottoms out in the same symbol, so there is no
fallback, and handing a guest predictable bytes it believes are random would be
worse than refusing. Callers inject a generator backed by the SoC's hardware RNG.

The 32-bit page-limit bug at the base of this stack only failed at
instantiation.

Add `WASI` and `WasmKitWASI` as ESP-IDF components and run a guest that writes
through `fd_write` to a console-backed `WASIFile`, asserted in the QEMU smoke
test.

Measured on esp32c6 with `-Osize`, linking `[.stdio, .process]` against the whole
surface:

| Firmware | `.bin` size |
| --- | --- |
| `[.stdio, .process]` | 672,528 B |
| `WASICapability.all` | 699,648 B |

The `WASIImplementation.path_open` symbol is absent from the subset image
entirely; only the `PATH_OPEN` rights constant remains.

Host integration tests cover selective linking, including the case where omitting
a needed capability must change behaviour. Without that one, a subset that
silently behaved like a full link would pass every other test.

## Stack

Reviewable in order; each PR targets the one above it. Merge bottom-up.

1. #404 Decouple WASIFile from GuestMemory
1. #406 Make the WASI host module table generic over guest memory
1. #407 Allow linking a subset of the WASI preview1 surface
1. #408 Decouple WASIDir from its associated iterator type
1. #409 Cover WASI in the embedded check and strip unused code
1. #410 Run a WASI guest on emulated hardware in the ESP32 example **← this PR**

#401, #402 and #403 were the first three layers and are merged.

One more branch continues this locally: running the GDB stub on emulated
hardware and driving it with a real lldb. It will be opened once these land.

Unrelated but worth landing first: #405 fixes a debugger crash that makes
`CLICommandsTests` fail intermittently on Linux. It is the cause of the red
runs these PRs will otherwise keep hitting.

GitHub's native stacked PRs are not yet available for this repository, so the
chain is expressed through base branches instead.
