### PR TITLE
Advertise the `qWasmInstance+` feature LLDB looks for

### DIFF
--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -31,7 +31,7 @@
 
     /// The module instance and global index a `qWasmGlobal` request names.
     ///
-    /// A debugger advertising `qWasmGlobalInstance+` specifies the instance owning
+    /// A debugger advertising `qWasmInstance+` specifies the instance owning
     /// the global index with an `instance:<id>` field. Older debuggers may send
     /// a frame index instead.
     struct WasmGlobalRequest {
@@ -289,7 +289,7 @@
                 ])
 
             case .supportedFeatures:
-                responseKind = .string("qXfer:libraries:read+;qWasmGlobalInstance+;PacketSize=1000;")
+                responseKind = .string("qXfer:libraries:read+;qWasmInstance+;PacketSize=1000;")
 
             case .vContSupportedActions:
                 responseKind = .vContSupportedActions([.continue, .step])

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -251,7 +251,7 @@
                     Issue.record("expected a feature string, got \(resp.kind)")
                     return
                 }
-                #expect(features.split(separator: ";").contains("qWasmGlobalInstance+"))
+                #expect(features.split(separator: ";").contains("qWasmInstance+"))
             }
         }
 


### PR DESCRIPTION
In #420, WasmKit started to advertise `qWasmGlobalInstance+`, which was the old spelling. LLDB checks for `qWasmInstance+` exactly, so the instance form never negotiated and every global read fell back to a frame index. This went unnoticed when running the LLDB test suite, because we have no integration tests that exercise this yet.