### PR TITLE
Add support for LLDB's updated `qWasmGlobal` packet

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -390,8 +390,10 @@
             throw Error.stackFrameIndexOOB(frameIndex)
         }
 
-        /// Globals are module-wide, so the GDB `qWasmGlobal:<frame>;<index>` frame argument is
-        /// irrelevant (matches LLDB eWasmTagGlobal).
+        /// The global at `index` in the debugged instance's global index space.
+        ///
+        /// Globals are instance-wide, so a `qWasmGlobal` frame argument carries no
+        /// information and is dropped, matching LLDB's `eWasmTagGlobal`.
         package func getGlobal(index: UInt) throws -> UInt64 {
             let globals = self.instance.handle.globals
             guard index < UInt(globals.count) else { throw Error.globalIndexOOB(index) }

--- a/Sources/WasmKitGDBHandler/DebuggerMemoryView.swift
+++ b/Sources/WasmKitGDBHandler/DebuggerMemoryView.swift
@@ -15,7 +15,15 @@
     import WasmKit
 
     package struct DebuggerMemoryView: ~Copyable {
-        package static let executableCodeOffset = UInt64(0x4000_0000_0000_0000)
+        /// Addresses tag their space in bits 63:62: 0 is linear memory, 1 the object
+        /// space holding the module image.
+        private static let objectSpaceTag = UInt64(1) << 62
+
+        /// The id of the only module instance the debugger runs, carried in bits 61:32
+        /// of the addresses reported for it.
+        package static let moduleInstanceID = UInt64(0)
+
+        package static let executableCodeOffset = objectSpaceTag | (moduleInstanceID << 32)
 
         /// WebAssembly binary loaded into memory for execution
         /// and for disassembly by the debugger.

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -29,6 +29,48 @@
         }
     }
 
+    /// The module instance and global index a `qWasmGlobal` request names.
+    ///
+    /// A debugger advertising `qWasmGlobalInstance+` specifies the instance owning
+    /// the global index with an `instance:<id>` field. Older debuggers may send
+    /// a frame index instead.
+    struct WasmGlobalRequest {
+        private static let instanceKey = "instance:"
+
+        /// The instance owning the global index space, or nil where the request named a
+        /// frame and the instance is whichever one that frame is executing.
+        let instance: UInt64?
+
+        let globalIndex: UInt
+
+        /// Parses `<global>;instance:<id>` or the older `<frame>;<global>`.
+        init?(arguments: String) {
+            // Keep empty fields so a malformed `<frame>;` is rejected rather than read as `<frame>`.
+            var fields = arguments.split(separator: ";", omittingEmptySubsequences: false)
+
+            // A request may terminate its last field with the delimiter, yielding a
+            // trailing empty field that carries no argument.
+            if fields.count == 3 && fields[2].isEmpty {
+                fields.removeLast()
+            }
+
+            // Exactly two fields, so a request mixing both forms is rejected rather than
+            // read as one of them.
+            guard fields.count == 2, let first = UInt(fields[0]) else { return nil }
+
+            if fields[1].hasPrefix(Self.instanceKey) {
+                guard let instance = UInt64(fields[1].dropFirst(Self.instanceKey.count)) else { return nil }
+                self.instance = instance
+                self.globalIndex = first
+                return
+            }
+
+            guard let globalIndex = UInt(fields[1]) else { return nil }
+            self.instance = nil
+            self.globalIndex = globalIndex
+        }
+    }
+
     /// A sans-IO GDB remote-protocol target.
     package final class WasmKitGDBHandler {
         enum ResumeThreadsAction: String {
@@ -54,6 +96,10 @@
         private let moduleFilePath: String
         private let logger: GDBLogger
         private var debugger: Debugger
+
+        /// Generic error reply. `QEnableErrorStrings` is unsupported, so a bare code is
+        /// the only way to refuse a request the target understands but cannot answer.
+        private static let errorReply = "E45"
 
         private var memoryView: DebuggerMemoryView
         /// User-set breakpoints, keyed by the address the debugger host
@@ -243,7 +289,7 @@
                 ])
 
             case .supportedFeatures:
-                responseKind = .string("qXfer:libraries:read+;PacketSize=1000;")
+                responseKind = .string("qXfer:libraries:read+;qWasmGlobalInstance+;PacketSize=1000;")
 
             case .vContSupportedActions:
                 responseKind = .vContSupportedActions([.continue, .step])
@@ -299,7 +345,7 @@
                         ("generic", "pc"),
                     ])
                 } else {
-                    responseKind = .string("E45")
+                    responseKind = .string(Self.errorReply)
                 }
 
             case .transfer:
@@ -410,17 +456,20 @@
                 )
 
             case .wasmGlobal:
-                // Keep empty fields so a malformed `<frame>;` is rejected rather than read as `<frame>`.
-                let arguments = command.arguments.split(separator: ";", omittingEmptySubsequences: false)
-                guard arguments.count == 2,
-                    let globalIndex = UInt(arguments[1])
-                else {
+                guard let request = WasmGlobalRequest(arguments: command.arguments) else {
                     throw Error.unknownWasmGlobalArguments(command.arguments)
                 }
 
-                responseKind = .hexEncodedBinary(
-                    try self.debugger.getGlobal(index: globalIndex).littleEndianBytes
-                )
+                // A global index is meaningful only within one instance's global index
+                // space, so a request naming another instance is refused rather than
+                // answered from this one.
+                if let instance = request.instance, instance != DebuggerMemoryView.moduleInstanceID {
+                    responseKind = .string(Self.errorReply)
+                } else {
+                    responseKind = .hexEncodedBinary(
+                        try self.debugger.getGlobal(index: request.globalIndex).littleEndianBytes
+                    )
+                }
 
             case .memoryRegionInfo:
                 responseKind = .empty

--- a/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
+++ b/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
@@ -68,6 +68,17 @@ struct GDBRemoteProtocolTests {
     }
 
     @Test
+    func decodingWasmGlobalNamingAnInstance() throws {
+        var decoder = self.decoder
+        // Only the first colon separates a command kind from its arguments, so a
+        // key-value argument keeps its own.
+        decoder.feed(Array("+$qWasmGlobal:1;instance:0;#fa".utf8))
+        let packet = try decoder.next()
+        #expect(packet?.payload.kind == .wasmGlobal)
+        #expect(packet?.payload.arguments == "1;instance:0;")
+    }
+
+    @Test
     func wasmGlobalMemberwiseInit() {
         let command = GDBHostCommand(kind: .wasmGlobal, arguments: "0;1")
         #expect(command.kind == .wasmGlobal)

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -183,9 +183,12 @@
             }
         }
 
+        // Distinct global values, so a reply pins down which field of a `qWasmGlobal`
+        // request was read as the global index.
         static let globalWAT = """
             (module
               (global $g (mut i32) (i32.const 7))
+              (global $h (mut i32) (i32.const 11))
               (func (export "_start") (result i32) (global.get $g)))
             """
 
@@ -220,12 +223,109 @@
         }
 
         @Test
+        func wasmGlobalIgnoresTheFrameIndex() async throws {
+            try await withGlobalHandler { h in
+                let resp = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;1"))
+                guard case .hexEncodedBinary(let bytes) = resp.kind else {
+                    Issue.record("expected hexEncodedBinary, got \(resp.kind)")
+                    return
+                }
+                #expect(UInt64(littleEndianBytes: bytes) == 11)
+            }
+        }
+
+        @Test
         func wasmGlobalRejectsMissingIndex() async throws {
             _ = try await withGlobalHandler { h in
                 #expect(throws: WasmKitGDBHandler.Error.self) {
                     _ = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;"))
                 }
             }
+        }
+
+        @Test
+        func supportedFeaturesAdvertisesInstanceNamedWasmGlobal() async throws {
+            try await withGlobalHandler { h in
+                let resp = try h.handle(command: .init(kind: .supportedFeatures, arguments: ""))
+                guard case .string(let features) = resp.kind else {
+                    Issue.record("expected a feature string, got \(resp.kind)")
+                    return
+                }
+                #expect(features.split(separator: ";").contains("qWasmGlobalInstance+"))
+            }
+        }
+
+        @Test
+        func wasmGlobalReadsTheGlobalOfAnInstanceNamedRequest() async throws {
+            try await withGlobalHandler { h in
+                let resp = try h.handle(
+                    command: .init(
+                        kind: .wasmGlobal,
+                        arguments: "1;instance:\(DebuggerMemoryView.moduleInstanceID);"))
+                guard case .hexEncodedBinary(let bytes) = resp.kind else {
+                    Issue.record("expected hexEncodedBinary, got \(resp.kind)")
+                    return
+                }
+                #expect(UInt64(littleEndianBytes: bytes) == 11)
+            }
+        }
+
+        @Test
+        func wasmGlobalAcceptsAnInstanceWithoutATrailingDelimiter() async throws {
+            try await withGlobalHandler { h in
+                let resp = try h.handle(
+                    command: .init(
+                        kind: .wasmGlobal,
+                        arguments: "1;instance:\(DebuggerMemoryView.moduleInstanceID)"))
+                guard case .hexEncodedBinary(let bytes) = resp.kind else {
+                    Issue.record("expected hexEncodedBinary, got \(resp.kind)")
+                    return
+                }
+                #expect(UInt64(littleEndianBytes: bytes) == 11)
+            }
+        }
+
+        @Test
+        func wasmGlobalRefusesAnInstanceItDoesNotRun() async throws {
+            try await withGlobalHandler { h in
+                let unknown = DebuggerMemoryView.moduleInstanceID + 1
+                let resp = try h.handle(
+                    command: .init(kind: .wasmGlobal, arguments: "0;instance:\(unknown);"))
+                guard case .string(let reply) = resp.kind else {
+                    Issue.record("expected an error reply, got \(resp.kind)")
+                    return
+                }
+                #expect(reply.hasPrefix("E"))
+            }
+        }
+
+        @Test
+        func wasmGlobalRejectsAnUnparsableInstance() async throws {
+            _ = try await withGlobalHandler { h in
+                #expect(throws: WasmKitGDBHandler.Error.self) {
+                    _ = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;instance:;"))
+                }
+            }
+        }
+
+        // Both forms at once names the global ambiguously, so neither reading may be served.
+        @Test
+        func wasmGlobalRejectsARequestMixingAFrameIndexAndAnInstance() async throws {
+            _ = try await withGlobalHandler { h in
+                #expect(throws: WasmKitGDBHandler.Error.self) {
+                    _ = try h.handle(
+                        command: .init(
+                            kind: .wasmGlobal,
+                            arguments: "0;1;instance:\(DebuggerMemoryView.moduleInstanceID);"))
+                }
+            }
+        }
+
+        // Addresses reported to a host are offsets from this base, making its value part
+        // of the protocol rather than an implementation detail.
+        @Test
+        func executableCodeStartsAtTheObjectSpaceTag() {
+            #expect(DebuggerMemoryView.executableCodeOffset == 0x4000_0000_0000_0000)
         }
     }
 


### PR DESCRIPTION
Currently the qWasmGlobal takes a frame index, making it impossible to request a global for a module instance that's not active on the stack. See #llvm-project/212833 for more details.

LLDB now supports instance owning a global with an `instance:<id>` field, negotiated through `qWasmGlobalInstance+`. This PR adds support for the new variant of the packet. The legacy frame variant stays supported for (older) debuggers that do not support it.

Also derive the executable code offset from the address tag bits, so the instance id matches.

Assisted-by: Claude