### PR TITLE
Report a stop at the start of the instruction run

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -5,7 +5,10 @@
     package struct Debugger: ~Copyable {
         package struct BreakpointState {
             let iseq: Execution.Breakpoint
+            /// Wasm address the engine stopped on.
             package let wasmPc: Int
+            /// Wasm address reported for this stop.
+            package var reportedPc: Int
         }
 
         package enum State {
@@ -51,10 +54,8 @@
         /// carries both what to restore and where, so taking one down never has to resolve again.
         private var armedBreakpoints = [Int: (iseq: Pc, originalHeadSlot: CodeSlot)]()
 
-        /// Resolved Wasm addresses the debugger host has asked for a breakpoint at. A breakpoint traps
-        /// *before* the instruction it replaced, so resuming means taking it out of the bytecode, which
-        /// the host's request outlives. That makes this a different fact from ``armedBreakpoints``.
-        private var hostBreakpoints = Set<Int>()
+        /// Breakpoints requested by the host, keyed by resolved address. Multiple requests may share a slot.
+        private var hostBreakpoints = [Int: Set<Int>]()
 
         /// Resolved Wasm addresses armed to bound the single-instruction step in progress. Every
         /// address execution can reach from the current one has to be armed, and all of them come
@@ -199,7 +200,7 @@
         @discardableResult
         package mutating func enableBreakpoint(address: Int) throws -> Int {
             let (iseq, wasm) = try self.findIseq(forWasmAddress: address)
-            self.hostBreakpoints.insert(wasm)
+            self.hostBreakpoints[wasm, default: []].insert(address)
             self.arm(resolved: wasm, iseq: iseq)
             return wasm
         }
@@ -221,7 +222,12 @@
             // Resolve the same way enableBreakpoint does, so a breakpoint set
             // at an elided address is found under its resolved key.
             let (_, wasm) = try self.findIseq(forWasmAddress: address)
-            self.hostBreakpoints.remove(wasm)
+            self.hostBreakpoints[wasm]?.remove(address)
+
+            // Keep armed if other requests share the slot.
+            guard self.hostBreakpoints[wasm]?.isEmpty ?? true else { return }
+
+            self.hostBreakpoints[wasm] = nil
             guard !self.stepBreakpoints.contains(wasm) else { return }
 
             self.disarm(resolved: wasm)
@@ -300,11 +306,18 @@
                 }
             } catch let breakpoint as Execution.Breakpoint {
                 let pc = breakpoint.pc
-                guard let wasmPc = self.instance.handle.instructionMapping.findWasm(forIseqAddress: pc) else {
+                let mapping = self.instance.handle.instructionMapping
+                guard let wasmPc = mapping.findWasm(forIseqAddress: pc) else {
                     throw Error.noReverseInstructionMappingAvailable(pc)
                 }
 
-                self.state = .stoppedAtBreakpoint(.init(iseq: breakpoint, wasmPc: wasmPc))
+                self.state = .stoppedAtBreakpoint(
+                    .init(
+                        iseq: breakpoint,
+                        wasmPc: wasmPc,
+                        reportedPc: self.hostBreakpoints[wasmPc]?.min() ?? mapping.firstWasm(forIseqAddress: pc) ?? wasmPc
+                    )
+                )
             }
         }
 
@@ -319,15 +332,31 @@
                 return
             }
 
+            // Report any remaining breakpoints sharing this slot before resuming.
+            guard !self.reportPendingHostBreakpoint(after: breakpoint) else { return }
+
             try self.setNextInstructionBreakpoints(breakpoint: breakpoint)
             try self.run()
             self.clearStepBreakpoints()
 
-            // Execution has moved past the instruction the breakpoint replaced, so its slot can hold a
-            // breakpoint again.
-            if self.hostBreakpoints.contains(breakpoint.wasmPc) {
-                try self.enableBreakpoint(address: breakpoint.wasmPc)
+            // Re-arm directly to avoid recording the resolved address as a new host request.
+            if self.hostBreakpoints[breakpoint.wasmPc] != nil {
+                self.arm(resolved: breakpoint.wasmPc, iseq: breakpoint.iseq.pc)
             }
+        }
+
+        /// Reports the next host breakpoint sharing this bytecode slot without resuming execution.
+        private mutating func reportPendingHostBreakpoint(after breakpoint: BreakpointState) -> Bool {
+            guard
+                let pending = self.hostBreakpoints[breakpoint.wasmPc]?
+                    .filter({ $0 > breakpoint.reportedPc })
+                    .min()
+            else { return false }
+
+            var breakpoint = breakpoint
+            breakpoint.reportedPc = pending
+            self.state = .stoppedAtBreakpoint(breakpoint)
+            return true
         }
 
         /// Resumes the module instantiated by the debugger stopped at a breakpoint. The breakpoint from which
@@ -344,7 +373,7 @@
 
             // Landing on a breakpoint the host set is a stop the host is waiting for.
             guard case .stoppedAtBreakpoint(let landed) = self.state,
-                !self.hostBreakpoints.contains(landed.wasmPc)
+                self.hostBreakpoints[landed.wasmPc] == nil
             else {
                 return
             }
@@ -431,16 +460,25 @@
         }
 
         /// Array of addresses in the Wasm binary of executed instructions on the call stack.
-        package var currentCallStack: [Int] {
+        package var currentCallStack: [Int] { self.callStack(atRunStart: false) }
+
+        /// ``currentCallStack`` with frames moved to the start of their instruction run.
+        package var reportedCallStack: [Int] { self.callStack(atRunStart: true) }
+
+        /// Wasm addresses of the frames on the stack, innermost first. Frames with no reverse
+        /// mapping are dropped.
+        private func callStack(atRunStart: Bool) -> [Int] {
             guard case .stoppedAtBreakpoint(let breakpoint) = self.state else {
                 return []
             }
 
-            var result = [breakpoint.wasmPc]
-            result.append(
-                contentsOf: Execution.captureBacktrace(sp: breakpoint.iseq.sp, store: self.store).symbols.compactMap {
-                    return self.instance.handle.instructionMapping.findWasm(forIseqAddress: $0.address)
-                })
+            let mapping = self.instance.handle.instructionMapping
+            var result = [atRunStart ? breakpoint.reportedPc : breakpoint.wasmPc]
+            for frame in Execution.CallStack(sp: breakpoint.iseq.sp) {
+                let wasm = atRunStart ? mapping.firstWasm(forIseqAddress: frame.pc) : mapping.findWasm(forIseqAddress: frame.pc)
+                guard let wasm else { continue }
+                result.append(wasm)
+            }
 
             return result
         }
@@ -458,7 +496,7 @@
         private mutating func clearStepBreakpoints() {
             let armedForStep = self.stepBreakpoints
             self.stepBreakpoints.removeAll()
-            for resolved in armedForStep where !self.hostBreakpoints.contains(resolved) {
+            for resolved in armedForStep where self.hostBreakpoints[resolved] == nil {
                 self.disarm(resolved: resolved)
             }
         }

--- a/Sources/WasmKit/Execution/DebuggerInstructionMapping.swift
+++ b/Sources/WasmKit/Execution/DebuggerInstructionMapping.swift
@@ -7,44 +7,48 @@ struct DebuggerInstructionMapping {
         /// Used for handling current call stack requests issued by a ``Debugger`` instance.
         private var iseqToWasm = [Pc: Int]()
 
+        /// Map from iseq Pc to the start of its instruction run.
+        private var iseqToCanonicalWasm = [Pc: Int]()
+
         /// Mapping from Wasm instruction addresses in the original binary to iseq instruction addresses.
         /// Used for handling breakpoint requests issued by a ``Debugger`` instance.
         private var wasmToIseq = [Int: Pc]()
 
-        /// Last iseq slot per wasm address. A call with args lowers to prep slots then the call, all
-        /// sharing one wasm address; `wasmToIseq` keeps the first (a prep slot), this keeps the call.
+        /// Last iseq slot emitted for a Wasm address when multiple instructions share an address.
         private var lastWasmToIseq = [Int: Pc]()
 
-        /// Wasm addresses sorted in ascending order for binary search when of the next closest mapped
-        /// instruction, when no key is found in `wasmToIseqMapping`.
+        /// Sorted emitting Wasm addresses for binary search when an address has no direct mapping.
         private var wasmMappings = [Int]()
 
-        mutating func add(wasm: Int, iseq: Pc) {
+        mutating func add(canonical: Int, emitting: Int, iseq: Pc) {
             // Don't override the existing mapping, only store a new pair if there's no mapping for a given key.
             if self.iseqToWasm[iseq] == nil {
-                self.iseqToWasm[iseq] = wasm
+                self.iseqToWasm[iseq] = emitting
             }
-            if self.wasmToIseq[wasm] == nil {
-                self.wasmToIseq[wasm] = iseq
+            if self.iseqToCanonicalWasm[iseq] == nil {
+                self.iseqToCanonicalWasm[iseq] = canonical
             }
-            self.lastWasmToIseq[wasm] = iseq
+            if self.wasmToIseq[emitting] == nil {
+                self.wasmToIseq[emitting] = iseq
+            }
+            self.lastWasmToIseq[emitting] = iseq
             // Insert in sorted order to maintain the binary search invariant.
             // With lazy compilation, functions may be compiled out of address order,
             // so simple append would break the sorted invariant.
-            if let last = self.wasmMappings.last, wasm > last {
+            if let last = self.wasmMappings.last, emitting > last {
                 // Fast path: appending in order (common within a single function)
-                self.wasmMappings.append(wasm)
-            } else if self.wasmMappings.last == wasm {
+                self.wasmMappings.append(emitting)
+            } else if self.wasmMappings.last == emitting {
                 // Duplicate of last entry, skip
             } else if self.wasmMappings.isEmpty {
-                self.wasmMappings.append(wasm)
+                self.wasmMappings.append(emitting)
             } else {
                 // Out-of-order insertion: find the sorted position
-                let insertionIndex = self.wasmMappings.firstIndex(where: { $0 >= wasm }) ?? self.wasmMappings.endIndex
-                if insertionIndex < self.wasmMappings.endIndex, self.wasmMappings[insertionIndex] == wasm {
+                let insertionIndex = self.wasmMappings.firstIndex(where: { $0 >= emitting }) ?? self.wasmMappings.endIndex
+                if insertionIndex < self.wasmMappings.endIndex, self.wasmMappings[insertionIndex] == emitting {
                     // Already present, skip
                 } else {
-                    self.wasmMappings.insert(wasm, at: insertionIndex)
+                    self.wasmMappings.insert(emitting, at: insertionIndex)
                 }
             }
         }
@@ -72,6 +76,11 @@ struct DebuggerInstructionMapping {
 
         func findWasm(forIseqAddress pc: Pc) -> Int? {
             self.iseqToWasm[pc]
+        }
+
+        /// Start of the Wasm instruction run sharing this slot.
+        func firstWasm(forIseqAddress pc: Pc) -> Int? {
+            self.iseqToCanonicalWasm[pc]
         }
 
         func lastIseq(forWasmAddress address: Int) -> Pc? {
@@ -113,5 +122,4 @@ struct DebuggerInstructionMapping {
             }
         }
     }
-
 #endif

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -958,13 +958,32 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
 
     // Wasm debugging support.
 
-    /// Current offset to an instruction in the original Wasm binary processed by this translator.
-    var binaryOffset: Int = 0
+    /// Current Wasm offset, updated for every instruction including non-emitting ones.
+    var binaryOffset: Int = 0 {
+        didSet {
+            #if WasmDebuggingSupport
+                guard self.module.isDebuggable else { return }
 
-    /// Mapping from `self.iseqBuilder.instructions` to Wasm instructions.
-    /// As mapping between iSeq to Wasm is many:many, but we only care about first mapping for overlapping address,
-    /// we need to iterate on it in the order the mappings were stored to ensure we don't overwrite the frist mapping.
-    var iseqToWasmMapping = [(iseq: Int, wasm: Int)]()
+                if self.hasEmittedSinceLastInstruction {
+                    self.currentRunStartWasm = self.binaryOffset
+                    self.hasEmittedSinceLastInstruction = false
+                } else if self.currentRunStartWasm == nil {
+                    self.currentRunStartWasm = self.binaryOffset
+                }
+            #endif
+        }
+    }
+
+    #if WasmDebuggingSupport
+        /// Start of the Wasm instruction run sharing the current bytecode slot.
+        var currentRunStartWasm: Int?
+
+        /// True if bytecode was emitted since the last instruction.
+        var hasEmittedSinceLastInstruction: Bool = false
+
+        /// Pending mappings from iseq bytecode offsets to their canonical and emitting Wasm addresses.
+        var iseqToWasmMapping = [(iseq: Int, canonical: Int, emitting: Int)]()
+    #endif
 
     init(
         allocator: ISeqAllocator,
@@ -1017,15 +1036,17 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
     }
 
     private mutating func emit(_ instruction: Instruction, resultRelink: ISeqBuilder.ResultRelink? = nil) {
-        self.updateInstructionMapping()
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emit(instruction, resultRelink: resultRelink)
+        self.updateInstructionMapping(from: oldPC)
     }
 
     @discardableResult
     private mutating func emitCopyStack(from source: VReg, to dest: VReg) -> Bool {
         guard source != dest else { return false }
-        self.updateInstructionMapping()
-        emit(.copyStack(Instruction.CopyStackOperand(source: LVReg(source), dest: LVReg(dest))))
+        let oldPC = iseqBuilder.insertingPC
+        iseqBuilder.emit(.copyStack(Instruction.CopyStackOperand(source: LVReg(source), dest: LVReg(dest))))
+        self.updateInstructionMapping(from: oldPC)
         return true
     }
 
@@ -1292,8 +1313,9 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             emit(.catchHandlersEnd(Instruction.CatchHandlersEndOperand(count: handlersToUnwind)))
         }
         try visitReturnLike()
-        self.updateInstructionMapping()
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emit(._return)
+        self.updateInstructionMapping(from: oldPC)
     }
     private mutating func markUnreachable() throws(WasmKitError) {
         try controlStack.markUnreachable()
@@ -1308,7 +1330,9 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         // Check dangling labels
         try iseqBuilder.assertDanglingLabels()
 
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emit(._return)
+        self.updateInstructionMapping(from: oldPC)
         let instructions = iseqBuilder.finalize()
         // TODO: Figure out a way to avoid the copy here while keeping the execution performance.
         let buffer = allocator.allocateInstructions(capacity: instructions.count)
@@ -1316,10 +1340,10 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         assert(initializedElementsIndex == instructions.endIndex)
 
         #if WasmDebuggingSupport
-            for (iseq, wasm) in self.iseqToWasmMapping {
+            for (iseq, canonical, emitting) in self.iseqToWasmMapping {
                 self.module.withValue {
                     let absoluteIseq = iseq + buffer.baseAddress.unsafelyUnwrapped
-                    $0.instructionMapping.add(wasm: wasm, iseq: absoluteIseq)
+                    $0.instructionMapping.add(canonical: canonical, emitting: emitting, iseq: absoluteIseq)
                 }
             }
         #endif
@@ -1332,12 +1356,15 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         )
     }
 
-    private mutating func updateInstructionMapping() {
-        // This is a hot path, so best to exclude the code altogether if the trait isn't enabled.
+    /// Maps the instruction head emitted at `oldPC`. Operand slots are omitted.
+    private mutating func updateInstructionMapping(from oldPC: MetaProgramCounter) {
         #if WasmDebuggingSupport
-            guard self.module.isDebuggable else { return }
+            guard self.module.isDebuggable, let canonical = self.currentRunStartWasm,
+                oldPC.offsetFromHead < self.iseqBuilder.insertingPC.offsetFromHead
+            else { return }
 
-            self.iseqToWasmMapping.append((self.iseqBuilder.insertingPC.offsetFromHead, self.binaryOffset))
+            self.iseqToWasmMapping.append((oldPC.offsetFromHead, canonical, self.binaryOffset))
+            self.hasEmittedSinceLastInstruction = true
         #endif
     }
 
@@ -1437,7 +1464,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             )
         )
         guard let condition = condition else { return }
-        self.updateInstructionMapping()
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emitWithLabel(Instruction.brIfNot, endLabel) { iseqBuilder, selfPC, endPC in
             let targetPC: MetaProgramCounter
             if let elsePC = iseqBuilder.resolveLabel(elseLabel) {
@@ -1448,6 +1475,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             let elseOrEnd = UInt32(targetPC.offsetFromHead - selfPC.offsetFromHead)
             return Instruction.BrIfOperand(condition: LVReg(condition), offset: Int32(elseOrEnd))
         }
+        self.updateInstructionMapping(from: oldPC)
     }
 
     mutating func visitElse() throws(WasmKitError) -> Output {
@@ -1459,11 +1487,12 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         try controlStack.resetReachability()
         iseqBuilder.resetLastEmission()
 
-        self.updateInstructionMapping()
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emitWithLabel(Instruction.br, endLabel) { _, selfPC, endPC in
             let offset = endPC.offsetFromHead - selfPC.offsetFromHead
             return Int32(offset)
         }
+        self.updateInstructionMapping(from: oldPC)
         for result in frame.blockType.results.reversed() {
             guard try checkBeforePop(typeHint: result, controlFrame: frame) else { continue }
             _ = try valueStack.pop(result)
@@ -1568,11 +1597,12 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             currentHeight: valueStack.slotHeight
         )
 
-        self.updateInstructionMapping()
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emitWithLabel(makeInstruction, frame.continuation) { _, selfPC, continuation in
             let relativeOffset = continuation.offsetFromHead - selfPC.offsetFromHead
             return make(Int32(relativeOffset), UInt32(copyCount), popCount)
         }
+        self.updateInstructionMapping(from: oldPC)
     }
     /// Emit `catchHandlersEnd` instructions for any `try_table` blocks that
     /// would be exited by branching to the given relative depth.
@@ -1614,13 +1644,14 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             guard let condition else { return }
             // Optimization where we don't need copying values when the branch taken
             // and no exception handlers need unwinding.
-            self.updateInstructionMapping()
+            let oldPC = iseqBuilder.insertingPC
             iseqBuilder.emitWithLabel(Instruction.brIf, frame.continuation) { _, selfPC, continuation in
                 let relativeOffset = continuation.offsetFromHead - selfPC.offsetFromHead
                 return Instruction.BrIfOperand(
                     condition: LVReg(condition), offset: Int32(relativeOffset)
                 )
             }
+            self.updateInstructionMapping(from: oldPC)
             return
         }
         preserveOnStack(depth: valueStack.valueHeight - frame.valueStackHeight)
@@ -1648,16 +1679,16 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             // [0x06] (local.get 1 reg:2) <----|---------+
             // [0x07] ...              <-------+
             let onBranchNotTaken = iseqBuilder.allocLabel()
-            self.updateInstructionMapping()
+            let oldPC = iseqBuilder.insertingPC
             iseqBuilder.emitWithLabel(Instruction.brIfNot, onBranchNotTaken) { _, conditionCheckAt, continuation in
                 let relativeOffset = continuation.offsetFromHead - conditionCheckAt.offsetFromHead
                 return Instruction.BrIfOperand(condition: LVReg(condition), offset: Int32(relativeOffset))
             }
+            self.updateInstructionMapping(from: oldPC)
             try copyOnBranch(targetFrame: frame)
             if handlersToUnwind > 0 {
                 emit(.catchHandlersEnd(Instruction.CatchHandlersEndOperand(count: handlersToUnwind)))
             }
-            self.updateInstructionMapping()
             try emitBranch(Instruction.br, relativeDepth: relativeDepth) { offset, copyCount, popCount in
                 return offset
             }
@@ -1684,8 +1715,9 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             baseAddress: tableBuffer.baseAddress!,
             count: UInt16(tableBuffer.count), index: index
         )
-        self.updateInstructionMapping()
+        let oldPC = iseqBuilder.insertingPC
         iseqBuilder.emit(.brTable(operand))
+        self.updateInstructionMapping(from: oldPC)
         let brTableAt = iseqBuilder.insertingPC
 
         //
@@ -1745,11 +1777,12 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
                 if handlersToUnwind > 0 {
                     emit(.catchHandlersEnd(Instruction.CatchHandlersEndOperand(count: handlersToUnwind)))
                 }
-                self.updateInstructionMapping()
+                let oldPC = iseqBuilder.insertingPC
                 iseqBuilder.emitWithLabel(Instruction.br, frame.continuation) { _, brAt, continuation in
                     let relativeOffset = continuation.offsetFromHead - brAt.offsetFromHead
                     return Int32(relativeOffset)
                 }
+                self.updateInstructionMapping(from: oldPC)
             } else {
                 // Optimization: If no value is copied and no handlers to unwind,
                 // we can directly jump to the target
@@ -1934,7 +1967,6 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         let catchTable = allocator.allocateCatchTable(capacity: tryCatch.catches.count)
 
         // Emit the catchHandlers instruction first so we know its PC position.
-        self.updateInstructionMapping()
         let operand = Instruction.CatchHandlersOperand(
             baseAddress: UnsafePointer(catchTable.baseAddress!),
             count: catchCount

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -251,6 +251,11 @@
             return argument
         }
 
+        /// Matches on the resolved address that caused the trap, rather than the reported address.
+        private func isStoppedAtUserBreakpoint(_ breakpoint: Debugger.BreakpointState) -> Bool {
+            self.userBreakpoints.contains { $0.value == breakpoint.wasmPc }
+        }
+
         var currentThreadStopInfo: GDBTargetResponse.Kind {
             get throws {
                 var result: [(String, String)] = [
@@ -259,16 +264,10 @@
                 ]
                 switch self.debugger.state {
                 case .stoppedAtBreakpoint(let breakpoint):
-                    let pc = breakpoint.wasmPc
-                    let userBreakpoint = self.userBreakpoints.first(where: { $0.value == pc })?.key
-                    // Report user-breakpoint stops at the address the host
-                    // requested, so it can attribute the stop to its
-                    // breakpoint even when the engine resolved the address
-                    // to the next emitted instruction.
-                    let reportedPc = UInt64(userBreakpoint ?? pc) + DebuggerMemoryView.executableCodeOffset
+                    let reportedPc = UInt64(breakpoint.reportedPc) + DebuggerMemoryView.executableCodeOffset
                     result.append(("thread-pcs", self.hexDump(reportedPc, endianness: .big)))
                     result.append(("00", self.hexDump(reportedPc, endianness: .little)))
-                    result.append(("reason", userBreakpoint != nil ? "breakpoint" : "trace"))
+                    result.append(("reason", self.isStoppedAtUserBreakpoint(breakpoint) ? "breakpoint" : "trace"))
                     return .keyValuePairs(result)
 
                 case .entrypointReturned(let values):
@@ -409,7 +408,7 @@
                 )
 
             case .wasmCallStack:
-                let callStack = self.debugger.currentCallStack
+                let callStack = self.debugger.reportedCallStack
                 var buffer = [UInt8]()
                 buffer.reserveCapacity(callStack.count * 8)
                 for pc in callStack {

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -76,6 +76,39 @@
                     kind: .insertSoftwareBreakpoint, arguments: "\(hostHex(wasmAddr)),1"))
         }
 
+        /// Frame addresses from a `qWasmCallStack` reply.
+        private func callStack(_ h: WasmKitGDBHandler) throws -> [Int] {
+            let reply = try h.handle(command: .init(kind: .wasmCallStack, arguments: ""))
+            guard case .hexEncodedBinary(let bytes) = reply.kind else {
+                Issue.record("expected a binary call stack reply, got \(reply.kind)")
+                return []
+            }
+            return stride(from: 0, to: bytes.count, by: 8).map { start in
+                let frame = bytes[start..<min(start + 8, bytes.count)]
+                return Int(frame.reversed().reduce(UInt64(0)) { ($0 << 8) | UInt64($1) } - offset)
+            }
+        }
+
+        /// Two requested addresses that resolve to the same bytecode slot. Both are raw byte offsets,
+        /// so the lower one is not necessarily the start of a Wasm instruction.
+        private func aliasingAddresses() throws -> (lower: Int, higher: Int) {
+            let bytes = try wat2wasm(Self.wat)
+            let module = try parseWasm(bytes: bytes)
+            let base = module.functions[1].code.originalAddress
+
+            var byResolved = [Int: [Int]]()
+            for delta in 0..<0x40 {
+                let requested = base + delta
+                guard let resolved = try? resolve(module: module, address: requested) else { continue }
+                byResolved[resolved, default: []].append(requested)
+            }
+            let group = try #require(
+                byResolved.values.filter({ $0.count > 1 }).min(by: { $0[0] < $1[0] }),
+                "no two addresses in the fixture resolve to one bytecode slot")
+            let sorted = group.sorted()
+            return (sorted[0], sorted[1])
+        }
+
         @Test
         func breakpointStopReportsBreakpointReasonAtRequestedAddress() throws {
             let (requested, resolved) = try divergentAddresses()
@@ -86,6 +119,77 @@
                 #expect(kv["reason"] == "breakpoint")
                 #expect(kv["thread-pcs"] == hostHex(requested))
                 #expect(kv["thread-pcs"] != hostHex(resolved))
+            }
+        }
+
+        @Test
+        func aliasedBreakpointsReportTheLowestRequestedAddress() throws {
+            let (lower, higher) = try aliasingAddresses()
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: lower)
+                try insert(h, at: higher)
+                let kv = pairs(try h.handle(command: .init(kind: .continue, arguments: "")))
+                #expect(kv["reason"] == "breakpoint")
+                #expect(kv["thread-pcs"] == hostHex(lower))
+            }
+        }
+
+        @Test
+        func stopReplyAndCallStackAgreeOnTheInnermostFrame() throws {
+            let (requested, _) = try divergentAddresses()
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: requested)
+                let kv = pairs(try h.handle(command: .init(kind: .continue, arguments: "")))
+                let frames = try callStack(h)
+                #expect(frames.first.map(hostHex) == kv["thread-pcs"])
+            }
+
+            let (lower, higher) = try aliasingAddresses()
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: lower)
+                try insert(h, at: higher)
+                let kv = pairs(try h.handle(command: .init(kind: .continue, arguments: "")))
+                let frames = try callStack(h)
+                #expect(frames.first.map(hostHex) == kv["thread-pcs"])
+            }
+        }
+
+        @Test
+        func stopWithoutABreakpointReportsTheRunStartNotTheEmittingInstruction() throws {
+            let module = try parseWasm(bytes: try wat2wasm(Self.wat))
+            let base = module.functions[1].code.originalAddress
+
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: base)
+                _ = try h.handle(command: .init(kind: .continue, arguments: ""))
+                _ = try h.handle(
+                    command: .init(kind: .removeSoftwareBreakpoint, arguments: "\(hostHex(base)),1"))
+                _ = try h.handle(command: .init(kind: .resumeThreads, arguments: "s:1"))
+
+                let kv = pairs(try h.handle(command: .init(kind: .threadStopInfo, arguments: "")))
+                let reported = try #require(try callStack(h).first)
+                #expect(kv["thread-pcs"] == hostHex(reported))
+                #expect(kv["reason"] == "trace")
+                #expect(try resolve(module: module, address: reported) > reported)
+            }
+        }
+
+        @Test
+        func aSecondBreakpointInOneRunIsAStopOfItsOwn() throws {
+            let (lower, higher) = try aliasingAddresses()
+            try withHandler(debugging: Self.wat) { h in
+                try insert(h, at: lower)
+                try insert(h, at: higher)
+
+                let first = pairs(try h.handle(command: .init(kind: .continue, arguments: "")))
+                #expect(first["reason"] == "breakpoint")
+                #expect(first["thread-pcs"] == hostHex(lower))
+
+                _ = try h.handle(command: .init(kind: .resumeThreads, arguments: "s:1"))
+                let second = pairs(try h.handle(command: .init(kind: .threadStopInfo, arguments: "")))
+                #expect(second["reason"] == "breakpoint")
+                #expect(second["thread-pcs"] == hostHex(higher))
+                #expect(try callStack(h).first == higher)
             }
         }
 

--- a/Tests/WasmKitTests/DebuggerTests.swift
+++ b/Tests/WasmKitTests/DebuggerTests.swift
@@ -1201,6 +1201,7 @@
             let module = try parseWasm(bytes: bytes)
             var debugger = try Debugger(module: module, store: store, imports: [:])
 
+            let requestedAddress = module.functions[1].code.originalAddress
             let breakpointAddress = try debugger.enableBreakpoint(
                 module: module,
                 function: 1
@@ -1210,8 +1211,8 @@
             #expect(try requireBreakpoint(debugger) == breakpointAddress)
 
             // Simulate lldb-dap breakpoint re-sync: remove then re-add
-            try debugger.disableBreakpoint(address: breakpointAddress)
-            try debugger.enableBreakpoint(address: breakpointAddress)
+            try debugger.disableBreakpoint(address: requestedAddress)
+            try debugger.enableBreakpoint(address: requestedAddress)
 
             // Should work fine after re-sync
             try debugger.step()
@@ -1221,7 +1222,7 @@
             try debugger.run()
             #expect(try requireBreakpoint(debugger) == breakpointAddress)
 
-            try debugger.disableBreakpoint(address: breakpointAddress)
+            try debugger.disableBreakpoint(address: requestedAddress)
             try debugger.runPreservingCurrentBreakpoint()
             let values = try requireReturned(debugger)
             #expect(values == [.i64(6)])


### PR DESCRIPTION
The translator only mapped instructions that emitted bytecode, skipping `local.get`, `i32.const`, and `block`. Stops mapped to the next emitted instruction instead, landing mid-statement and causing steps to overshoot. Track each bytecode slot's instruction run and report its start. Make `BreakpointState.reportedPc` the single source of truth so stop replies and `qWasmCallStack` agree.

The debugger disassembles from the run start, so it can set breakpoints on non-emitting instructions within the run. Because every instruction in a run shares one bytecode slot, track requested addresses per slot so they remain distinct, and report successive breakpoints on the same slot without resuming execution. Removing a breakpoint now requires the originally requested address.

Attribute stops by resolved address rather than reported address. If a breakpoint was set before code was compiled, it may have resolved to a later instruction. When that code is later compiled and stepped onto, matching on reported address falsely reported a breakpoint hit, causing LLDB to abort its step plan.