### PR TITLE
Support writing guest linear memory

### DIFF
--- a/Sources/GDBRemoteProtocol/GDBHostCommand.swift
+++ b/Sources/GDBRemoteProtocol/GDBHostCommand.swift
@@ -38,6 +38,7 @@ package struct GDBHostCommand: Equatable {
         case transfer
         case readMemoryBinaryData
         case readMemory
+        case writeMemory
         case wasmCallStack
         case threadStopInfo
         case symbolLookup
@@ -148,6 +149,11 @@ package struct GDBHostCommand: Equatable {
         .init(
             kind: .readMemory,
             prefix: "m"
+        ),
+        .init(
+            kind: .writeMemory,
+            prefix: "M",
+            argumentsContainColonDelimiter: true
         ),
         .init(
             kind: .insertSoftwareBreakpoint,

--- a/Sources/GDBRemoteProtocol/GDBTargetResponse.swift
+++ b/Sources/GDBRemoteProtocol/GDBTargetResponse.swift
@@ -43,6 +43,9 @@ package struct GDBTargetResponse {
         /// Binary buffer hex-encoded in the response.
         case hexEncodedBinary([UInt8])
 
+        /// Standard `E<nn>` error response carrying an error number.
+        case error(UInt8)
+
         /// Standard empty response (no content is sent).
         case empty
     }

--- a/Sources/GDBRemoteProtocol/GDBTargetResponseEncoder.swift
+++ b/Sources/GDBRemoteProtocol/GDBTargetResponseEncoder.swift
@@ -58,6 +58,9 @@ package final class GDBTargetResponseEncoder {
             self.logger.trace("GDBTargetResponseEncoder encoded a response: \(hexDumpResponse)")
             out.append(contentsOf: hexDumpResponse.utf8)
 
+        case .error(let number):
+            out.append(contentsOf: "E\(HexEncoding.encodeByteUppercase(number))".appendedChecksum.utf8)
+
         case .empty:
             out.append(contentsOf: "".appendedChecksum.utf8)
         }

--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -21,7 +21,7 @@
 
         package enum Error: Swift.Error, @unchecked Sendable {
             case entrypointFunctionNotFound
-            case unknownCurrentFunctionForResumedBreakpoint(UnsafeMutablePointer<UInt64>)
+            case unknownCurrentFunctionAtBreakpoint(UnsafeMutablePointer<UInt64>)
             case noInstructionMappingAvailable(Int)
             case noReverseInstructionMappingAvailable(UnsafeMutablePointer<UInt64>)
             case stackFrameIndexOOB(UInt)
@@ -30,7 +30,7 @@
             case globalUnsupportedType(UInt)
             case notStoppedAtBreakpoint
             case linearMemoryNotInitialized
-            case linearMemoryOOB(Range<Int>)
+            case linearMemoryOOB(address: UInt, length: UInt)
         }
 
         private let valueStack: Sp
@@ -71,6 +71,7 @@
 
         private var md: Md = nil
         private var ms: Ms = 0
+        private var linearMemoryByteCount = 0
 
         /// Starts of this instance's Wasm functions in the original binary, in ascending order,
         /// paired with their indices. Excludes imported functions: their addresses are offsets
@@ -279,16 +280,6 @@
                     var sp = iseq.sp
                     var pc = iseq.pc
 
-                    guard let currentFunction = sp.currentFunction else {
-                        throw Error.unknownCurrentFunctionForResumedBreakpoint(sp)
-                    }
-
-                    Execution.CurrentMemory.mayUpdateCurrentInstance(
-                        instance: currentFunction.instance,
-                        md: &md,
-                        ms: &ms
-                    )
-
                     do {
                         switch self.threadingModel {
                         case .direct:
@@ -337,6 +328,17 @@
                         reportedPc: self.hostBreakpoints[wasmPc]?.min() ?? mapping.firstWasm(forIseqAddress: pc) ?? wasmPc
                     )
                 )
+
+                guard let currentFunction = breakpoint.sp.currentFunction else {
+                    throw Error.unknownCurrentFunctionAtBreakpoint(breakpoint.sp)
+                }
+                Execution.CurrentMemory.mayUpdateCurrentInstance(
+                    instance: currentFunction.instance,
+                    md: &self.md,
+                    ms: &self.ms
+                )
+                // ms may include uncommitted guard pages that fault outside the trap guard.
+                self.linearMemoryByteCount = currentFunction.instance.memories.first?.byteCount ?? 0
             }
         }
 
@@ -420,7 +422,7 @@
                 }
 
                 guard let currentFunction = frame.sp.currentFunction else {
-                    throw Debugger.Error.unknownCurrentFunctionForResumedBreakpoint(frame.sp)
+                    throw Debugger.Error.unknownCurrentFunctionAtBreakpoint(frame.sp)
                 }
 
                 try currentFunction.ensureCompiled(store: StoreRef(store))
@@ -464,20 +466,30 @@
         }
 
         package func readLinearMemory<T>(address: UInt, length: UInt, reader: (UnsafeRawBufferPointer) -> T) throws(Error) -> T {
-            guard let md, ms > 0 else {
+            let range = try self.linearMemoryRange(address: address, length: length)
+            let memory = UnsafeRawBufferPointer(start: self.md, count: self.linearMemoryByteCount)
+
+            return reader(UnsafeRawBufferPointer(rebasing: memory[range]))
+        }
+
+        package mutating func writeLinearMemory(address: UInt, bytes: some Collection<UInt8>) throws(Error) {
+            let range = try self.linearMemoryRange(address: address, length: UInt(bytes.count))
+            let memory = UnsafeMutableRawBufferPointer(start: self.md, count: self.linearMemoryByteCount)
+
+            UnsafeMutableRawBufferPointer(rebasing: memory[range]).copyBytes(from: bytes)
+        }
+
+        private func linearMemoryRange(address: UInt, length: UInt) throws(Error) -> Range<Int> {
+            guard self.md != nil, self.linearMemoryByteCount > 0 else {
                 throw Error.linearMemoryNotInitialized
             }
 
-            let upperBound = address + length
-            let range = Int(address)..<Int(upperBound)
-
-            guard address + length < ms else {
-                throw Error.linearMemoryOOB(range)
+            let (upperBound, overflowed) = address.addingReportingOverflow(length)
+            guard !overflowed, upperBound <= UInt(self.linearMemoryByteCount) else {
+                throw Error.linearMemoryOOB(address: address, length: length)
             }
 
-            let memory = UnsafeRawBufferPointer(start: md, count: ms)
-
-            return reader(UnsafeRawBufferPointer(rebasing: memory[range]))
+            return Int(address)..<Int(upperBound)
         }
 
         /// Array of addresses in the Wasm binary of executed instructions on the call stack.

--- a/Sources/WasmKitGDBHandler/DebuggerMemoryView.swift
+++ b/Sources/WasmKitGDBHandler/DebuggerMemoryView.swift
@@ -25,6 +25,14 @@
 
         package static let executableCodeOffset = objectSpaceTag | (moduleInstanceID << 32)
 
+        package enum Error: Swift.Error {
+            /// The module image mapped at ``executableCodeOffset`` is read-only.
+            case codeIsNotWritable(UInt64)
+
+            /// The address exceeds the target's pointer width.
+            case addressNotRepresentable(UInt64)
+        }
+
         /// WebAssembly binary loaded into memory for execution
         /// and for disassembly by the debugger.
         private let wasmBinary: [UInt8]
@@ -53,6 +61,21 @@
             }
         }
 
+        package func writeMemory(
+            debugger: inout Debugger,
+            addressInProtocolSpace: UInt64,
+            bytes: some Collection<UInt8>
+        ) throws {
+            guard addressInProtocolSpace < Self.executableCodeOffset else {
+                throw Error.codeIsNotWritable(addressInProtocolSpace)
+            }
+
+            guard let address = UInt(exactly: addressInProtocolSpace) else {
+                throw Error.addressNotRepresentable(addressInProtocolSpace)
+            }
+
+            try debugger.writeLinearMemory(address: address, bytes: bytes)
+        }
     }
 
 #endif

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -81,6 +81,7 @@
         package enum Error: Swift.Error {
             case unknownTransferArguments
             case unknownReadMemoryArguments
+            case unknownWriteMemoryArguments(String)
             case stoppingAtEntrypointFailed
             case multipleThreadsNotSupported
             case unknownThreadAction(String)
@@ -99,7 +100,10 @@
 
         /// Generic error reply. `QEnableErrorStrings` is unsupported, so a bare code is
         /// the only way to refuse a request the target understands but cannot answer.
-        private static let errorReply = "E45"
+        private static let errorReply = GDBTargetResponse.Kind.error(0x45)
+
+        /// Error code for refused memory writes, matching debugserver.
+        private static let memoryWriteFailed: UInt8 = 0x09
 
         private var memoryView: DebuggerMemoryView
         /// User-set breakpoints, keyed by the address the debugger host
@@ -251,6 +255,22 @@
             return argument
         }
 
+        private static func writeMemoryArguments(_ arguments: String) throws -> (addressInProtocolSpace: UInt64, bytes: [UInt8]) {
+            let addressAndRest = arguments.split(separator: ",", maxSplits: 1)
+            guard addressAndRest.count == 2,
+                let addressInProtocolSpace = UInt64(hexEncoded: addressAndRest[0])
+            else { throw Error.unknownWriteMemoryArguments(arguments) }
+
+            let lengthAndBytes = addressAndRest[1].split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard lengthAndBytes.count == 2,
+                let length = Int(hexEncoded: lengthAndBytes[0]),
+                let bytes = HexEncoding.decode(lengthAndBytes[1]),
+                bytes.count == length
+            else { throw Error.unknownWriteMemoryArguments(arguments) }
+
+            return (addressInProtocolSpace, bytes)
+        }
+
         /// Matches on the resolved address that caused the trap, rather than the reported address.
         private func isStoppedAtUserBreakpoint(_ breakpoint: Debugger.BreakpointState) -> Bool {
             self.userBreakpoints.contains { $0.value == breakpoint.wasmPc }
@@ -374,7 +394,7 @@
                         ("generic", "pc"),
                     ])
                 } else {
-                    responseKind = .string(Self.errorReply)
+                    responseKind = Self.errorReply
                 }
 
             case .transfer:
@@ -406,6 +426,20 @@
                         length: length
                     )
                 )
+
+            case .writeMemory:
+                do {
+                    let (addressInProtocolSpace, bytes) = try Self.writeMemoryArguments(command.arguments)
+                    try self.memoryView.writeMemory(
+                        debugger: &self.debugger,
+                        addressInProtocolSpace: addressInProtocolSpace,
+                        bytes: bytes
+                    )
+                    responseKind = .ok
+                } catch {
+                    logger.debug("memory write `\(command.arguments)` failed: \(error)")
+                    responseKind = .error(Self.memoryWriteFailed)
+                }
 
             case .wasmCallStack:
                 let callStack = self.debugger.reportedCallStack
@@ -461,7 +495,7 @@
                     responseKind = .ok
                 } catch let error as Debugger.Error {
                     logger.debug("refusing a breakpoint at \(requested): \(error)")
-                    responseKind = .string(Self.errorReply)
+                    responseKind = Self.errorReply
                 }
 
             case .removeSoftwareBreakpoint:
@@ -477,7 +511,7 @@
                     responseKind = .ok
                 } catch let error as Debugger.Error {
                     logger.debug("refusing to remove a breakpoint at \(requested): \(error)")
-                    responseKind = .string(Self.errorReply)
+                    responseKind = Self.errorReply
                 }
 
             case .wasmLocal:
@@ -504,7 +538,7 @@
                 // space, so a request naming another instance is refused rather than
                 // answered from this one.
                 if let instance = request.instance, instance != DebuggerMemoryView.moduleInstanceID {
-                    responseKind = .string(Self.errorReply)
+                    responseKind = Self.errorReply
                 } else {
                     responseKind = .hexEncodedBinary(
                         try self.debugger.getGlobal(index: request.globalIndex).littleEndianBytes

--- a/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
+++ b/Tests/GDBRemoteProtocolTests/GDBRemoteProtocolTests.swift
@@ -105,11 +105,22 @@ struct GDBRemoteProtocolTests {
     }
 
     @Test
+    func decodingWriteMemory() throws {
+        var decoder = self.decoder
+        decoder.feed(Array("+$M1000,2:beef#38".utf8))
+        let packet = try decoder.next()
+        #expect(packet?.payload.kind == .writeMemory)
+        #expect(packet?.payload.arguments == "1000,2:beef")
+    }
+
+    @Test
     func encodingRoundTrip() {
         let encoder = GDBTargetResponseEncoder(logger: .disabled)
         let ok = encoder.encode(data: .init(kind: .ok, isNoAckModeActive: false))
         #expect(String(decoding: ok, as: UTF8.self) == "+$OK#9a")
         let binary = encoder.encode(data: .init(kind: .hexEncodedBinary([0xDE, 0xAD]), isNoAckModeActive: false))
         #expect(String(decoding: binary, as: UTF8.self) == "+$dead#8E")
+        let error = encoder.encode(data: .init(kind: .error(0x09), isNoAckModeActive: false))
+        #expect(String(decoding: error, as: UTF8.self) == "+$E09#AE")
     }
 }

--- a/Tests/WasmKitGDBHandlerTests/MemoryWriteTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/MemoryWriteTests.swift
@@ -1,0 +1,121 @@
+#if WasmDebuggingSupport
+
+    import GDBRemoteProtocol
+    import Testing
+    import WAT
+    import WasmKitWASI
+
+    @testable import WasmKit
+    @testable import WasmKitGDBHandler
+
+    @Suite
+    struct MemoryWriteTests {
+        /// Exits with byte 0 to observe guest memory directly.
+        static let wat = """
+            (module
+              (memory 1)
+              (data (i32.const 0) "hello")
+              (func (export "_start") (result i32)
+                (i32.load8_u (i32.const 0))))
+            """
+
+        private func write(_ handler: WasmKitGDBHandler, at address: UInt64, _ bytes: [UInt8]) throws -> GDBTargetResponse.Kind {
+            try handler.handle(
+                command: .init(
+                    kind: .writeMemory,
+                    arguments: "\(String(address, radix: 16)),\(String(bytes.count, radix: 16)):\(HexEncoding.encode(bytes))"
+                )
+            ).kind
+        }
+
+        private func read(_ handler: WasmKitGDBHandler, at address: UInt64, count: Int) throws -> [UInt8] {
+            let response = try handler.handle(
+                command: .init(
+                    kind: .readMemory,
+                    arguments: "\(String(address, radix: 16)),\(String(count, radix: 16))"
+                )
+            )
+            guard case .hexEncodedBinary(let bytes) = response.kind else { return [] }
+            return bytes
+        }
+
+        private func isOK(_ kind: GDBTargetResponse.Kind) -> Bool {
+            if case .ok = kind { return true }
+            return false
+        }
+
+        private func isRefusal(_ kind: GDBTargetResponse.Kind) -> Bool {
+            if case .error = kind { return true }
+            return false
+        }
+
+        @Test
+        func writtenBytesReadBack() throws {
+            try withHandler(debugging: Self.wat) { handler in
+                let accepted = try self.write(handler, at: 1, [0x41, 0x42])
+                #expect(self.isOK(accepted))
+
+                let readBack = try self.read(handler, at: 0, count: 5)
+                #expect(readBack == Array("hABlo".utf8))
+            }
+        }
+
+        @Test
+        func theGuestSeesAWrittenByte() throws {
+            try withHandler(debugging: Self.wat) { handler in
+                let accepted = try self.write(handler, at: 0, [0x5a])
+                #expect(self.isOK(accepted))
+
+                guard case .string(let reply) = try handler.handle(command: .init(kind: .continue, arguments: "")).kind else {
+                    Issue.record("resuming did not report an exit")
+                    return
+                }
+                #expect(reply == "W5a")
+            }
+        }
+
+        @Test
+        func writingToTheCodeAddressRangeIsRefused() throws {
+            try withHandler(debugging: Self.wat) { handler in
+                let refused = try self.write(handler, at: DebuggerMemoryView.executableCodeOffset, [0x00])
+                #expect(self.isRefusal(refused))
+            }
+        }
+
+        @Test
+        func aRefusedWriteLeavesTheTargetUsable() throws {
+            try withHandler(debugging: Self.wat) { handler in
+                let refused = try self.write(handler, at: 1 << 40, [0x00])
+                #expect(self.isRefusal(refused))
+
+                let accepted = try self.write(handler, at: 0, [0x48])
+                #expect(self.isOK(accepted))
+
+                let readBack = try self.read(handler, at: 0, count: 1)
+                #expect(readBack == [0x48])
+            }
+        }
+
+        @Test
+        func aLengthDisagreeingWithThePayloadIsRefused() throws {
+            try withHandler(debugging: Self.wat) { handler in
+                let response = try handler.handle(command: .init(kind: .writeMemory, arguments: "0,4:4142"))
+                #expect(self.isRefusal(response.kind))
+
+                let unchanged = try self.read(handler, at: 0, count: 1)
+                #expect(unchanged == [0x68])
+            }
+        }
+
+        @Test
+        func aLengthThatOverflowsTheAddressSpaceIsRefused() throws {
+            try withHandler(debugging: Self.wat) { handler in
+                #expect(throws: Debugger.Error.self) {
+                    _ = try handler.handle(command: .init(kind: .readMemory, arguments: "0,ffffffffffffffff"))
+                }
+                return
+            }
+        }
+    }
+
+#endif

--- a/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/WasmKitGDBHandlerTests.swift
@@ -357,11 +357,10 @@
                 let unknown = DebuggerMemoryView.moduleInstanceID + 1
                 let resp = try h.handle(
                     command: .init(kind: .wasmGlobal, arguments: "0;instance:\(unknown);"))
-                guard case .string(let reply) = resp.kind else {
+                guard case .error = resp.kind else {
                     Issue.record("expected an error reply, got \(resp.kind)")
                     return
                 }
-                #expect(reply.hasPrefix("E"))
             }
         }
 


### PR DESCRIPTION
Add support for the GDB remote `M` packet to allow hosts to write to guest linear memory. Refusals (such as writes to the read-only code range or malformed packets) return an error response (`E09`) instead of terminating the connection.

Unify and correct linear memory bounds checking for reads and writes: guard against arithmetic overflow on the upper bound, include the final byte, and bound against committed memory rather than the shared memory reservation size.

Update linear memory pointers on stop rather than on resume so memory is accessible for host inspection at the initial stop.