### PR TITLE
Materialize stack-live constants on block entry

### DIFF
--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -1031,6 +1031,16 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         return copied
     }
 
+    /// Emit copy instructions to ensure local and constant values on the logical
+    /// stack are on the physical stack.
+    ///
+    /// > Important: This permanently rewrites the affected value-stack entries to
+    /// > ``MetaValueOnStack/stack(_:)``, so every later reference to them reads the
+    /// > physical slot. The copies emitted here must therefore dominate the rest of
+    /// > the block, which is why block-like constructs preserve the *whole* stack on
+    /// > entry rather than just their parameters: a branch nested inside the block
+    /// > would otherwise materialize an enclosing frame's value on its own path only,
+    /// > leaving the slot undefined on the paths that skip it.
     private mutating func preserveOnStack(depth: Int) {
         preserveLocalsOnStack(depth: depth)
         for (source, dest, type) in valueStack.preserveConstsOnStack(depth: depth) {
@@ -1330,7 +1340,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
     mutating func visitBlock(blockType: WasmParser.BlockType) throws(WasmKitError) -> Output {
         let blockType = try module.resolveBlockType(blockType)
         let endLabel = iseqBuilder.allocLabel()
-        self.preserveLocalsOnStack(depth: self.valueStack.valueHeight)
+        self.preserveOnStack(depth: self.valueStack.valueHeight)
         let stackHeight = try popPushValues(blockType.parameters)
         controlStack.pushFrame(
             ControlStack.ControlFrame(
@@ -1345,7 +1355,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
 
     mutating func visitLoop(blockType: WasmParser.BlockType) throws(WasmKitError) -> Output {
         let blockType = try module.resolveBlockType(blockType)
-        preserveOnStack(depth: blockType.parameters.count)
+        preserveOnStack(depth: self.valueStack.valueHeight)
         iseqBuilder.resetLastEmission()
         for param in blockType.parameters.reversed() {
             _ = try popOperand(param)
@@ -1370,8 +1380,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         // Pop condition value
         let condition = try popVRegOperand(.i32)
         let blockType = try module.resolveBlockType(blockType)
-        self.preserveLocalsOnStack(depth: self.valueStack.valueHeight)
-        preserveOnStack(depth: blockType.parameters.count)
+        self.preserveOnStack(depth: self.valueStack.valueHeight)
         let endLabel = iseqBuilder.allocLabel()
         let elseLabel = iseqBuilder.allocLabel()
         for param in blockType.parameters.reversed() {
@@ -1879,7 +1888,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         let blockType = try module.resolveBlockType(blockType)
         let endLabel = iseqBuilder.allocLabel()
 
-        self.preserveLocalsOnStack(depth: self.valueStack.valueHeight)
+        self.preserveOnStack(depth: self.valueStack.valueHeight)
         let stackHeight = try popPushValues(blockType.parameters)
 
         let catchCount = UInt16(tryCatch.catches.count)

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -547,6 +547,13 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             return copies
         }
 
+        /// Whether the value at `index` already lives in its physical slot,
+        /// rather than being a reference to a local or a constant slot.
+        func isMaterialized(at index: Int) -> Bool {
+            guard case .stack = values[index] else { return false }
+            return true
+        }
+
         func peek(depth: Int) -> ValueSource {
             return makeValueSource(valueIndexFromTop: depth)
         }
@@ -1031,6 +1038,34 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         return copied
     }
 
+    /// Check that materializing the top `depth` values does not reach into an
+    /// enclosing control frame.
+    ///
+    /// Materialization rewrites the value-stack entry to
+    /// ``MetaValueOnStack/stack(_:)`` for the rest of translation, but emits its
+    /// copy at the current position. That is only sound when the copy dominates
+    /// every later read, which holds within the innermost frame -- straight-line
+    /// code since the frame was entered -- but not for values belonging to an
+    /// enclosing frame: a path that skips this point would leave the slot
+    /// undefined while translation assumes it holds the value. Block-like
+    /// constructs therefore materialize their whole stack on entry, and this
+    /// check catches any site that reintroduces the hazard.
+    private func assertPreservationStaysInCurrentFrame(depth: Int, caller: StaticString = #function) {
+        #if DEBUG
+            guard let frame = try? controlStack.currentFrame() else { return }
+            for offset in 0..<Swift.min(depth, valueStack.valueHeight) {
+                let index = valueStack.valueHeight - 1 - offset
+                guard index < frame.valueStackHeight else { continue }
+                assert(
+                    valueStack.isMaterialized(at: index),
+                    "[\(caller)] value at stack index \(index) belongs to an enclosing"
+                        + " control frame (which starts at \(frame.valueStackHeight)); its"
+                        + " copy would not dominate all later reads of the slot"
+                )
+            }
+        #endif
+    }
+
     /// Emit copy instructions to ensure local and constant values on the logical
     /// stack are on the physical stack.
     ///
@@ -1041,7 +1076,8 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
     /// > entry rather than just their parameters: a branch nested inside the block
     /// > would otherwise materialize an enclosing frame's value on its own path only,
     /// > leaving the slot undefined on the paths that skip it.
-    private mutating func preserveOnStack(depth: Int) {
+    private mutating func preserveOnStack(depth: Int, site: StaticString = #function) {
+        assertPreservationStaysInCurrentFrame(depth: depth, caller: site)
         preserveLocalsOnStack(depth: depth)
         for (source, dest, type) in valueStack.preserveConstsOnStack(depth: depth) {
             emitCopyValueSlots(type, from: source, to: dest)
@@ -1049,6 +1085,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
     }
 
     private mutating func preserveLocalsOnStack(_ localIndex: LocalIndex) {
+        assertPreservationStaysInCurrentFrame(depth: valueStack.valueHeight)
         for (copyTo, type) in valueStack.preserveLocalsOnStack(localIndex) {
             emitCopyValueSlots(type, from: localReg(localIndex), to: copyTo)
         }

--- a/Tests/WasmKitTests/ExtraSuite/const_slot.wast
+++ b/Tests/WasmKitTests/ExtraSuite/const_slot.wast
@@ -25,3 +25,69 @@
 (assert_return (invoke "check-limit" (i32.const 3)) (i32.const 5))
 (assert_return (invoke "invalidate-relink") (i32.const 0))
 
+
+;; A constant left on the value stack across a block-like construct is
+;; materialized into a stack slot on demand. The copy has to dominate every
+;; later read of that slot: a branch nested in the block would otherwise
+;; materialize it on its own path only, leaving the slot undefined on the paths
+;; that skip the branch. Each function below dirties the target slot first so a
+;; missing copy is observable.
+
+(module
+  (func (export "const-across-block") (param i32) (result i32)
+    (drop (i32.add (local.get 0) (i32.const 200)))
+    i32.const 42
+    block
+      ;; Leaves the block before the branch below when the parameter is non-zero.
+      local.get 0
+      br_if 0
+      ;; Branching out of the function spans the constant sitting below this
+      ;; frame. Never taken.
+      i32.const 7
+      i32.const 0
+      br_if 1
+      drop
+    end
+  )
+)
+
+(assert_return (invoke "const-across-block" (i32.const 0)) (i32.const 42))
+(assert_return (invoke "const-across-block" (i32.const 1)) (i32.const 42))
+
+(module
+  (func (export "const-across-if") (param i32) (result i32)
+    (drop (i32.add (local.get 0) (i32.const 200)))
+    i32.const 42
+    local.get 0
+    if (result i32)
+      i32.const 7
+      i32.const 0
+      br_if 1
+    else
+      i32.const 2
+    end
+    drop
+  )
+)
+
+(assert_return (invoke "const-across-if" (i32.const 0)) (i32.const 42))
+(assert_return (invoke "const-across-if" (i32.const 1)) (i32.const 42))
+
+(module
+  (func (export "const-across-loop") (param i32) (result i32)
+    (drop (i32.add (local.get 0) (i32.const 200)))
+    i32.const 42
+    loop
+      local.get 0
+      if
+        i32.const 7
+        i32.const 0
+        br_if 2
+        drop
+      end
+    end
+  )
+)
+
+(assert_return (invoke "const-across-loop" (i32.const 0)) (i32.const 42))
+(assert_return (invoke "const-across-loop" (i32.const 1)) (i32.const 42))


### PR DESCRIPTION
Fixes #229.

`wasm-opt` output routinely leaves an `i32.const` on the operand stack across a
whole block. WasmKit keeps such constants virtual, as a reference to a
constant-pool slot, and copies one into its physical stack slot only when
something needs it there. `preserveOnStack(depth:)` performs that copy, and it
also rewrites the value-stack entry to `.stack` for the remainder of
translation, so every later read of that value goes to the slot.

`visitBlock`, `visitIf` and `visitLoop` preserved only the block's parameters,
which left a constant sitting below the block still virtual. The first branch
inside the block that targeted an outer label then materialized it, since that
branch's preserve depth spans everything down to the target frame. The copy
landed inside the block body. Any path that skipped the body, such as the `if`'s
own entry test, left the slot undefined while translation assumed it held the
constant.

The same hazard was already handled for locals, whose sites call
`preserveLocalsOnStack(depth: valueStack.valueHeight)`. This restores the
symmetry for constants and gives `visitLoop` the locals preservation it was also
missing.

## Effect

zeroperl, a Perl build that uses Binaryen Asyncify for `setjmp`/`longjmp`, spun
forever printing `Attempt to free unreferenced scalar`. It now runs to
completion. The corrupted value was a `0` that one function should have
returned; it returned a stale slot, and Perl unwound into garbage.

LLVM never emits this shape, so ordinary builds are unaffected. It takes
wasm-opt's optimizer, which parks values on the operand stack across blocks, and
asyncify, which multiplies the branches that reach past them.

I found it by differential trace against wasmi. Both engines agreed for 682 call
events through the entire unwind and rewind cycle, with byte-identical memory,
identical call arguments and `__asyncify_state == 0`, then took different
branches inside one function.

## Tests

`Tests/WasmKitTests/ExtraSuite/const_slot.wast` gains `const-across-block`,
`const-across-if` and `const-across-loop`. Each parks a constant across the
construct, dirties the target slot beforehand so a missing copy is observable,
and puts a never-taken branch out of the function inside. Without the fix all
three return the dirtying value (201, 200, 200) rather than 42, on both
threading models.

All 374 tests pass. So do 328 asyncify-optimized `wasm-smith` modules run
through the debug build described below, with no spurious assertion failures.

## Debug invariant

The second commit adds a `DEBUG`-only assertion: materialization must not reach
below the innermost control frame. Block entry dominates everything after it, so
preserving there is sound. A branch site does not, so reaching past the frame is
the bug.

This is about coverage. ClusterFuzzLite builds only `FuzzTranslator`, which
discards results and reports crashes, so a wrong return value is invisible to
it. `FuzzDifferential`, the one target that compares values against Wasmtime, is
not wired into CI. Generation would not have rescued us either: 2000 raw
`wasm-smith` modules, 337 through `wasm-opt -O` and 2495 through `--asyncify -O`
produced no behavioural difference between fixed and unfixed builds. Since
`fuzzInstantiation` compiles eagerly, the assertion instead trips right where
the bad code is emitted.

Giving `FuzzDifferential` a CI job is worth doing too, but belongs in its own
change.
