### PR TITLE
Recommend --omit-frame-pointers for Linux release builds and use it for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,11 @@ jobs:
       - run: |
           VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
           echo "WASMKIT_VERSION=${VERSION}" >> "$GITHUB_ENV"
-      - run: ./build-exec ./Utilities/build-release.py -o wasmkit-x86_64-swift-linux-musl.tar.gz  -s $WASMKIT_VERSION -- --swift-sdk x86_64-swift-linux-musl
+      # x86-64 only: By default, fp prologue/epilogue are emitted for VM instruction handlers even though
+      # they are "leaf" function (in LLVM, a function whose only call is a guaranteed tail call counts as
+      # leaf). The fp operations slows down the VM execution quite a bit, so we omit them for the x86-64 build.
+      - run: ./build-exec ./Utilities/build-release.py -o wasmkit-x86_64-swift-linux-musl.tar.gz  -s $WASMKIT_VERSION -- --swift-sdk x86_64-swift-linux-musl --omit-frame-pointers
+      # For aarch64, we don't need `--omit-frame-pointers` because clang by default omits them for leaf functions for aarch64.
       - run: ./build-exec ./Utilities/build-release.py -o wasmkit-aarch64-swift-linux-musl.tar.gz -s $WASMKIT_VERSION -- --swift-sdk aarch64-swift-linux-musl
       - uses: actions/upload-artifact@v7
         with:

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -84,7 +84,7 @@ Or directly, which is more convenient while iterating because it takes a filter
 and engine-configuration flags:
 
 ```console
-$ swift build -c release --package-path . --product WasmiBenchmarks
+$ swift build -c release --package-path . --product WasmiBenchmarks --omit-frame-pointers
 $ ./.build/release/WasmiBenchmarks                    # everything
 $ ./.build/release/WasmiBenchmarks counter            # only cases matching "counter"
 $ ./.build/release/WasmiBenchmarks coremark


### PR DESCRIPTION
Every `wasmkit_tc_*` handler on x86_64 begins `push %rbp; mov %rsp,%rbp` and ends `pop %rbp` before `jmp *%rax`.
Omitting the frame-pointer prologue/epilogue to reduce a few instructions per instruction handler.

Measured on my Linux box (2 runs each): CoreMark 2868 -> 3081; fibonacci-iter -27%.