### PR TITLE
Accept an empty value for an `--env` variable

### DIFF
--- a/Sources/CLICommands/Run.swift
+++ b/Sources/CLICommands/Run.swift
@@ -48,8 +48,8 @@ package struct Run: AsyncParsableCommand {
         let key: String
         let value: String
         init?(argument: String) {
-            var parts = argument.split(separator: "=", maxSplits: 1).makeIterator()
-            guard let key = parts.next(), let value = parts.next() else { return nil }
+            var parts = argument.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false).makeIterator()
+            guard let key = parts.next(), !key.isEmpty, let value = parts.next() else { return nil }
             self.key = String(key)
             self.value = String(value)
         }

--- a/Tests/CLICommandsTests/RunOptionsTests.swift
+++ b/Tests/CLICommandsTests/RunOptionsTests.swift
@@ -90,6 +90,18 @@ import WasmKitWASI
         let run = try Run.parse(["--env", "A=1", "--env", "A=2", "module.wasm"])
         #expect(run.deriveEnvironment() == ["A": "2"])
     }
+
+    @Test func environmentValueCanBeEmpty() throws {
+        let run = try Run.parse(["--env", "A=", "module.wasm"])
+        #expect(run.deriveEnvironment() == ["A": ""])
+    }
+
+    @Test func environmentKeyCannotBeEmpty() throws {
+        let error = #expect(throws: (any Error).self) {
+            _ = try Run.parse(["--env", "=value", "module.wasm"])
+        }
+        #expect(Run.exitCode(for: try #require(error)) == .validationFailure)
+    }
 }
 
 #if WasmDebuggingSupport


### PR DESCRIPTION
`EnvOption.init?` split on `=` with `omittingEmptySubsequences` left at its default of `true`, so `KEY=` collapsed to the single element `["KEY"]`, the second `parts.next()` returned nil, and the pair was rejected:

```
$ wasmkit run --env=DYLD_LIBRARY_PATH= module.wasm
Error: The value 'DYLD_LIBRARY_PATH=' is invalid for '--env <key=value>'
$ echo $?
64
```

`KEY=` is the ordinary spelling for "set KEY to the empty string". AFAIK WASI draws no distinction between an empty value and any other so there is no reason to refuse it. The motivator is LLDB's WebAssembly platform, which forwards the inferior's environment to the runtime one `--env=` argument at a time.

Pass `omittingEmptySubsequences: false` and reject an empty key explicitly, which keeps `=value` a usage error.