### PR TITLE
Demote debugger server lifecycle logs to trace

### DIFF
--- a/Sources/CLICommands/DebuggerServer.swift
+++ b/Sources/CLICommands/DebuggerServer.swift
@@ -33,7 +33,7 @@
 
             let listener = try TCPListener(host: self.host, port: self.port)
             defer { listener.close() }
-            logger.info("Debugger server listening on port \(port)")
+            logger.trace("Debugger server listening on port \(port)")
 
             // A GDB stub serves one client at a time: accept connections
             // sequentially until the client asks the target to shut down.
@@ -53,7 +53,7 @@
                         }
                     }
                 } catch WasmKitGDBHandler.Error.killRequestReceived {
-                    logger.info("Debugger shut down request received")
+                    logger.trace("Debugger shut down request received")
                     break serving
                 } catch {
                     logger.error("Error in GDB remote protocol connection: \(error)")


### PR DESCRIPTION
These two messages describe the stub's own lifecycle, not the guest's behavior, and they land on stderr next to the guest's WASI stderr. This mixes the stub's log output with the program's output.

This is a problem for LLDB when using WasmKit to run our test suite when targeting WebAssembly. It needs to match the inferior's output, unpolluted by log messages from the runtime.

Log at trace instead, where the rest of the debugger stack already logs, so a non-verbose run stays silent unless something actually fails. Alternatively, we could have a way to silence the engine. I considered making the verbose flag take a value or log level (e.g. `--verbose=0`) but went with this approach as the log messages are relatively low-value IMHO.