### PR TITLE
Stop leaking and losing breakpoints while stepping

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -46,8 +46,21 @@
         /// Threading model of the Wasm engine configuration, cached for a potentially hot path.
         private let threadingModel: EngineConfiguration.ThreadingModel
 
-        /// Mapping from a Wasm address of a breakpoint to a corresponding iseq code slot.
-        package private(set) var breakpoints = [Int: UInt64]()
+        /// Breakpoints currently present in the bytecode, keyed by resolved Wasm address. The value
+        /// carries both what to restore and where, so taking one down never has to resolve again.
+        private var armedBreakpoints = [Int: (iseq: Pc, originalHeadSlot: CodeSlot)]()
+
+        /// Resolved Wasm addresses the debugger host has asked for a breakpoint at. A breakpoint traps
+        /// *before* the instruction it replaced, so resuming means taking it out of the bytecode, which
+        /// the host's request outlives. That makes this a different fact from ``armedBreakpoints``.
+        private var hostBreakpoints = Set<Int>()
+
+        /// Resolved Wasm addresses armed to bound the single-instruction step in progress. Every
+        /// address execution can reach from the current one has to be armed, and all of them come
+        /// down again once the step lands, except where the host wants a breakpoint too.
+        private var stepBreakpoints = Set<Int>()
+
+        package var armedBreakpointAddresses: Set<Int> { Set(self.armedBreakpoints.keys) }
 
         package private(set) var state: State
 
@@ -157,6 +170,25 @@
             throw Error.noInstructionMappingAvailable(address)
         }
 
+        /// Puts a breakpoint into the bytecode at an already resolved Wasm address, preserving the
+        /// instruction it replaces. Idempotent, so that arming for one owner cannot record another
+        /// owner's breakpoint instruction as the original.
+        private mutating func arm(resolved: Int, iseq: Pc) {
+            guard self.armedBreakpoints[resolved] == nil else { return }
+
+            self.armedBreakpoints[resolved] = (iseq: iseq, originalHeadSlot: iseq.pointee)
+            iseq.pointee = Instruction.breakpoint.headSlot(threadingModel: self.threadingModel)
+        }
+
+        /// Takes the breakpoint at an already resolved Wasm address out of the bytecode, restoring
+        /// the instruction it replaced. Leaves ``hostBreakpoints`` and ``stepBreakpoints`` alone: it
+        /// is the bytecode half of a breakpoint, not the request for one.
+        private mutating func disarm(resolved: Int) {
+            guard let armed = self.armedBreakpoints.removeValue(forKey: resolved) else { return }
+
+            armed.iseq.pointee = armed.originalHeadSlot
+        }
+
         /// Enables a breakpoint at a given Wasm address.
         /// - Parameter address: byte offset of the Wasm instruction that will be replaced with a breakpoint. If no
         /// direct internal bytecode matching instruction is found, the next closest internal bytecode instruction
@@ -166,12 +198,8 @@
         @discardableResult
         package mutating func enableBreakpoint(address: Int) throws -> Int {
             let (iseq, wasm) = try self.findIseq(forWasmAddress: address)
-            guard self.breakpoints[wasm] == nil else {
-                return wasm
-            }
-
-            self.breakpoints[wasm] = iseq.pointee
-            iseq.pointee = Instruction.breakpoint.headSlot(threadingModel: self.threadingModel)
+            self.hostBreakpoints.insert(wasm)
+            self.arm(resolved: wasm, iseq: iseq)
             return wasm
         }
 
@@ -191,24 +219,34 @@
         package mutating func disableBreakpoint(address: Int) throws {
             // Resolve the same way enableBreakpoint does, so a breakpoint set
             // at an elided address is found under its resolved key.
-            let (iseq, wasm) = try self.findIseq(forWasmAddress: address)
-            guard let oldCodeSlot = self.breakpoints[wasm] else {
-                return
-            }
+            let (_, wasm) = try self.findIseq(forWasmAddress: address)
+            self.hostBreakpoints.remove(wasm)
+            guard !self.stepBreakpoints.contains(wasm) else { return }
 
-            self.breakpoints[wasm] = nil
-            iseq.pointee = oldCodeSlot
+            self.disarm(resolved: wasm)
         }
 
-        /// Resumes the module instantiated by the debugger stopped at a breakpoint. The breakpoint is disabled
-        /// and execution is resumed until the next breakpoint is triggered or all remaining instructions are
-        /// executed. If the module is not stopped at a breakpoint, this function returns immediately.
+        /// Forgets every breakpoint, so that execution can resume without the debugger observing it
+        /// again.
+        package mutating func removeAllBreakpoints() {
+            self.hostBreakpoints.removeAll()
+            self.stepBreakpoints.removeAll()
+            for armed in self.armedBreakpoints.values {
+                armed.iseq.pointee = armed.originalHeadSlot
+            }
+            self.armedBreakpoints.removeAll()
+        }
+
+        /// Resumes the module instantiated by the debugger stopped at a breakpoint. The lowest-level
+        /// resume: the breakpoint at the current program counter is taken out of the bytecode so that
+        /// execution can make progress, and it is not put back. Execution continues until the next
+        /// breakpoint is triggered or all remaining instructions are executed. If the module is not
+        /// stopped at a breakpoint, this function returns immediately.
         package mutating func run() throws {
             do {
                 switch self.state {
                 case .stoppedAtBreakpoint(let breakpoint):
-                    // Remove the breakpoint before resuming
-                    try self.disableBreakpoint(address: breakpoint.wasmPc)
+                    self.disarm(resolved: breakpoint.wasmPc)
                     self.execution.resetError()
 
                     let iseq = breakpoint.iseq
@@ -268,6 +306,8 @@
         /// Steps by a single Wasm instruction in the module instantiated by the debugger stopped at a breakpoint.
         /// The current breakpoint is disabled and new breakpoints are put on the next instruction (or instructions in case
         /// of multiple possible execution branches). After breakpoints setup, execution is resumed until suspension.
+        /// Every breakpoint the step needed comes down again once it lands, and the breakpoint it stepped off
+        /// goes back in, so a step leaves the host's breakpoints exactly as it found them.
         /// If the module is not stopped at a breakpoint, this function returns immediately.
         package mutating func step() throws {
             guard case .stoppedAtBreakpoint(let breakpoint) = self.state else {
@@ -276,19 +316,34 @@
 
             try self.setNextInstructionBreakpoints(breakpoint: breakpoint)
             try self.run()
+            self.clearStepBreakpoints()
+
+            // Execution has moved past the instruction the breakpoint replaced, so its slot can hold a
+            // breakpoint again.
+            if self.hostBreakpoints.contains(breakpoint.wasmPc) {
+                try self.enableBreakpoint(address: breakpoint.wasmPc)
+            }
         }
 
         /// Resumes the module instantiated by the debugger stopped at a breakpoint. The breakpoint from which
         /// the debugger resumes is preserved. If the module is current not stopped at a breakpoint, this function
         /// returns immediately.
         package mutating func runPreservingCurrentBreakpoint() throws {
-            guard case .stoppedAtBreakpoint(let breakpoint) = self.state else {
+            guard case .stoppedAtBreakpoint = self.state else {
                 return
             }
 
-            try self.setNextInstructionBreakpoints(breakpoint: breakpoint)
-            try self.run()
-            try self.enableBreakpoint(address: breakpoint.wasmPc)
+            // A bounded single step is what gets execution out of the slot the resumed-from breakpoint
+            // occupies, which is the precondition for putting that breakpoint back.
+            try self.step()
+
+            // Landing on a breakpoint the host set is a stop the host is waiting for.
+            guard case .stoppedAtBreakpoint(let landed) = self.state,
+                !self.hostBreakpoints.contains(landed.wasmPc)
+            else {
+                return
+            }
+
             try self.run()
         }
 
@@ -378,13 +433,31 @@
             return result
         }
 
+        /// Arms a breakpoint that only exists to bound the step in progress.
+        private mutating func armStepBreakpoint(address: Int) throws {
+            let (iseq, wasm) = try self.findIseq(forWasmAddress: address)
+            self.stepBreakpoints.insert(wasm)
+            self.arm(resolved: wasm, iseq: iseq)
+        }
+
+        /// Takes down the breakpoints that bounded a step that has landed. Only one of them is where
+        /// execution went, and none of them are the host's, so leaving any behind stops the program at
+        /// an address nothing asked about.
+        private mutating func clearStepBreakpoints() {
+            let armedForStep = self.stepBreakpoints
+            self.stepBreakpoints.removeAll()
+            for resolved in armedForStep where !self.hostBreakpoints.contains(resolved) {
+                self.disarm(resolved: resolved)
+            }
+        }
+
         /// Analyzes the control-flow instruction at the given breakpoint and sets breakpoints
         /// at all possible next instruction locations.
         private mutating func setNextInstructionBreakpoints(breakpoint: BreakpointState) throws {
             // If the breakpoint was externally removed (e.g. via disableBreakpoint
             // while stopped), the original instruction has already been restored at the
             // iseq PC, so read it directly.
-            let savedHead = self.breakpoints[breakpoint.wasmPc] ?? breakpoint.iseq.pc.pointee
+            let savedHead = self.armedBreakpoints[breakpoint.wasmPc]?.originalHeadSlot ?? breakpoint.iseq.pc.pointee
             let operandPc = breakpoint.iseq.pc.advanced(by: 1)
             let sp = breakpoint.iseq.sp
 
@@ -398,7 +471,7 @@
                 // Empty targets means terminal (unreachable, endOfExecution) — no breakpoints to set.
                 for pc in targets {
                     if let wasmAddr = self.instance.handle.instructionMapping.findWasm(forIseqAddress: pc) {
-                        try self.enableBreakpoint(address: wasmAddr)
+                        try self.armStepBreakpoint(address: wasmAddr)
                     }
                 }
                 return
@@ -407,12 +480,12 @@
             // The head slot is non-control because a call with args maps its wasm address to a
             // prep slot, not the call.
             if let calleeEntry = self.stepInTargetIfCall(breakpoint: breakpoint) {
-                try self.enableBreakpoint(address: calleeEntry)
+                try self.armStepBreakpoint(address: calleeEntry)
                 return
             }
 
             // Non-control instruction: fall back to next Wasm address
-            try self.enableBreakpoint(address: breakpoint.wasmPc + 1)
+            try self.armStepBreakpoint(address: breakpoint.wasmPc + 1)
         }
 
         /// The call is the last iseq emit for its wasm address (prep slots come first), so `lastIseq`

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -341,9 +341,8 @@
                 throw Error.killRequestReceived
 
             case .detach:
-                for address in self.debugger.breakpoints.keys {
-                    try self.debugger.disableBreakpoint(address: address)
-                }
+                self.debugger.removeAllBreakpoints()
+                self.userBreakpoints.removeAll()
 
                 try self.debugger.run()
                 throw Error.killRequestReceived

--- a/Tests/WasmKitTests/DebuggerTests.swift
+++ b/Tests/WasmKitTests/DebuggerTests.swift
@@ -359,15 +359,14 @@
             var debugger = try Debugger(module: module, store: store, imports: [:])
 
             try debugger.stopAtEntrypoint()
-            #expect(debugger.breakpoints.count == 1)
+            #expect(debugger.armedBreakpointAddresses.count == 1)
 
             try debugger.run()
-            let firstExpectedPc = try #require(debugger.breakpoints.keys.first)
+            let firstExpectedPc = try requireBreakpoint(debugger)
             #expect(debugger.currentCallStack == [firstExpectedPc])
 
             try debugger.step()
-            #expect(debugger.breakpoints.count == 1)
-            let secondExpectedPc = try #require(debugger.breakpoints.keys.first)
+            let secondExpectedPc = try requireBreakpoint(debugger)
             #expect(debugger.currentCallStack == [secondExpectedPc])
 
             #expect(firstExpectedPc < secondExpectedPc)
@@ -1217,9 +1216,113 @@
             // Should work fine after re-sync
             try debugger.step()
             try requireBreakpoint(debugger)
+
+            // The re-added breakpoint is still the one $factorial recurses into.
             try debugger.run()
+            #expect(try requireBreakpoint(debugger) == breakpointAddress)
+
+            try debugger.disableBreakpoint(address: breakpointAddress)
+            try debugger.runPreservingCurrentBreakpoint()
             let values = try requireReturned(debugger)
             #expect(values == [.i64(6)])
+        }
+
+        // MARK: - breakpoint ownership
+
+        /// A step arms a breakpoint at every address execution can reach from the current one. Once
+        /// it has landed, and with nothing of its owner's left, the debugger has nothing to stop for.
+        @Test
+        func stepLeavesNoBreakpointBehind() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(loopWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            let base = module.functions[0].code.originalAddress
+            let breakpointAddress = try debugger.enableBreakpoint(address: base + 17)  // br_if
+
+            // First of three iterations: $i goes from 3 to 2, so the branch back is taken and the
+            // step has two possible destinations.
+            try debugger.run()
+            #expect(try requireBreakpoint(debugger) == breakpointAddress)
+
+            try debugger.step()
+            try requireBreakpoint(debugger)
+
+            try debugger.disableBreakpoint(address: breakpointAddress)
+            #expect(debugger.armedBreakpointAddresses.isEmpty)
+
+            try debugger.runPreservingCurrentBreakpoint()
+            let values = try requireReturned(debugger)
+            #expect(values == [.i32(0)])
+        }
+
+        /// A step off a breakpoint has to take it out of the bytecode to execute the instruction
+        /// under it, which is not something its owner asked for.
+        @Test
+        func stepKeepsTheBreakpointItSteppedOff() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(loopWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            let base = module.functions[0].code.originalAddress
+            let breakpointAddress = try debugger.enableBreakpoint(address: base + 17)  // br_if
+
+            try debugger.run()
+            #expect(try requireBreakpoint(debugger) == breakpointAddress)
+
+            try debugger.step()
+            #expect(debugger.armedBreakpointAddresses == [breakpointAddress])
+
+            // Second of three iterations: $i goes from 2 to 1.
+            try debugger.runPreservingCurrentBreakpoint()
+            #expect(try requireBreakpoint(debugger) == breakpointAddress)
+        }
+
+        /// Resuming single-steps off the breakpoint it resumes from. When that step lands on another
+        /// breakpoint, that is a stop rather than a slot to run through.
+        @Test
+        func resumeStopsAtABreakpointOneInstructionAway() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(callInLoopWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            let callAddress = try debugger.enableBreakpoint(
+                // _start body: i32.const 3 (2) + local.set (2) + block (2) + loop (2) + local.get (2)
+                module: module, function: 0, offsetWithinFunction: 10  // call $decrement
+            )
+            let calleeAddress = try debugger.enableBreakpoint(module: module, function: 1)
+
+            try debugger.run()
+            #expect(try requireBreakpoint(debugger) == callAddress)
+
+            try debugger.runPreservingCurrentBreakpoint()
+            #expect(try requireBreakpoint(debugger) == calleeAddress)
+        }
+
+        /// Detaching has to leave the bytecode as it found it, so that the guest runs on without a
+        /// debugger to report to.
+        @Test
+        func removingAllBreakpointsRunsToCompletion() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(counterDemoWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            _ = try debugger.enableBreakpoint(module: module, function: 1)
+            _ = try debugger.enableBreakpoint(module: module, function: 2)
+
+            try debugger.run()
+            try requireBreakpoint(debugger)
+
+            debugger.removeAllBreakpoints()
+            #expect(debugger.armedBreakpointAddresses.isEmpty)
+
+            try debugger.run()
+            let values = try requireReturned(debugger)
+            #expect(values == [.i32(2)])
         }
     }
 


### PR DESCRIPTION
Stepping arms a breakpoint at every address execution can reach from the current one, but nothing ever took them back down. Every step left live breakpoints behind at addresses the host never asked about, and so did every continue, which single-steps off the breakpoint it resumes from. The program then stopped where nobody had set a breakpoint.

The opposite happened too. run() resumed by calling disableBreakpoint(), which forgets the host's request as well as taking the breakpoint out of the bytecode, and runPreservingCurrentBreakpoint() only put back the address it started from, not the one its intermediate step landed on. A continue that landed on another of the host's breakpoints destroyed it, which is also why a breakpoint one instruction past the resumed-from one was never reported.

Both come from conflating two facts in one dictionary: whether a breakpoint is in the bytecode, and whether someone wants one at that address. A breakpoint traps before the instruction it replaced, so resuming has to take it out of the bytecode and cannot put it back until execution has left the slot, but the request for it outlives all of that. Keep the two apart: armedBreakpoints is what is in the bytecode, hostBreakpoints and stepBreakpoints are the two reasons to want one, and an address stays armed while either reason remains. step() now arms, runs, clears its own breakpoints and puts back the breakpoint it stepped off, which leaves runPreservingCurrentBreakpoint() as a step plus a resume.

Detach goes through a new removeAllBreakpoints() instead of walking the breakpoint map, which is no longer exposed.