### PR TITLE
Bind breakpoint resolution to the containing function

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -72,9 +72,9 @@
         private var md: Md = nil
         private var ms: Ms = 0
 
-        /// Addresses of functions in the original Wasm binary, used for looking up functions when a breakpoint
-        /// is enabled at an arbitrary address if it isn't present in ``InstructionMapping`` yet (i.e. the
-        /// was not compiled yet in lazy compilation mode).
+        /// Starts of this instance's Wasm functions in the original binary, in ascending order,
+        /// paired with their indices. Excludes imported functions: their addresses are offsets
+        /// into the defining binary, not this one.
         private let functionAddresses: [(address: Int, instanceFunctionIndex: Int)]
 
         /// Reverse map from a head code slot to its opcode ID, used for resolving
@@ -106,10 +106,11 @@
             }
 
             self.instance = instance
-            self.functionAddresses = instance.handle.functions.enumerated().filter { $0.element.isWasm }.lazy.map {
+            self.functionAddresses = instance.handle.functions.enumerated().compactMap {
+                guard $0.element.isWasm, $0.element.wasm.instance == instance.handle else { return nil }
                 switch $0.element.wasm.code {
                 case .uncompiled(let wasm), .debuggable(let wasm, _):
-                    return (address: wasm.originalAddress, instanceFunctionIndex: $0.offset)
+                    return (address: wasm.originalBodyAddress, instanceFunctionIndex: $0.offset)
                 case .compiled:
                     fatalError()
                 }
@@ -155,21 +156,39 @@
             }
         }
 
+        /// The Wasm function containing `address` and the start of the next function. Uses the
+        /// module layout to support breakpoints in functions not yet compiled.
+        private func functionContaining(address: Int) -> (function: InternalFunction, upperBound: Int)? {
+            let following = self.functionAddresses.partitioningIndex { $0.address > address }
+            guard following > self.functionAddresses.startIndex else { return nil }
+
+            let entry = self.functionAddresses[following - 1]
+            let upperBound = following < self.functionAddresses.endIndex ? self.functionAddresses[following].address : Int.max
+            return (self.instance.handle.functions[entry.instanceFunctionIndex], upperBound)
+        }
+
         private func findIseq(forWasmAddress address: Int) throws -> (iseq: Pc, wasm: Int) {
-            if let (iseq, wasm) = self.instance.handle.instructionMapping.findIseq(forWasmAddress: address) {
-                return (iseq, wasm)
+            if let iseq = self.instance.handle.instructionMapping.iseq(forWasmAddress: address) {
+                return (iseq, address)
             }
 
-            let followingIndex = self.functionAddresses.firstIndex(where: { $0.address > address }) ?? self.functionAddresses.endIndex
-            let functionIndex = self.functionAddresses[followingIndex - 1].instanceFunctionIndex
-            let function = instance.handle.functions[functionIndex]
+            // Addresses that didn't emit bytecode slide forward to the next emitting instruction.
+            // This requires the containing function to be compiled and bounds the search.
+            guard let (function, upperBound) = self.functionContaining(address: address) else {
+                throw Error.noInstructionMappingAvailable(address)
+            }
             try function.wasm.ensureCompiled(store: StoreRef(self.store))
 
-            if let (iseq, wasm) = self.instance.handle.instructionMapping.findIseq(forWasmAddress: address) {
-                return (iseq, wasm)
+            guard
+                let resolved = self.instance.handle.instructionMapping.findIseq(
+                    forWasmAddress: address,
+                    before: upperBound
+                )
+            else {
+                throw Error.noInstructionMappingAvailable(address)
             }
 
-            throw Error.noInstructionMappingAvailable(address)
+            return resolved
         }
 
         /// Puts a breakpoint into the bytecode at an already resolved Wasm address, preserving the
@@ -335,10 +354,12 @@
             // Report any remaining breakpoints sharing this slot before resuming.
             guard !self.reportPendingHostBreakpoint(after: breakpoint) else { return }
 
+            // Clear step-specific breakpoints even if execution fails.
+            defer { self.clearStepBreakpoints() }
+
             try self.setNextInstructionBreakpoints(breakpoint: breakpoint)
             try self.run()
             self.clearStepBreakpoints()
-
             // Re-arm directly to avoid recording the resolved address as a new host request.
             if self.hostBreakpoints[breakpoint.wasmPc] != nil {
                 self.arm(resolved: breakpoint.wasmPc, iseq: breakpoint.iseq.pc)

--- a/Sources/WasmKit/Execution/DebuggerInstructionMapping.swift
+++ b/Sources/WasmKit/Execution/DebuggerInstructionMapping.swift
@@ -53,11 +53,20 @@ struct DebuggerInstructionMapping {
             }
         }
 
+        /// The bytecode slot for the Wasm instruction at exactly `address`, if it emitted any.
+        func iseq(forWasmAddress address: Int) -> Pc? {
+            self.wasmToIseq[address]
+        }
+
         /// Computes an address of WasmKit's iseq bytecode instruction that matches a given Wasm instruction address.
-        /// - Parameter address: the Wasm instruction to find a mapping for.
+        /// - Parameters:
+        ///   - address: the Wasm instruction to find a mapping for.
+        ///   - bound: Exclusive upper bound. Prevents resolving into a neighboring function.
         /// - Returns: A tuple with an address of found iseq instruction and the original Wasm instruction or next
         /// closest match if no direct match was found.
-        func findIseq(forWasmAddress address: Int) -> (iseq: Pc, wasm: Int)? {
+        func findIseq(forWasmAddress address: Int, before bound: Int) -> (iseq: Pc, wasm: Int)? {
+            guard address < bound else { return nil }
+
             // Look in the main mapping
             if let iseq = self.wasmToIseq[address] {
                 return (iseq, address)
@@ -65,6 +74,7 @@ struct DebuggerInstructionMapping {
 
             // If nothing found, find the closest Wasm address using binary search
             guard let nextAddress = self.wasmMappings.binarySearch(nextClosestTo: address),
+                nextAddress < bound,
                 // Look in the main mapping again with the next closest address if binary search produced anything
                 let iseq = self.wasmToIseq[nextAddress]
             else {
@@ -90,36 +100,32 @@ struct DebuggerInstructionMapping {
 }
 
 #if WasmDebuggingSupport
+    extension RandomAccessCollection {
+        /// Index of the first element for which `belongsInSecondPartition` is true, assuming
+        /// the collection is partitioned by that predicate.
+        func partitioningIndex(where belongsInSecondPartition: (Element) -> Bool) -> Index {
+            var low = self.startIndex
+            var high = self.endIndex
+            while low < high {
+                let middle = self.index(low, offsetBy: self.distance(from: low, to: high) / 2)
+                if belongsInSecondPartition(self[middle]) {
+                    high = middle
+                } else {
+                    low = self.index(after: middle)
+                }
+            }
+            return low
+        }
+    }
+
     extension [Int] {
         /// Uses binary search to find an element in `self` that's next closest to a given value.
         /// - Parameter value: the array element to search for or to use as a baseline when searching.
         /// - Returns: array element `result`, where `result - value` is the smallest possible, while
-        /// `result > value` also holds.
+        /// `result >= value` also holds.
         package func binarySearch(nextClosestTo value: Int) -> Int? {
-            switch self.count {
-            case 0:
-                return nil
-            default:
-                var slice = self[0..<self.count]
-                while let last = slice.last {
-                    guard last >= value else { return nil }
-
-                    let middle = slice.startIndex + (slice.endIndex - slice.startIndex) / 2
-                    guard middle > 0 else { break }
-
-                    if self[middle] < value {
-                        // Not found anything in the lower half, assigning higher half to `slice`.
-                        slice = slice[(middle + 1)..<slice.endIndex]
-                    } else if self[middle] > value && self[middle - 1] > value {
-                        // Not found anything in the higher half, assigning lower half to `slice`.
-                        slice = slice[slice.startIndex..<middle]
-                    } else {
-                        return self[middle]
-                    }
-                }
-
-                return self[slice.startIndex]
-            }
+            let index = self.partitioningIndex { $0 >= value }
+            return index < self.endIndex ? self[index] : nil
         }
     }
 #endif

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -1224,5 +1224,6 @@ extension InternalUncompiledCode {
     var expression: ArraySlice<UInt8> { withValue { $0.expression } }
     #if WasmDebuggingSupport
         var originalAddress: Int { withValue { $0.originalAddress } }
+        var originalBodyAddress: Int { withValue { $0.originalBodyAddress } }
     #endif
 }

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -455,8 +455,14 @@
                         separator: ",",
                         endianness: .big
                     ) - DebuggerMemoryView.executableCodeOffset)
-                self.userBreakpoints[requested] = try self.debugger.enableBreakpoint(address: requested)
-                responseKind = .ok
+                // Report refusal as a GDB error instead of throwing to keep the connection open.
+                do {
+                    self.userBreakpoints[requested] = try self.debugger.enableBreakpoint(address: requested)
+                    responseKind = .ok
+                } catch let error as Debugger.Error {
+                    logger.debug("refusing a breakpoint at \(requested): \(error)")
+                    responseKind = .string(Self.errorReply)
+                }
 
             case .removeSoftwareBreakpoint:
                 let requested = Int(
@@ -465,9 +471,14 @@
                         separator: ",",
                         endianness: .big
                     ) - DebuggerMemoryView.executableCodeOffset)
-                try self.debugger.disableBreakpoint(address: requested)
-                self.userBreakpoints[requested] = nil
-                responseKind = .ok
+                do {
+                    try self.debugger.disableBreakpoint(address: requested)
+                    self.userBreakpoints[requested] = nil
+                    responseKind = .ok
+                } catch let error as Debugger.Error {
+                    logger.debug("refusing to remove a breakpoint at \(requested): \(error)")
+                    responseKind = .string(Self.errorReply)
+                }
 
             case .wasmLocal:
                 let arguments = command.arguments.split(separator: ";")

--- a/Sources/WasmParser/WasmParser.swift
+++ b/Sources/WasmParser/WasmParser.swift
@@ -1019,7 +1019,7 @@ extension Parser {
             codes.append(
                 Code(
                     locals: locals, expression: expressionBytes,
-                    offset: expressionStart, features: features
+                    offset: expressionStart, bodyOffset: bodyStart, features: features
                 )
             )
         }

--- a/Sources/WasmParser/WasmTypes.swift
+++ b/Sources/WasmParser/WasmTypes.swift
@@ -13,17 +13,24 @@ public struct Code: Sendable {
     @usableFromInline
     internal let offset: Int
     @usableFromInline
+    internal let bodyOffset: Int
+    @usableFromInline
     internal let features: WasmFeatureSet
 
     #if WasmDebuggingSupport
         package var originalAddress: Int { self.offset }
+
+        /// Start of the function body (locals declaration). DWARF's `DW_AT_low_pc` typically
+        /// points here.
+        package var originalBodyAddress: Int { self.bodyOffset }
     #endif
 
     @inlinable
-    init(locals: [ValueType], expression: ArraySlice<UInt8>, offset: Int, features: WasmFeatureSet) {
+    init(locals: [ValueType], expression: ArraySlice<UInt8>, offset: Int, bodyOffset: Int, features: WasmFeatureSet) {
         self.locals = locals
         self.expression = expression
         self.offset = offset
+        self.bodyOffset = bodyOffset
         self.features = features
     }
 }

--- a/Tests/WasmKitTests/DebuggerTests.swift
+++ b/Tests/WasmKitTests/DebuggerTests.swift
@@ -320,6 +320,46 @@
         )
         """
 
+    /// Two callees; the first is called before the second.
+    private let twoCalleesWAT = """
+        (module
+          (func (export "_start") (result i32)
+            (call $first)
+            (drop)
+            (call $second))
+          (func $first (result i32)
+            (i32.const 1)
+            (i32.const 2)
+            (i32.add))
+          (func $second (result i32)
+            (i32.const 42))
+        )
+        """
+
+    /// Library export padded to an address exceeding `importingModuleWAT`.
+    private let paddedLibraryWAT = """
+        (module
+          (func $pad \(String(repeating: "(nop)", count: 200)))
+          (func (export "helper") (result i32)
+            (i32.const 7))
+        )
+        """
+
+    /// Imports a function from another binary to test address resolution with imports.
+    private let importingModuleWAT = """
+        (module
+          (import "lib" "helper" (func $helper (result i32)))
+          (func (export "_start") (result i32)
+            (call $helper)
+            (drop)
+            (call $own))
+          (func $own (result i32)
+            (i32.const 1)
+            (i32.const 2)
+            (i32.add))
+        )
+        """
+
     /// Asserts the debugger is stopped at a breakpoint, returning the wasm PC.
     @discardableResult
     private func requireBreakpoint(
@@ -1324,6 +1364,103 @@
             try debugger.run()
             let values = try requireReturned(debugger)
             #expect(values == [.i32(2)])
+        }
+
+        // MARK: - address resolution across lazy compilation
+
+        /// Addresses that didn't emit bytecode slide forward to the next emitting instruction.
+        /// Verify the slide is bounded to the containing function.
+        @Test
+        func aBreakpointResolvesInsideTheFunctionThatContainsIt() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(twoCalleesWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            // Compile the later function first, so that the earlier one has something above it to
+            // slide into.
+            _ = try debugger.enableBreakpoint(module: module, function: 2)
+            let firstBp = try debugger.enableBreakpoint(module: module, function: 1)
+
+            #expect(firstBp >= module.functions[1].code.originalAddress)
+            #expect(firstBp < module.functions[2].code.originalBodyAddress)
+
+            // `$first` is called first, so that is where execution has to stop.
+            try debugger.run()
+            #expect(try requireBreakpoint(debugger) == firstBp)
+        }
+
+        /// DWARF's `DW_AT_low_pc` typically points to the locals declaration. Verify that a
+        /// breakpoint there resolves into the function it starts.
+        @Test
+        func aBreakpointAtAFunctionsStartResolvesIntoIt() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(twoCalleesWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            // Compile `$second` first, so the address has something above it to slide into.
+            _ = try debugger.enableBreakpoint(module: module, function: 2)
+            let firstBp = try debugger.enableBreakpoint(address: module.functions[1].code.originalBodyAddress)
+
+            #expect(firstBp >= module.functions[1].code.originalAddress)
+            #expect(firstBp < module.functions[2].code.originalBodyAddress)
+        }
+
+        /// Verify that an address past every instruction in a function does not resolve into
+        /// the next function.
+        @Test
+        func anAddressPastItsFunctionDoesNotResolveIntoTheNext() throws {
+            let store = Store(engine: Engine())
+            let bytes = try wat2wasm(twoCalleesWAT)
+            let module = try parseWasm(bytes: bytes)
+            var debugger = try Debugger(module: module, store: store, imports: [:])
+
+            // The size prefix of `$second`'s code entry: still within `$first`'s range, and past
+            // every instruction it has.
+            let past = module.functions[2].code.originalBodyAddress - 1
+            // Compile `$second` so there is something above the address to slide into.
+            _ = try debugger.enableBreakpoint(module: module, function: 2)
+
+            #expect {
+                try debugger.enableBreakpoint(address: past)
+            } throws: { error in
+                guard let error = error as? Debugger.Error,
+                    case .noInstructionMappingAvailable(let refused) = error
+                else { return false }
+                return refused == past
+            }
+        }
+
+        /// Imported function addresses are offsets into their defining binary. Verify they
+        /// do not displace this module's own addresses.
+        @Test
+        func anImportedFunctionDoesNotDisplaceThisModulesAddresses() throws {
+            let store = Store(engine: Engine())
+            let libModule = try parseWasm(bytes: try wat2wasm(paddedLibraryWAT))
+            let module = try parseWasm(bytes: try wat2wasm(importingModuleWAT))
+
+            // What makes the import's address misleading: it lies above everything in the module
+            // that imports it.
+            #expect(libModule.functions[1].code.originalBodyAddress > module.functions[1].code.originalBodyAddress)
+
+            let libInstance = try libModule.instantiate(store: store)
+            guard case .function(let helper) = libInstance.exports["helper"] else {
+                Issue.record("expected the library to export `helper`")
+                return
+            }
+            var imports = Imports()
+            imports.define(module: "lib", name: "helper", helper)
+
+            var debugger = try Debugger(module: module, store: store, imports: imports)
+            let bp = try debugger.enableBreakpoint(module: module, function: 1)
+
+            try debugger.run()
+            #expect(try requireBreakpoint(debugger) == bp)
+
+            // Stepping resolves through the same addresses.
+            try debugger.step()
+            #expect(try requireBreakpoint(debugger) > bp)
         }
     }
 


### PR DESCRIPTION
An address with no bytecode of its own slides forward to the next mapped instruction. Previously, this slide was unbounded: an address past the final instruction in a function resolved to the subsequent function, placing the breakpoint in an unexpected location. Bind the search to the start of the following function and refuse the address when no match is found.

Address two issues that prevented the function layout from accurately describing the module:

- Imported functions contribute addresses that are offsets into their defining binary, displacing the module's own functions in the sorted list. Skip imported functions.
- Functions were keyed by their code entry offset, which precedes the size prefix. Because DWARF's `DW_AT_low_pc` points at the locals declaration, record that offset as well and key on it.

Update the GDB handler to return an error reply for refused breakpoints instead of throwing, which drops the connection.