### PR TITLE
Answer `qMemoryRegionInfo` with the region containing an address

### DIFF
--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -71,7 +71,9 @@
 
         private var md: Md = nil
         private var ms: Ms = 0
-        private var linearMemoryByteCount = 0
+
+        /// Bytes of linear memory the guest can see, zero before a stop has bound any.
+        package private(set) var linearMemoryByteCount = 0
 
         /// Starts of this instance's Wasm functions in the original binary, in ascending order,
         /// paired with their indices. Excludes imported functions: their addresses are offsets

--- a/Sources/WasmKitGDBHandler/DebuggerMemoryView.swift
+++ b/Sources/WasmKitGDBHandler/DebuggerMemoryView.swift
@@ -31,6 +31,9 @@
 
             /// The address exceeds the target's pointer width.
             case addressNotRepresentable(UInt64)
+
+            /// The address lies outside every mapped region.
+            case addressUnmapped(UInt64)
         }
 
         /// WebAssembly binary loaded into memory for execution
@@ -41,21 +44,35 @@
             self.wasmBinary = wasmBinary
         }
 
+        /// The bytes at `addressInProtocolSpace`, narrowed to the end of the region containing it.
         package func readMemory(
             debugger: borrowing Debugger,
             addressInProtocolSpace: UInt64,
             length: UInt
-        ) throws(Debugger.Error) -> [UInt8] {
+        ) throws -> [UInt8] {
+            // An empty read touches nothing, so it needs no mapping to answer.
+            guard length > 0 else { return [] }
+
             if addressInProtocolSpace >= Self.executableCodeOffset {
-                var length = Int(length)
-                let codeAddress = Int(addressInProtocolSpace - Self.executableCodeOffset)
-                if codeAddress + length > wasmBinary.count {
-                    length = wasmBinary.count - codeAddress
+                let codeAddress = addressInProtocolSpace - Self.executableCodeOffset
+                guard codeAddress < UInt64(wasmBinary.count) else {
+                    throw Error.addressUnmapped(addressInProtocolSpace)
                 }
 
-                return Array(wasmBinary[codeAddress..<(codeAddress + length)])
+                let start = Int(codeAddress)
+                let count = Int(min(UInt64(length), UInt64(wasmBinary.count - start)))
+                return Array(wasmBinary[start..<(start + count)])
             } else {
-                return try debugger.readLinearMemory(address: UInt(addressInProtocolSpace), length: length) {
+                guard let address = UInt(exactly: addressInProtocolSpace) else {
+                    throw Error.addressNotRepresentable(addressInProtocolSpace)
+                }
+
+                let mapped = UInt(debugger.linearMemoryByteCount)
+                guard address < mapped else {
+                    throw Error.addressUnmapped(addressInProtocolSpace)
+                }
+
+                return try debugger.readLinearMemory(address: address, length: min(length, mapped - address)) {
                     Array($0)
                 }
             }
@@ -75,6 +92,58 @@
             }
 
             try debugger.writeLinearMemory(address: address, bytes: bytes)
+        }
+
+        /// A range of the address space a debugger host sees, mapped or not.
+        package struct MemoryRegion {
+            package let start: UInt64
+            package let size: UInt64
+
+            /// Nil when unmapped: the protocol omits the key for unmapped regions.
+            package let permissions: String?
+            package let name: String?
+        }
+
+        /// Linear memory is bounded by what the guest can see, not the underlying reservation,
+        /// because access beyond it faults instead of trapping.
+        private func mappedRegions(debugger: borrowing Debugger) -> [MemoryRegion] {
+            [
+                MemoryRegion(
+                    start: 0,
+                    size: UInt64(debugger.linearMemoryByteCount),
+                    permissions: "rw",
+                    name: "memory"
+                ),
+                MemoryRegion(
+                    start: Self.executableCodeOffset,
+                    size: UInt64(self.wasmBinary.count),
+                    permissions: "rx",
+                    name: "module"
+                ),
+            ].filter { $0.size > 0 }
+        }
+
+        /// The region containing `addressInProtocolSpace`. Unmapped regions span to the next
+        /// mapped region or the top of the address space.
+        package func memoryRegion(
+            debugger: borrowing Debugger,
+            containing addressInProtocolSpace: UInt64
+        ) -> MemoryRegion {
+            let mapped = self.mappedRegions(debugger: debugger)
+
+            if let region = mapped.first(where: {
+                addressInProtocolSpace >= $0.start && addressInProtocolSpace - $0.start < $0.size
+            }) {
+                return region
+            }
+
+            let next = mapped.lazy.map(\.start).filter { $0 > addressInProtocolSpace }.min()
+            return MemoryRegion(
+                start: addressInProtocolSpace,
+                size: (next ?? UInt64.max) - addressInProtocolSpace,
+                permissions: nil,
+                name: nil
+            )
         }
     }
 

--- a/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
+++ b/Sources/WasmKitGDBHandler/WasmKitGDBHandler.swift
@@ -17,14 +17,18 @@
     import WasmKit
     import WasmKitWASI
 
-    extension BinaryInteger {
+    extension FixedWidthInteger {
         init?(hexEncoded: Substring) {
-            var result = Self.zero
-            for (offset, element) in hexEncoded.reversed().enumerated() {
-                guard let digit = element.hexDigitValue else { return nil }
-                result += Self(digit) << (offset * 4)
-            }
+            guard !hexEncoded.isEmpty else { return nil }
 
+            var result = Self.zero
+            for element in hexEncoded {
+                guard let digit = element.hexDigitValue else { return nil }
+                let (shifted, shiftOverflowed) = result.multipliedReportingOverflow(by: 16)
+                let (sum, addOverflowed) = shifted.addingReportingOverflow(Self(digit))
+                guard !shiftOverflowed, !addOverflowed else { return nil }
+                result = sum
+            }
             self = result
         }
     }
@@ -101,6 +105,9 @@
         /// Generic error reply. `QEnableErrorStrings` is unsupported, so a bare code is
         /// the only way to refuse a request the target understands but cannot answer.
         private static let errorReply = GDBTargetResponse.Kind.error(0x45)
+
+        /// Error code for refused memory reads, matching debugserver.
+        private static let memoryReadFailed: UInt8 = 0x08
 
         /// Error code for refused memory writes, matching debugserver.
         private static let memoryWriteFailed: UInt8 = 0x09
@@ -419,13 +426,18 @@
                     let length = UInt(hexEncoded: argumentsArray[1])
                 else { throw Error.unknownReadMemoryArguments }
 
-                responseKind = .hexEncodedBinary(
-                    try self.memoryView.readMemory(
-                        debugger: self.debugger,
-                        addressInProtocolSpace: addressInProtocolSpace,
-                        length: length
+                do {
+                    responseKind = .hexEncodedBinary(
+                        try self.memoryView.readMemory(
+                            debugger: self.debugger,
+                            addressInProtocolSpace: addressInProtocolSpace,
+                            length: length
+                        )
                     )
-                )
+                } catch {
+                    logger.debug("memory read `\(command.arguments)` failed: \(error)")
+                    responseKind = .error(Self.memoryReadFailed)
+                }
 
             case .writeMemory:
                 do {
@@ -546,7 +558,29 @@
                 }
 
             case .memoryRegionInfo:
-                responseKind = .empty
+                // A host probes support by sending this query without an address.
+                if command.arguments.isEmpty {
+                    responseKind = .ok
+                } else if let addressInProtocolSpace = UInt64(hexEncoded: command.arguments[...]) {
+                    let region = self.memoryView.memoryRegion(
+                        debugger: self.debugger,
+                        containing: addressInProtocolSpace
+                    )
+                    var pairs = [
+                        ("start", String(region.start, radix: 16)),
+                        ("size", String(region.size, radix: 16)),
+                    ]
+                    if let permissions = region.permissions {
+                        pairs.append(("permissions", permissions))
+                    }
+                    if let name = region.name {
+                        pairs.append(("name", HexEncoding.encode(name.utf8)))
+                    }
+                    responseKind = .keyValuePairs(pairs)
+                } else {
+                    logger.debug("refusing a memory region query for `\(command.arguments)`")
+                    responseKind = Self.errorReply
+                }
 
             case .generalRegisters:
                 responseKind = .empty

--- a/Tests/WasmKitGDBHandlerTests/MemoryRegionTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/MemoryRegionTests.swift
@@ -1,0 +1,189 @@
+#if WasmDebuggingSupport
+
+    import GDBRemoteProtocol
+    import Testing
+    import WAT
+
+    @testable import WasmKitGDBHandler
+
+    @Suite
+    struct MemoryRegionTests {
+        /// One page of linear memory, so the mapped region's size is a known 0x10000.
+        static let wat = """
+            (module
+              (memory 1)
+              (func (export "_start") (result i32)
+                (i32.load8_u (i32.const 0))))
+            """
+
+        private static let pageSize = UInt64(0x1_0000)
+        private let offset = DebuggerMemoryView.executableCodeOffset
+
+        private func withModule(_ wat: String = MemoryRegionTests.wat, _ body: (WasmKitGDBHandler, Int) throws -> Void) throws {
+            let moduleSize = try wat2wasm(wat).count
+            try withHandler(debugging: wat) { try body($0, moduleSize) }
+        }
+
+        private func region(_ handler: WasmKitGDBHandler, at address: UInt64) throws -> [String: String] {
+            let response = try handler.handle(
+                command: .init(kind: .memoryRegionInfo, arguments: String(address, radix: 16)))
+            guard case .keyValuePairs(let pairs) = response.kind else {
+                Issue.record("expected memory region fields, got \(response.kind)")
+                return [:]
+            }
+            return Dictionary(pairs, uniquingKeysWith: { first, _ in first })
+        }
+
+        @Test
+        func linearMemoryIsAReadWriteRange() throws {
+            try withModule { handler, _ in
+                let memory = try region(handler, at: 0)
+                #expect(memory["start"] == "0")
+                #expect(memory["size"] == String(Self.pageSize, radix: 16))
+                #expect(memory["permissions"] == "rw")
+                #expect(memory["name"] == HexEncoding.encode(Array("memory".utf8)))
+            }
+        }
+
+        @Test
+        func theModuleImageIsAReadExecuteRange() throws {
+            try withModule { handler, moduleSize in
+                let code = try region(handler, at: offset)
+                #expect(code["start"] == String(offset, radix: 16))
+                #expect(code["size"] == String(moduleSize, radix: 16))
+                #expect(code["permissions"] == "rx")
+                #expect(code["name"] == HexEncoding.encode(Array("module".utf8)))
+            }
+        }
+
+        @Test
+        func theGapBelowTheModuleImageReachesIt() throws {
+            try withModule { handler, _ in
+                let gap = try region(handler, at: Self.pageSize)
+                #expect(gap["start"] == String(Self.pageSize, radix: 16))
+                #expect(gap["size"] == String(offset - Self.pageSize, radix: 16))
+                #expect(gap["permissions"] == nil)
+            }
+        }
+
+        @Test
+        func theRangeAboveTheModuleImageReachesTheEndOfTheAddressSpace() throws {
+            try withModule { handler, moduleSize in
+                let end = offset + UInt64(moduleSize)
+                let top = try region(handler, at: end)
+                #expect(top["start"] == String(end, radix: 16))
+                #expect(top["size"] == String(UInt64.max - end, radix: 16))
+                #expect(top["permissions"] == nil)
+            }
+        }
+
+        @Test
+        func theWalkCoversTheAddressSpaceWithoutOverlapping() throws {
+            try withModule { handler, _ in
+                var address = UInt64(0)
+                var previousEnd: UInt64?
+                var steps = 0
+                while steps < 8 {
+                    steps += 1
+                    let fields = try region(handler, at: address)
+                    let start = try #require(UInt64(fields["start"] ?? "", radix: 16))
+                    let size = try #require(UInt64(fields["size"] ?? "", radix: 16))
+                    #expect(start == previousEnd ?? 0)
+                    previousEnd = start + size
+                    if previousEnd == UInt64.max { break }
+                    address = previousEnd!
+                }
+                #expect(previousEnd == UInt64.max)
+                #expect(steps == 4)
+            }
+        }
+
+        @Test
+        func aModuleWithoutLinearMemoryMapsNothingAtZero() throws {
+            let wat = """
+                (module
+                  (func (export "_start") (result i32)
+                    (i32.const 0)))
+                """
+            try withModule(wat) { handler, _ in
+                let bottom = try region(handler, at: 0)
+                #expect(bottom["start"] == "0")
+                #expect(bottom["size"] == String(offset, radix: 16))
+                #expect(bottom["permissions"] == nil)
+                #expect(bottom["name"] == nil)
+            }
+        }
+
+        private func readReply(_ handler: WasmKitGDBHandler, at address: UInt64, length: UInt64) throws -> GDBTargetResponse.Kind {
+            try handler.handle(
+                command: .init(
+                    kind: .readMemory,
+                    arguments: "\(String(address, radix: 16)),\(String(length, radix: 16))")
+            ).kind
+        }
+
+        @Test
+        func readingAnUnmappedRangeIsRefused() throws {
+            try withModule { handler, moduleSize in
+                let unmapped: [UInt64] = [
+                    Self.pageSize,  // Above linear memory, below the module image.
+                    offset + UInt64(moduleSize) + 0x10,
+                    0xc000_0000_0000_0000,
+                ]
+                for address in unmapped {
+                    guard case .error = try readReply(handler, at: address, length: 4) else {
+                        Issue.record("expected a refusal for \(String(address, radix: 16))")
+                        continue
+                    }
+                }
+            }
+        }
+
+        @Test
+        func anEmptyReadOfAnUnmappedRangeIsEmpty() throws {
+            try withModule { handler, moduleSize in
+                for address in [Self.pageSize + 0x10, offset + UInt64(moduleSize) + 0x10] {
+                    guard case .hexEncodedBinary(let bytes) = try readReply(handler, at: address, length: 0) else {
+                        Issue.record("expected an empty read at \(String(address, radix: 16)) to be answered")
+                        continue
+                    }
+                    #expect(bytes.isEmpty)
+                }
+            }
+        }
+
+        @Test
+        func aReadCrossingTheEndOfLinearMemoryIsNarrowed() throws {
+            try withModule { handler, _ in
+                guard case .hexEncodedBinary(let bytes) = try readReply(handler, at: Self.pageSize - 4, length: 0x100) else {
+                    Issue.record("expected memory contents")
+                    return
+                }
+                #expect(bytes.count == 4)
+            }
+        }
+
+        @Test
+        func aQueryWithoutAnAddressReportsSupport() throws {
+            try withModule { handler, _ in
+                let response = try handler.handle(command: .init(kind: .memoryRegionInfo, arguments: ""))
+                guard case .ok = response.kind else {
+                    Issue.record("expected support to be reported, got \(response.kind)")
+                    return
+                }
+            }
+        }
+
+        @Test
+        func aQueryWithAMalformedAddressIsRefused() throws {
+            try withModule { handler, _ in
+                let response = try handler.handle(command: .init(kind: .memoryRegionInfo, arguments: "zz"))
+                guard case .error = response.kind else {
+                    Issue.record("expected a refusal, got \(response.kind)")
+                    return
+                }
+            }
+        }
+    }
+
+#endif

--- a/Tests/WasmKitGDBHandlerTests/MemoryWriteTests.swift
+++ b/Tests/WasmKitGDBHandlerTests/MemoryWriteTests.swift
@@ -108,12 +108,14 @@
         }
 
         @Test
-        func aLengthThatOverflowsTheAddressSpaceIsRefused() throws {
+        func aLengthThatOverflowsTheAddressSpaceIsNarrowed() throws {
             try withHandler(debugging: Self.wat) { handler in
-                #expect(throws: Debugger.Error.self) {
-                    _ = try handler.handle(command: .init(kind: .readMemory, arguments: "0,ffffffffffffffff"))
+                let response = try handler.handle(command: .init(kind: .readMemory, arguments: "0,ffffffffffffffff"))
+                guard case .hexEncodedBinary(let bytes) = response.kind else {
+                    Issue.record("expected memory contents, got \(response.kind)")
+                    return
                 }
-                return
+                #expect(bytes.count == 0x1_0000)
             }
         }
     }


### PR DESCRIPTION
Inform the host of mapped regions so it avoids probing unmapped addresses.

Report linear memory as `rw` at zero and the module image as `rx` at the executable code offset. Span gaps between and above them to the next mapped region. Bound linear memory to the guest-visible size, not the underlying reservation, to trap on out-of-bounds access.

Bound reads to the same regions: refuse unmapped addresses with debugserver error 0x08, narrow reads crossing region boundaries, and permit empty reads.

Reject empty and over-long hex arguments instead of decoding as zero or truncating to low bits.