### PR TITLE
Report the guest's exit status instead of dropping the connection

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -13,6 +13,7 @@
             case stoppedAtBreakpoint(BreakpointState)
             case trapped(String)
             case entrypointReturned([Value])
+            case exited(status: UInt32)
         }
 
         package enum Error: Swift.Error, @unchecked Sendable {
@@ -290,6 +291,10 @@
                     )
                     self.state = .entrypointReturned(result)
 
+                case .exited:
+                    // The guest is gone, so there is nothing to resume.
+                    return
+
                 case .trapped, .entrypointReturned:
                     fatalError("Restarting a Wasm module from the debugger is not implemented yet.")
                 }
@@ -345,6 +350,11 @@
             }
 
             try self.run()
+        }
+
+        /// Records that the guest exited with the given status.
+        package mutating func recordExit(status: UInt32) {
+            self.state = .exited(status: status)
         }
 
         package func getLocal(frameIndex: UInt, localIndex: UInt) throws -> UInt64 {

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -175,6 +175,28 @@
             )
         }
 
+        /// How far to let the guest run.
+        private enum Resume {
+            /// One Wasm instruction.
+            case step
+            /// Until the next breakpoint.
+            case untilBreakpoint
+            /// Until the guest ends.
+            case toCompletion
+        }
+
+        private func resume(_ resume: Resume) throws {
+            do {
+                switch resume {
+                case .step: try self.debugger.step()
+                case .untilBreakpoint: try self.debugger.runPreservingCurrentBreakpoint()
+                case .toCompletion: try self.debugger.run()
+                }
+            } catch let exit as WASIExitCode {
+                self.debugger.recordExit(status: exit.code)
+            }
+        }
+
         package func close() throws {
             try wasi.close()
         }
@@ -188,11 +210,16 @@
             // Resuming a guest that already returned would be a restart, which is unimplemented.
             guard case .stoppedAtBreakpoint = self.debugger.state else { return }
 
-            try self.debugger.run()
+            try self.resume(.toCompletion)
         }
 
         enum Endianness {
             case big, little
+        }
+
+        /// Reply that the guest has exited with the given exit status.
+        private static func exitReply(status: some FixedWidthInteger) -> GDBTargetResponse.Kind {
+            .string("W\(HexEncoding.encode(UInt8(truncatingIfNeeded: status).bigEndianBytes))")
         }
 
         private func hexDump<I: FixedWidthInteger>(_ value: I, endianness: Endianness) -> String {
@@ -246,14 +273,17 @@
 
                 case .entrypointReturned(let values):
                     guard !values.isEmpty else {
-                        return .string("W\(self.hexDump(0 as UInt8, endianness: .big))")
+                        return Self.exitReply(status: 0)
                     }
 
                     guard case .i32(let exitCode) = values.first else {
                         throw Error.exitCodeUnknown(values)
                     }
 
-                    return .string("W\(self.hexDump(exitCode, endianness: .big))")
+                    return Self.exitReply(status: exitCode)
+
+                case .exited(let status):
+                    return Self.exitReply(status: status)
 
                 case .trapped(let trapReason):
                     result.append(("reason", "trap"))
@@ -400,15 +430,15 @@
 
                 switch threadAction {
                 case .step:
-                    try self.debugger.step()
+                    try self.resume(.step)
                 case .continue:
-                    try self.debugger.runPreservingCurrentBreakpoint()
+                    try self.resume(.untilBreakpoint)
                 }
 
                 responseKind = try self.currentThreadStopInfo
 
             case .continue:
-                try self.debugger.runPreservingCurrentBreakpoint()
+                try self.resume(.untilBreakpoint)
 
                 responseKind = try self.currentThreadStopInfo
 

--- a/Tests/WasmKitGDBHandlerTests/ExitTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/ExitTests.swift
@@ -1,0 +1,52 @@
+#if WasmDebuggingSupport
+
+    import GDBRemoteProtocol
+    import Testing
+    import WAT
+
+    @testable import WasmKit
+    @testable import WasmKitGDBHandler
+
+    @Suite
+    struct ExitTests {
+        /// Asking WASI to exit is the only way a guest ends with a status of its own choosing, and
+        /// it is the way a C `main` returning nonzero gets there.
+        static let wat = """
+            (module
+              (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+              (memory (export "memory") 1)
+              (func (export "_start")
+                (call $proc_exit (i32.const 75))
+                (unreachable))
+            )
+            """
+
+        /// The reply a `c` produced, or nil where it was not the plain string an exit is reported as.
+        private func continueGuest(_ handler: WasmKitGDBHandler) throws -> String? {
+            guard case .string(let reply) = try handler.handle(command: .init(kind: .continue, arguments: "")).kind
+            else { return nil }
+            return reply
+        }
+
+        /// An exit reaches the target as an error thrown out of a host call. Letting it escape drops
+        /// the connection, so a host sees the guest vanish rather than the status it ended with.
+        @Test
+        func anExitIsReportedWithItsStatus() throws {
+            try withDebuggedHandler(debugging: try wat2wasm(Self.wat)) { handler in
+                let reply = try self.continueGuest(handler)
+                #expect(reply == "W4b")
+            }
+        }
+
+        /// A host resumes after every stop it is told about, including the last one.
+        @Test
+        func resumingAfterAnExitReportsItAgain() throws {
+            try withDebuggedHandler(debugging: try wat2wasm(Self.wat)) { handler in
+                let first = try self.continueGuest(handler)
+                let again = try self.continueGuest(handler)
+                #expect(again == first)
+            }
+        }
+    }
+
+#endif

--- a/Tests/WasmKitGDBHandlerTests/ExitTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/ExitTests.swift
@@ -32,7 +32,7 @@
         /// the connection, so a host sees the guest vanish rather than the status it ended with.
         @Test
         func anExitIsReportedWithItsStatus() throws {
-            try withDebuggedHandler(debugging: try wat2wasm(Self.wat)) { handler in
+            try withHandler(debugging: Self.wat) { handler in
                 let reply = try self.continueGuest(handler)
                 #expect(reply == "W4b")
             }
@@ -41,7 +41,7 @@
         /// A host resumes after every stop it is told about, including the last one.
         @Test
         func resumingAfterAnExitReportsItAgain() throws {
-            try withDebuggedHandler(debugging: try wat2wasm(Self.wat)) { handler in
+            try withHandler(debugging: Self.wat) { handler in
                 let first = try self.continueGuest(handler)
                 let again = try self.continueGuest(handler)
                 #expect(again == first)

--- a/Tests/WasmKitGDBHandlerTests/TestHandler.swift
+++ b/Tests/WasmKitGDBHandlerTests/TestHandler.swift
@@ -1,0 +1,28 @@
+#if WasmDebuggingSupport
+
+    import WasmKitWASI
+
+    @testable import WasmKit
+    @testable import WasmKitGDBHandler
+
+    /// Runs `body` against a handler debugging `wasmBinary`, stopped at its entrypoint.
+    ///
+    /// Closes on both paths because WASIBridgeToHost's deinit preconditions on close() having run.
+    func withDebuggedHandler(debugging wasmBinary: [UInt8], _ body: (WasmKitGDBHandler) throws -> Void) throws {
+        let handler = try WasmKitGDBHandler(
+            wasmBinary: wasmBinary,
+            moduleFilePath: "/tmp/test.wasm",
+            wasiConfiguration: WASIConfiguration(arguments: [], environment: [:], preopens: []),
+            engineConfiguration: EngineConfiguration(),
+            logger: .disabled
+        )
+        do {
+            try body(handler)
+            try handler.close()
+        } catch {
+            try handler.close()
+            throw error
+        }
+    }
+
+#endif

--- a/Tests/WasmKitGDBHandlerTests/TestHandler.swift
+++ b/Tests/WasmKitGDBHandlerTests/TestHandler.swift
@@ -1,24 +1,26 @@
 #if WasmDebuggingSupport
 
+    import WAT
     import WasmKitWASI
 
     @testable import WasmKit
     @testable import WasmKitGDBHandler
 
-    /// Runs `body` against a handler debugging `wasmBinary`, stopped at its entrypoint.
+    /// Runs `body` against a handler debugging `wat`, stopped at its entrypoint.
     ///
     /// Closes on both paths because WASIBridgeToHost's deinit preconditions on close() having run.
-    func withDebuggedHandler(debugging wasmBinary: [UInt8], _ body: (WasmKitGDBHandler) throws -> Void) throws {
+    func withHandler<R>(debugging wat: String, _ body: (WasmKitGDBHandler) throws -> R) throws -> R {
         let handler = try WasmKitGDBHandler(
-            wasmBinary: wasmBinary,
+            wasmBinary: try wat2wasm(wat),
             moduleFilePath: "/tmp/test.wasm",
             wasiConfiguration: WASIConfiguration(arguments: [], environment: [:], preopens: []),
             engineConfiguration: EngineConfiguration(),
             logger: .disabled
         )
         do {
-            try body(handler)
+            let result = try body(handler)
             try handler.close()
+            return result
         } catch {
             try handler.close()
             throw error

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -1,7 +1,6 @@
 #if WasmDebuggingSupport
 
     import GDBRemoteProtocol
-    import WasmKitWASI
     import Testing
     import WAT
 
@@ -60,25 +59,6 @@
             return try debugger.enableBreakpoint(address: address)
         }
 
-        // Closes on both paths because WASIBridgeToHost's deinit preconditions on close() having run.
-        private func withHandler<R>(_ body: (WasmKitGDBHandler) async throws -> R) async throws -> R {
-            let bytes = try wat2wasm(Self.wat)
-            let h = try WasmKitGDBHandler(
-                wasmBinary: bytes,
-                moduleFilePath: "/tmp/test.wasm",
-                wasiConfiguration: WASIConfiguration(arguments: [], environment: [:], preopens: []),
-                engineConfiguration: EngineConfiguration(),
-                logger: .disabled)
-            do {
-                let result = try await body(h)
-                try h.close()
-                return result
-            } catch {
-                try h.close()
-                throw error
-            }
-        }
-
         private func pairs(_ r: GDBTargetResponse) -> [String: String] {
             guard case .keyValuePairs(let kvs) = r.kind else { return [:] }
             return Dictionary(kvs, uniquingKeysWith: { a, _ in a })
@@ -90,17 +70,17 @@
             HexEncoding.encode((UInt64(wasmAddr) + offset).bigEndianBytes)
         }
 
-        private func insert(_ h: WasmKitGDBHandler, at wasmAddr: Int) async throws {
+        private func insert(_ h: WasmKitGDBHandler, at wasmAddr: Int) throws {
             _ = try h.handle(
                 command: .init(
                     kind: .insertSoftwareBreakpoint, arguments: "\(hostHex(wasmAddr)),1"))
         }
 
         @Test
-        func breakpointStopReportsBreakpointReasonAtRequestedAddress() async throws {
+        func breakpointStopReportsBreakpointReasonAtRequestedAddress() throws {
             let (requested, resolved) = try divergentAddresses()
-            try await withHandler { h in
-                try await insert(h, at: requested)
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: requested)
                 let stop = try h.handle(command: .init(kind: .continue, arguments: ""))
                 let kv = pairs(stop)
                 #expect(kv["reason"] == "breakpoint")
@@ -110,10 +90,10 @@
         }
 
         @Test
-        func removeBreakpointUninstallsAtResolvedAddress() async throws {
+        func removeBreakpointUninstallsAtResolvedAddress() throws {
             let (requested, _) = try divergentAddresses()
-            try await withHandler { h in
-                try await insert(h, at: requested)
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: requested)
                 _ = try h.handle(
                     command: .init(
                         kind: .removeSoftwareBreakpoint, arguments: "\(hostHex(requested)),1"))
@@ -128,10 +108,10 @@
         }
 
         @Test
-        func stepLandingReportsTraceNotBreakpoint() async throws {
+        func stepLandingReportsTraceNotBreakpoint() throws {
             let (requested, _) = try divergentAddresses()
-            try await withHandler { h in
-                try await insert(h, at: requested)
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: requested)
                 _ = try h.handle(command: .init(kind: .continue, arguments: ""))
                 let step = try h.handle(command: .init(kind: .resumeThreads, arguments: "s:1"))
                 #expect(pairs(step)["reason"] == "trace")
@@ -139,10 +119,10 @@
         }
 
         @Test
-        func detachRunsTheGuestToCompletion() async throws {
+        func detachRunsTheGuestToCompletion() throws {
             let (requested, _) = try divergentAddresses()
-            try await withHandler { h in
-                try await insert(h, at: requested)
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: requested)
                 #expect(pairs(try h.handle(command: .init(kind: .continue, arguments: "")))["reason"] == "breakpoint")
 
                 try h.detach()
@@ -157,8 +137,8 @@
         }
 
         @Test
-        func detachOnDisconnectIsRequestedByDefaultAndSelectable() async throws {
-            try await withHandler { h in
+        func detachOnDisconnectIsRequestedByDefaultAndSelectable() throws {
+            try withHandler(debugging: Self.wat) { h in
                 #expect(h.detachesOnDisconnect)
 
                 let off = try h.handle(command: .init(kind: .setDetachOnError, arguments: "0"))
@@ -174,8 +154,8 @@
         }
 
         @Test
-        func setDetachOnErrorRejectsValuesOtherThanZeroOrOne() async throws {
-            _ = try await withHandler { h in
+        func setDetachOnErrorRejectsValuesOtherThanZeroOrOne() throws {
+            _ = try withHandler(debugging: Self.wat) { h in
                 #expect(throws: WasmKitGDBHandler.Error.self) {
                     _ = try h.handle(command: .init(kind: .setDetachOnError, arguments: "2"))
                 }
@@ -192,27 +172,9 @@
               (func (export "_start") (result i32) (global.get $g)))
             """
 
-        private func withGlobalHandler<R>(_ body: (WasmKitGDBHandler) async throws -> R) async throws -> R {
-            let bytes = try wat2wasm(Self.globalWAT)
-            let h = try WasmKitGDBHandler(
-                wasmBinary: bytes,
-                moduleFilePath: "/tmp/test.wasm",
-                wasiConfiguration: WASIConfiguration(arguments: [], environment: [:], preopens: []),
-                engineConfiguration: EngineConfiguration(),
-                logger: .disabled)
-            do {
-                let result = try await body(h)
-                try h.close()
-                return result
-            } catch {
-                try h.close()
-                throw error
-            }
-        }
-
         @Test
-        func wasmGlobalRepliesWithLittleEndianValue() async throws {
-            try await withGlobalHandler { h in
+        func wasmGlobalRepliesWithLittleEndianValue() throws {
+            try withHandler(debugging: Self.globalWAT) { h in
                 let resp = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;0"))
                 guard case .hexEncodedBinary(let bytes) = resp.kind else {
                     Issue.record("expected hexEncodedBinary, got \(resp.kind)")
@@ -223,8 +185,8 @@
         }
 
         @Test
-        func wasmGlobalIgnoresTheFrameIndex() async throws {
-            try await withGlobalHandler { h in
+        func wasmGlobalIgnoresTheFrameIndex() throws {
+            try withHandler(debugging: Self.globalWAT) { h in
                 let resp = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;1"))
                 guard case .hexEncodedBinary(let bytes) = resp.kind else {
                     Issue.record("expected hexEncodedBinary, got \(resp.kind)")
@@ -235,8 +197,8 @@
         }
 
         @Test
-        func wasmGlobalRejectsMissingIndex() async throws {
-            _ = try await withGlobalHandler { h in
+        func wasmGlobalRejectsMissingIndex() throws {
+            _ = try withHandler(debugging: Self.globalWAT) { h in
                 #expect(throws: WasmKitGDBHandler.Error.self) {
                     _ = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;"))
                 }
@@ -244,8 +206,8 @@
         }
 
         @Test
-        func supportedFeaturesAdvertisesInstanceNamedWasmGlobal() async throws {
-            try await withGlobalHandler { h in
+        func supportedFeaturesAdvertisesInstanceNamedWasmGlobal() throws {
+            try withHandler(debugging: Self.globalWAT) { h in
                 let resp = try h.handle(command: .init(kind: .supportedFeatures, arguments: ""))
                 guard case .string(let features) = resp.kind else {
                     Issue.record("expected a feature string, got \(resp.kind)")
@@ -256,8 +218,8 @@
         }
 
         @Test
-        func wasmGlobalReadsTheGlobalOfAnInstanceNamedRequest() async throws {
-            try await withGlobalHandler { h in
+        func wasmGlobalReadsTheGlobalOfAnInstanceNamedRequest() throws {
+            try withHandler(debugging: Self.globalWAT) { h in
                 let resp = try h.handle(
                     command: .init(
                         kind: .wasmGlobal,
@@ -271,8 +233,8 @@
         }
 
         @Test
-        func wasmGlobalAcceptsAnInstanceWithoutATrailingDelimiter() async throws {
-            try await withGlobalHandler { h in
+        func wasmGlobalAcceptsAnInstanceWithoutATrailingDelimiter() throws {
+            try withHandler(debugging: Self.globalWAT) { h in
                 let resp = try h.handle(
                     command: .init(
                         kind: .wasmGlobal,
@@ -286,8 +248,8 @@
         }
 
         @Test
-        func wasmGlobalRefusesAnInstanceItDoesNotRun() async throws {
-            try await withGlobalHandler { h in
+        func wasmGlobalRefusesAnInstanceItDoesNotRun() throws {
+            try withHandler(debugging: Self.globalWAT) { h in
                 let unknown = DebuggerMemoryView.moduleInstanceID + 1
                 let resp = try h.handle(
                     command: .init(kind: .wasmGlobal, arguments: "0;instance:\(unknown);"))
@@ -300,8 +262,8 @@
         }
 
         @Test
-        func wasmGlobalRejectsAnUnparsableInstance() async throws {
-            _ = try await withGlobalHandler { h in
+        func wasmGlobalRejectsAnUnparsableInstance() throws {
+            _ = try withHandler(debugging: Self.globalWAT) { h in
                 #expect(throws: WasmKitGDBHandler.Error.self) {
                     _ = try h.handle(command: .init(kind: .wasmGlobal, arguments: "0;instance:;"))
                 }
@@ -310,8 +272,8 @@
 
         // Both forms at once names the global ambiguously, so neither reading may be served.
         @Test
-        func wasmGlobalRejectsARequestMixingAFrameIndexAndAnInstance() async throws {
-            _ = try await withGlobalHandler { h in
+        func wasmGlobalRejectsARequestMixingAFrameIndexAndAnInstance() throws {
+            _ = try withHandler(debugging: Self.globalWAT) { h in
                 #expect(throws: WasmKitGDBHandler.Error.self) {
                     _ = try h.handle(
                         command: .init(


### PR DESCRIPTION
A WASI `proc_exit` reaches the target as a `WASIExitCode` thrown out of the host call. It escaped the packet handler, which tore down the connection, so LLDB saw the guest vanish rather than the status it ended with.

Catch it wherever the guest is resumed and record it as a new `exited` debugger state, reported as `W<status>`. The state persists so a `c` after the exit reports it again instead of restarting.