### PR TITLE
Exit with the client and detach from the guest

### DIFF
--- a/Sources/CLICommands/DebuggerServer.swift
+++ b/Sources/CLICommands/DebuggerServer.swift
@@ -35,29 +35,30 @@
             defer { listener.close() }
             logger.trace("Debugger server listening on port \(port)")
 
-            // A GDB stub serves one client at a time: accept connections
-            // sequentially until the client asks the target to shut down.
-            serving: while true {
-                let connection = try listener.accept()
-                defer { connection.close() }
+            // A GDB stub serves one client. The guest advances only through that client's
+            // packets and cannot be restarted, so a second one has nothing to attach to.
+            let connection = try listener.accept()
+            defer { connection.close() }
 
-                var decoder = GDBHostCommandDecoder(logger: logger)
-                let encoder = GDBTargetResponseEncoder(logger: logger)
+            var decoder = GDBHostCommandDecoder(logger: logger)
+            let encoder = GDBTargetResponseEncoder(logger: logger)
 
-                do {
-                    while let bytes = try connection.receive() {
-                        decoder.feed(bytes)
-                        while let packet = try decoder.next() {
-                            let response = try debuggerHandler.handle(command: packet.payload)
-                            try connection.send(encoder.encode(data: response))
-                        }
+            do {
+                while let bytes = try connection.receive() {
+                    decoder.feed(bytes)
+                    while let packet = try decoder.next() {
+                        let response = try debuggerHandler.handle(command: packet.payload)
+                        try connection.send(encoder.encode(data: response))
                     }
-                } catch WasmKitGDBHandler.Error.killRequestReceived {
-                    logger.trace("Debugger shut down request received")
-                    break serving
-                } catch {
-                    logger.error("Error in GDB remote protocol connection: \(error)")
                 }
+                logger.trace("Debugger disconnected")
+                if debuggerHandler.detachesOnDisconnect {
+                    try debuggerHandler.detach()
+                }
+            } catch WasmKitGDBHandler.Error.killRequestReceived {
+                logger.trace("Debugger shut down request received")
+            } catch {
+                logger.error("Error in GDB remote protocol connection: \(error)")
             }
             try debuggerHandler.close()
         }

--- a/Sources/CLICommands/TCPListener.swift
+++ b/Sources/CLICommands/TCPListener.swift
@@ -1,5 +1,5 @@
 // A minimal blocking TCP listener for the debugger server. A GDB stub serves
-// one client at a time, so a simple accept/read/write loop is all we need.
+// one client, so a simple accept/read/write loop is all we need.
 #if WasmDebuggingSupport && !os(Windows)
 
     #if canImport(Darwin)

--- a/Sources/GDBRemoteProtocol/GDBHostCommand.swift
+++ b/Sources/GDBRemoteProtocol/GDBHostCommand.swift
@@ -27,6 +27,7 @@ package struct GDBHostCommand: Equatable {
         case vContSupportedActions
         case isVAttachOrWaitSupported
         case enableErrorStrings
+        case setDetachOnError
         case processInfo
         case currentThreadID
         case firstThreadInfo
@@ -76,6 +77,8 @@ package struct GDBHostCommand: Equatable {
                 self = .isVAttachOrWaitSupported
             case "QEnableErrorStrings":
                 self = .enableErrorStrings
+            case "QSetDetachOnError":
+                self = .setDetachOnError
             case "qProcessInfo":
                 self = .processInfo
             case "qC":

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -48,6 +48,7 @@
             case unknownHexEncodedArguments(String)
             case unknownWasmLocalArguments(String)
             case unknownWasmGlobalArguments(String)
+            case unknownDetachOnErrorArgument(String)
         }
 
         private let moduleFilePath: String
@@ -61,6 +62,10 @@
         /// the requested address, which is the location the host knows.
         private var userBreakpoints: [Int: Int] = [:]
         private let wasi: WASIBridgeToHost
+
+        /// Whether a client that goes away without `k` or `D` leaves the guest running to
+        /// completion, as `QSetDetachOnError` selects.
+        package private(set) var detachesOnDisconnect = true
 
         /// Creates a handler debugging the given WebAssembly binary.
         ///
@@ -126,6 +131,18 @@
 
         package func close() throws {
             try wasi.close()
+        }
+
+        /// Lets the guest run to completion, as `D` asks for. The resume is blocking, so a guest
+        /// that never terminates keeps the caller here.
+        package func detach() throws {
+            self.debugger.removeAllBreakpoints()
+            self.userBreakpoints.removeAll()
+
+            // Resuming a guest that already returned would be a restart, which is unimplemented.
+            guard case .stoppedAtBreakpoint = self.debugger.state else { return }
+
+            try self.debugger.run()
         }
 
         enum Endianness {
@@ -235,6 +252,18 @@
                 .symbolLookup, .jsonThreadsInfo, .jsonThreadExtendedInfo:
                 responseKind = .empty
 
+            case .setDetachOnError:
+                switch command.arguments {
+                case "0":
+                    self.detachesOnDisconnect = false
+                case "1":
+                    self.detachesOnDisconnect = true
+                default:
+                    throw Error.unknownDetachOnErrorArgument(command.arguments)
+                }
+
+                responseKind = .ok
+
             case .processInfo:
                 responseKind = .keyValuePairs([
                     ("pid", "1"),
@@ -341,10 +370,7 @@
                 throw Error.killRequestReceived
 
             case .detach:
-                self.debugger.removeAllBreakpoints()
-                self.userBreakpoints.removeAll()
-
-                try self.debugger.run()
+                try self.detach()
                 throw Error.killRequestReceived
 
             case .insertSoftwareBreakpoint:

--- a/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
+++ b/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
@@ -75,6 +75,15 @@ struct GDBRemoteProtocolTests {
     }
 
     @Test
+    func decodingSetDetachOnError() throws {
+        var decoder = self.decoder
+        decoder.feed(Array("+$QSetDetachOnError:1#f8".utf8))
+        let packet = try decoder.next()
+        #expect(packet?.payload.kind == .setDetachOnError)
+        #expect(packet?.payload.arguments == "1")
+    }
+
+    @Test
     func decodingSplitAcrossFeeds() throws {
         var decoder = self.decoder
         decoder.feed(Array("+$g".utf8))

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -138,6 +138,51 @@
             }
         }
 
+        @Test
+        func detachRunsTheGuestToCompletion() async throws {
+            let (requested, _) = try divergentAddresses()
+            try await withHandler { h in
+                try await insert(h, at: requested)
+                #expect(pairs(try h.handle(command: .init(kind: .continue, arguments: "")))["reason"] == "breakpoint")
+
+                try h.detach()
+
+                let status = try h.handle(command: .init(kind: .targetStatus, arguments: ""))
+                guard case .string(let reply) = status.kind else {
+                    Issue.record("expected an exit reply after detaching, got \(status.kind)")
+                    return
+                }
+                #expect(reply.hasPrefix("W"))
+            }
+        }
+
+        @Test
+        func detachOnDisconnectIsRequestedByDefaultAndSelectable() async throws {
+            try await withHandler { h in
+                #expect(h.detachesOnDisconnect)
+
+                let off = try h.handle(command: .init(kind: .setDetachOnError, arguments: "0"))
+                if case .ok = off.kind {
+                } else {
+                    Issue.record("expected OK, got \(off.kind)")
+                }
+                #expect(!h.detachesOnDisconnect)
+
+                _ = try h.handle(command: .init(kind: .setDetachOnError, arguments: "1"))
+                #expect(h.detachesOnDisconnect)
+            }
+        }
+
+        @Test
+        func setDetachOnErrorRejectsValuesOtherThanZeroOrOne() async throws {
+            _ = try await withHandler { h in
+                #expect(throws: WasmKitGDBHandler.Error.self) {
+                    _ = try h.handle(command: .init(kind: .setDetachOnError, arguments: "2"))
+                }
+                #expect(h.detachesOnDisconnect)
+            }
+        }
+
         static let globalWAT = """
             (module
               (global $g (mut i32) (i32.const 7))


### PR DESCRIPTION
A connection ending without `k` or `D` sent the server back to `accept()`, where it waited for a second client indefinitely while holding the guest. The guest only advances on packets from the connection that drove it and cannot be restarted, so serve one connection and exit with it.

Treat an unannounced disconnect as a detach and implement `QSetDetachOnError` so the client can pick. LLDB sends it at launch from `target.detach-on-error`, which defaults to true, and debugserver detaches a running inferior when its packet connection drops. Detaching reuses the `D` path: drop the breakpoints, then resume.

`Debugger.run()` traps with "Restarting a Wasm module from the debugger is not implemented yet" in `.entrypointReturned`, so a detach from a guest that already returned stops after dropping the breakpoints.

Closing a connection without `k` now exits within a second instead of waiting indefinitely, and `QSetDetachOnError:0` exits without resuming. The resume is blocking, so a guest that never stops still outlives its client.