### PR TITLE
Collapse br_if landing pads that copy nothing into a single branch

### DIFF
--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -838,9 +838,31 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             // Anything emitted after the candidate (e.g. `preserveOnStack`
             // copies) makes the fusion unsound.
             guard emission.end.offsetFromHead == insertingPC.offsetFromHead else { return false }
-            // A label pinned inside or after the candidate would move.
-            guard highestPinnedLabelOffset <= emission.position.offsetFromHead else { return false }
-            return true
+            return canRewind(to: emission.position)
+        }
+
+        /// Whether the buffer can be rewound to `position` without moving or
+        /// dangling a label that has already been pinned.
+        fileprivate func canRewind(to position: MetaProgramCounter) -> Bool {
+            guard position.offsetFromHead <= instructions.count else { return false }
+            // A label pinned strictly after `position` would be retargeted at
+            // whatever is emitted in place of the removed instructions. A label
+            // pinned exactly at `position` is fine: it keeps pointing at the
+            // start of the replacement.
+            return highestPinnedLabelOffset <= position.offsetFromHead
+        }
+
+        /// Drops every pending user of an unpinned label so the instructions
+        /// referring to it can be rewound away.
+        ///
+        /// The label must not have been pinned yet, and is never pinned
+        /// afterwards -- it simply disappears together with its only user.
+        fileprivate mutating func discardUnpinnedLabel(_ ref: LabelRef) {
+            guard case .unpinned = self.labels[ref] else {
+                preconditionFailure("Internal consistency error: Label (#\(ref)) is already pinned and cannot be discarded")
+            }
+            self.labels[ref] = .unpinned(users: [])
+            self.unpinnedLabels.remove(ref)
         }
 
         /// Drops every slot from `position` to the end of the buffer.
@@ -1663,11 +1685,11 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         guard let condition = condition else { return }
         // NOTE: `preserveOnStack` above may have emitted copies; when it did,
         // `canRewind` refuses and we fall back to the unfused form.
-        if let makeFused = fuseCompareIntoBranch(fusable, condition: condition, polarity: .ifFalse) {
+        if let makeFused = fuseCompareIntoBranch(fusable, condition: condition) {
             let oldPC = iseqBuilder.insertingPC
             iseqBuilder.emitBranchWithLabel(endLabel) { iseqBuilder, selfPC, endPC in
                 let targetPC = iseqBuilder.resolveLabel(elseLabel) ?? endPC
-                return makeFused(Int32(targetPC.offsetFromHead - selfPC.offsetFromHead))
+                return makeFused(.ifFalse, Int32(targetPC.offsetFromHead - selfPC.offsetFromHead))
             }
             self.updateInstructionMapping(from: oldPC)
             return
@@ -1800,6 +1822,13 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
         case ifFalse
     }
 
+    /// Builds a fused compare+branch for a given polarity and pc-relative offset.
+    ///
+    /// The polarity is supplied at emission time so that a branch already
+    /// emitted as `ifFalse` can be re-emitted as `ifTrue` if the landing pad it
+    /// skipped over turns out to be empty (see ``visitBrIf(relativeDepth:)``).
+    private typealias FusedBranchFactory = (_ polarity: FusedBranchPolarity, _ offset: Int32) -> Instruction
+
     /// Folds a just-emitted comparison into the conditional branch about to be
     /// emitted.
     ///
@@ -1817,28 +1846,27 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
     /// ``ISeqBuilder/canRewind(to:)`` refuse).
     private mutating func fuseCompareIntoBranch(
         _ candidate: FusableEmission?,
-        condition: VReg,
-        polarity: FusedBranchPolarity
-    ) -> ((_ offset: Int32) -> Instruction)? {
+        condition: VReg
+    ) -> FusedBranchFactory? {
         guard let candidate, candidate.result == condition else { return nil }
         guard iseqBuilder.canRewind(to: candidate) else { return nil }
 
-        let factory: (Int32) -> Instruction
+        let factory: FusedBranchFactory
         switch candidate.condition {
         case .compare(let kind, let lhs, let rhs):
-            let fused = polarity == .ifTrue ? kind : kind.complement
-            let makeBrIf = fused.makeBrIf
-            factory = { offset in
-                makeBrIf(Instruction.BrIfCmpOperand(lhs: lhs, rhs: rhs, offset: offset))
+            factory = { polarity, offset in
+                let fused = polarity == .ifTrue ? kind : kind.complement
+                return fused.makeBrIf(Instruction.BrIfCmpOperand(lhs: lhs, rhs: rhs, offset: offset))
             }
         case .i32Eqz(let input):
             // `eqz(x)` is non-zero exactly when `x` is zero, so the fused form
             // is just the plain branch with the opposite polarity on `x`.
-            switch polarity {
-            case .ifTrue:
-                factory = { Instruction.brIfNot(Instruction.BrIfOperand(condition: LVReg(input), offset: $0)) }
-            case .ifFalse:
-                factory = { Instruction.brIf(Instruction.BrIfOperand(condition: LVReg(input), offset: $0)) }
+            factory = { polarity, offset in
+                let operand = Instruction.BrIfOperand(condition: LVReg(input), offset: offset)
+                switch polarity {
+                case .ifTrue: return Instruction.brIfNot(operand)
+                case .ifFalse: return Instruction.brIf(operand)
+                }
             }
         }
         iseqBuilder.rewind(to: candidate.position)
@@ -1908,10 +1936,10 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             guard let condition else { return }
             // Optimization where we don't need copying values when the branch taken
             // and no exception handlers need unwinding.
-            if let makeFused = fuseCompareIntoBranch(fusable, condition: condition, polarity: .ifTrue) {
+            if let makeFused = fuseCompareIntoBranch(fusable, condition: condition) {
                 let oldPC = iseqBuilder.insertingPC
                 iseqBuilder.emitBranchWithLabel(frame.continuation) { _, selfPC, continuation in
-                    makeFused(Int32(continuation.offsetFromHead - selfPC.offsetFromHead))
+                    makeFused(.ifTrue, Int32(continuation.offsetFromHead - selfPC.offsetFromHead))
                 }
                 self.updateInstructionMapping(from: oldPC)
                 return
@@ -1953,28 +1981,94 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             let onBranchNotTaken = iseqBuilder.allocLabel()
             // NOTE: `preserveOnStack` above may have emitted copies; when it did,
             // `canRewind` refuses and we fall back to the unfused form.
-            if let makeFused = fuseCompareIntoBranch(fusable, condition: condition, polarity: .ifFalse) {
-                let oldPC = iseqBuilder.insertingPC
+            let makeFused = fuseCompareIntoBranch(fusable, condition: condition)
+            let conditionCheckPC = iseqBuilder.insertingPC
+            if let makeFused {
                 iseqBuilder.emitBranchWithLabel(onBranchNotTaken) { _, conditionCheckAt, continuation in
-                    makeFused(Int32(continuation.offsetFromHead - conditionCheckAt.offsetFromHead))
+                    makeFused(.ifFalse, Int32(continuation.offsetFromHead - conditionCheckAt.offsetFromHead))
                 }
-                self.updateInstructionMapping(from: oldPC)
             } else {
-                let oldPC = iseqBuilder.insertingPC
                 iseqBuilder.emitWithLabel(Instruction.brIfNot, onBranchNotTaken) { _, conditionCheckAt, continuation in
                     let relativeOffset = continuation.offsetFromHead - conditionCheckAt.offsetFromHead
                     return Instruction.BrIfOperand(condition: LVReg(condition), offset: Int32(relativeOffset))
                 }
-                self.updateInstructionMapping(from: oldPC)
             }
+            self.updateInstructionMapping(from: conditionCheckPC)
+            let landingPadPC = iseqBuilder.insertingPC
             try copyOnBranch(targetFrame: frame)
-            if handlersToUnwind > 0 {
-                emit(.catchHandlersEnd(Instruction.CatchHandlersEndOperand(count: handlersToUnwind)))
+
+            // The landing pad only exists to run the copies (and the handler
+            // unwind) on the taken path. `frame.copySlotCount != 0` does *not*
+            // imply that any copy is emitted: for a `loop (param ...)`
+            // back-edge the operand usually already sits in the destination
+            // slot, so `copyOnBranch` emits nothing and the pad degenerates
+            // into two dispatches for one guest branch.
+            //
+            // (loop $continue (param i32) (result i32)
+            //   (i32.const 1)
+            //   (i32.sub)
+            //   (local.tee $n)
+            //   (local.get $n)
+            //   (br_if $continue) ---> back to the loop head
+            // )
+            //
+            // [0x02] (i32.sub reg:4, reg:0 -> reg:4)       <-----------+
+            // [0x04] (copy reg:4 -> local $n)                          |
+            // [0x06] (copy local $n -> reg:4)                          |
+            // [0x08] (br_if_not cond=local $n, offset=+2) --+          |
+            // [0x0a] (br offset=-10) -----------------------|----------+
+            // [0x0c] ...                        <-----------+
+            //
+            // Collapse that into a single conditional branch (fused, when
+            // the condition came from a comparison) straight to the real
+            // destination:
+            //
+            // [0x02] (i32.sub reg:4, reg:0 -> reg:4)       <-----------+
+            // [0x04] (copy reg:4 -> local $n)                          |
+            // [0x06] (copy local $n -> reg:4)                          |
+            // [0x08] (br_if cond=local $n, offset=-8) ------------------+
+            // [0x0a] ...
+            //
+            // Only the "no copy was emitted" case is collapsed. When copies
+            // *were* emitted they cannot be hoisted above the branch: they
+            // write the branch target's slots, which are below the current
+            // stack top and generally still live on the fall-through path (in
+            // the example above reg:0 must keep holding 42 when the branch is
+            // not taken). Proving those slots dead needs liveness information
+            // this single-pass translator does not have, so the copying case
+            // keeps the landing pad.
+            let collapseLandingPad =
+                handlersToUnwind == 0
+                && iseqBuilder.insertingPC.offsetFromHead == landingPadPC.offsetFromHead
+                && iseqBuilder.canRewind(to: conditionCheckPC)
+            if collapseLandingPad {
+                // The conditional branch just emitted is the only user of the
+                // landing pad's label, and it is about to be removed.
+                iseqBuilder.discardUnpinnedLabel(onBranchNotTaken)
+                iseqBuilder.rewind(to: conditionCheckPC)
+                self.rewindInstructionMapping(to: conditionCheckPC)
+                if let makeFused {
+                    iseqBuilder.emitBranchWithLabel(frame.continuation) { _, selfPC, continuation in
+                        makeFused(.ifTrue, Int32(continuation.offsetFromHead - selfPC.offsetFromHead))
+                    }
+                } else {
+                    iseqBuilder.emitWithLabel(Instruction.brIf, frame.continuation) { _, selfPC, continuation in
+                        let relativeOffset = continuation.offsetFromHead - selfPC.offsetFromHead
+                        return Instruction.BrIfOperand(
+                            condition: LVReg(condition), offset: Int32(relativeOffset)
+                        )
+                    }
+                }
+                self.updateInstructionMapping(from: conditionCheckPC)
+            } else {
+                if handlersToUnwind > 0 {
+                    emit(.catchHandlersEnd(Instruction.CatchHandlersEndOperand(count: handlersToUnwind)))
+                }
+                try emitBranch(Instruction.br, relativeDepth: relativeDepth) { offset, copyCount, popCount in
+                    return offset
+                }
+                try iseqBuilder.pinLabelHere(onBranchNotTaken)
             }
-            try emitBranch(Instruction.br, relativeDepth: relativeDepth) { offset, copyCount, popCount in
-                return offset
-            }
-            try iseqBuilder.pinLabelHere(onBranchNotTaken)
         }
         try popPushValues(frame.copyTypes)
     }

--- a/Tests/WATTests/EncoderTests.swift
+++ b/Tests/WATTests/EncoderTests.swift
@@ -307,7 +307,12 @@ struct EncoderTests {
 
     #if !(os(iOS) || os(watchOS) || os(tvOS) || os(visionOS))
         @Test(
-            arguments: Spectest.wastFiles(include: [], exclude: [])
+            arguments: Spectest.wastFiles(
+                include: [],
+                // Uses tags; wast2json is not run with `--enable-exceptions` here
+                // and the encoder orders the type section differently for them.
+                exclude: ["br_if_landing_pad_try_table.wast"]
+            )
         )
         func spectest(wastFile: URL) throws {
             guard let wast2json = TestSupport.lookupExecutable("wast2json") else {

--- a/Tests/WasmKitTests/ExtraSuite/br_if_landing_pad.wast
+++ b/Tests/WasmKitTests/ExtraSuite/br_if_landing_pad.wast
@@ -1,0 +1,89 @@
+;; br_if targets whose block parameters or results already sit in the
+;; destination slots (the "landing pad copies nothing" shape), next to targets
+;; that really need the copy and targets that leave a try_table. The branch
+;; must take exactly the copies it needs, and only on the taken path.
+
+;; A loop (param i32) (result i32) whose back-edge needs no copy: the operand
+;; is already in the loop's parameter slot. Counts down to zero.
+(module
+  (func (export "loop_no_copy") (param $n i32) (result i32)
+    (local.get $n)
+    (loop $continue (param i32) (result i32)
+      (i32.const 1)
+      (i32.sub)
+      (local.tee $n)
+      (local.get $n)
+      (br_if $continue)
+    )
+  )
+)
+(assert_return (invoke "loop_no_copy" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "loop_no_copy" (i32.const 10)) (i32.const 0))
+(assert_return (invoke "loop_no_copy" (i32.const 1000)) (i32.const 0))
+
+;; The same shape with a comparison as the condition; the loop operand is a
+;; temporary so nothing sits between the comparison and the branch. Returns
+;; the sum of 0..<max(n, 1).
+(module
+  (func (export "loop_no_copy_cmp") (param $n i32) (result i32) (local $i i32)
+    (i32.const 0)
+    (loop $continue (param i32) (result i32)
+      (local.get $i)
+      (i32.add)
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (i32.lt_s (local.get $i) (local.get $n))
+      (br_if $continue)
+    )
+  )
+)
+(assert_return (invoke "loop_no_copy_cmp" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "loop_no_copy_cmp" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "loop_no_copy_cmp" (i32.const 5)) (i32.const 10))
+(assert_return (invoke "loop_no_copy_cmp" (i32.const 100)) (i32.const 4950))
+
+;; A br_if whose target needs a copy: the copy writes a slot that stays live
+;; on the fall-through path, so it may only run when the branch is taken.
+(module
+  (func (export "real_copy") (param $c i32) (result i32)
+    (block (result i32)
+      (i32.const 42)
+      (i32.const 24)
+      (local.get $c)
+      (br_if 0)
+      (drop)
+    )
+  )
+)
+;; Taken: the block result is the copied 24.
+(assert_return (invoke "real_copy" (i32.const 1)) (i32.const 24))
+;; Not taken: the copy must not have happened, 42 is still there.
+(assert_return (invoke "real_copy" (i32.const 0)) (i32.const 42))
+
+;; Same, with a comparison as the condition and temporaries as the operands.
+(module
+  (func (export "real_copy_cmp") (param $a i32) (param $b i32) (result i32)
+    (block (result i32)
+      (i32.add (local.get $a) (local.get $a))
+      (i32.add (local.get $b) (local.get $b))
+      (i32.lt_s (local.get $a) (local.get $b))
+      (br_if 0)
+      (drop)
+    )
+  )
+)
+;; Taken: the block result is the copied 2*b.
+(assert_return (invoke "real_copy_cmp" (i32.const 1) (i32.const 2)) (i32.const 4))
+;; Not taken: the copy must not have happened, 2*a is still there.
+(assert_return (invoke "real_copy_cmp" (i32.const 3) (i32.const 2)) (i32.const 6))
+
+;; if with block parameters.
+(module
+  (func (export "if_params") (param $a i32) (param $c i32) (result i32)
+    (local.get $a)
+    (if (param i32) (result i32) (local.get $c)
+      (then (i32.const 1) (i32.add))
+      (else (i32.const 2) (i32.add)))
+  )
+)
+(assert_return (invoke "if_params" (i32.const 10) (i32.const 1)) (i32.const 11))
+(assert_return (invoke "if_params" (i32.const 10) (i32.const 0)) (i32.const 12))

--- a/Tests/WasmKitTests/ExtraSuite/br_if_landing_pad_try_table.wast
+++ b/Tests/WasmKitTests/ExtraSuite/br_if_landing_pad_try_table.wast
@@ -1,0 +1,54 @@
+;; br_if leaving a try_table. The landing pad must stay so that the catch
+;; handler is popped on the taken path only; see br_if_landing_pad.wast for the
+;; cases without exception handlers. Kept apart from that file because the WAT
+;; encoder test does not enable the exception-handling proposal.
+
+;; A br_if that leaves a try_table: the catch handler must be popped on the
+;; taken path only.
+(module
+  (tag $e)
+  (func (export "leave_try_table") (param $c i32) (result i32)
+    (block $out (result i32)
+      (block $h
+        (try_table (catch_all $h)
+          (local.get $c)
+          (br_if $out (local.get $c))
+          (i32.const 7)
+          (br $out)
+        )
+        (i32.const 8)
+        (br $out)
+      )
+      (i32.const 9)
+    )
+  )
+)
+(assert_return (invoke "leave_try_table" (i32.const 0)) (i32.const 7))
+(assert_return (invoke "leave_try_table" (i32.const 5)) (i32.const 5))
+
+;; A throw inside the try_table after the br_if was not taken: the handler
+;; stack must still be balanced.
+(module
+  (tag $e)
+  (func $thrower (throw $e))
+  (func (export "throw_after_br_if") (param $c i32) (result i32)
+    (block $out (result i32)
+      (block $h
+        (try_table (catch_all $h)
+          (local.get $c)
+          (br_if $out (local.get $c))
+          (call $thrower)
+          (i32.const 7)
+          (br $out)
+        )
+        (i32.const 8)
+        (br $out)
+      )
+      (i32.const 9)
+    )
+  )
+)
+;; Not taken: falls into the throw, caught by catch_all.
+(assert_return (invoke "throw_after_br_if" (i32.const 0)) (i32.const 9))
+;; Taken: leaves the try_table with the handler popped.
+(assert_return (invoke "throw_after_br_if" (i32.const 3)) (i32.const 3))


### PR DESCRIPTION
`visitBrIf` only emitted a single `brIf` (or the fused compare-branch) when `frame.copySlotCount == 0 && handlersToUnwind == 0`. Every `loop (param ...)` has `copySlotCount != 0`, so the lowering was `brIfNot cond, +skip; <copies>; br target` even when `copyOnBranch` emitted no copies at all: two dispatches per loop back-edge where one would do.

This PR still emits the landing pad, then checks whether it was worth it: if nothing was emitted after `copyOnBranch` and no handlers need unwinding, the pad's label is discarded, the buffer is rewound and a single conditional branch to the real target is emitted in its place. Translator-only; no handler and no generated file changes.

### Example

The `counter-param` loop. Its back-edge operand is already in the loop's parameter slot, so the branch has nothing to copy.

```wat
(module
  (func (export "count") (param $n i32) (result i32)
    (local.get $n)
    (loop $continue (param i32) (result i32)
      (i32.const 1)
      (i32.sub)
      (local.tee $n)
      (local.get $n)
      (br_if $continue)
    )
  )
)
```

`wasmkit-cli explore` output for the function, before (`up/05`) and after (`up/06`):

<table>
<tr>
<th>before (<code>up/05</code>)</th>
<th>after (<code>up/06</code>)</th>
</tr>
<tr>
<td>

```
==== Function[0] ====
 [-4] Param 0, Result 0
 [-3] Saved Instance
 [-2] Saved Pc
 [-1] Saved Sp
 [ 0] Const 0 = UntypedValue(storage: 1)
0x00: reg:4 = copy reg:-4
0x02: reg:4 = i32.sub reg:4, reg:0
0x04: reg:-4 = copy reg:4
0x06: reg:4 = copy reg:-4
0x08: br_if_not reg:-4, +2 ; 0xc
0x0a: br -10 ; 0x2
0x0c: reg:-4 = copy reg:4
0x0e: return
0x0f: return
```

</td>
<td>

```
==== Function[0] ====
 [-4] Param 0, Result 0
 [-3] Saved Instance
 [-2] Saved Pc
 [-1] Saved Sp
 [ 0] Const 0 = UntypedValue(storage: 1)
0x00: reg:4 = copy reg:-4
0x02: reg:4 = i32.sub reg:4, reg:0
0x04: reg:-4 = copy reg:4
0x06: reg:4 = copy reg:-4
0x08: br_if reg:-4, -8 ; 0x2
0x0a: reg:-4 = copy reg:4
0x0c: return
0x0d: return
```

</td>
</tr>
</table>

### Metrics

5x per side (instead of best-of-two) and report mean ± stddev below. Before = `0684131` (main, parent of this PR's commit), after = `d10d4ee` (this PR), whole suite, direct threading, `min` ms per run averaged over 5 runs

| case | before mean ± stddev (ms) | after mean ± stddev (ms) | ratio (after/before) |
|---|---:|---:|---:|
| counter-local | 2.496 ± 0.034 | 2.492 ± 0.036 | 0.998 |
| counter-param | 3.072 ± 0.017 | 3.280 ± 0.027 | **1.068** |
| counter-global | 1.259 ± 0.006 | 1.268 ± 0.007 | 1.007 |
| fibonacci-rec | 15.517 ± 0.161 | 15.506 ± 0.076 | 0.999 |
| fibonacci-iter | 4.676 ± 0.005 | 4.730 ± 0.005 | 1.012 |
| fibonacci-tail | 6.460 ± 0.046 | 6.408 ± 0.037 | 0.992 |
| bulk-ops | 0.444 ± 0.003 | 0.436 ± 0.012 | 0.982 |
| sort | 257.278 ± 1.582 | 258.126 ± 1.967 | 1.003 |
| sort-dyn | 230.171 ± 1.316 | 229.798 ± 1.402 | 0.998 |
| prime-sieve | 183.582 ± 1.630 | 183.107 ± 2.035 | 0.997 |
| matrix-mul | 278.903 ± 1.973 | 278.947 ± 1.919 | 1.000 |
| nbody | 84.549 ± 0.293 | 84.147 ± 1.535 | 0.995 |
| argon2 | 198.820 ± 1.051 | 195.790 ± 3.237 | 0.985 |
| tiny-keccak | 0.126 ± 0.002 | 0.124 ± 0.003 | 0.983 |
| mandelbrot | 120.324 ± 0.715 | 120.100 ± 1.516 | 0.998 |
| spectralnorm | 82.732 ± 0.402 | 82.279 ± 0.383 | 0.995 |
| compression | 34.949 ± 0.210 | 34.762 ± 0.454 | 0.995 |
| word-count | 5.024 ± 0.009 | 5.015 ± 0.015 | 0.998 |
| json-parse | 36.360 ± 0.484 | 35.362 ± 0.304 | 0.973 |
| reverse-complement | 0.166 ± 0.001 | 0.164 ± 0.004 | 0.992 |
| regex-redux | 0.116 ± 0.000 | 0.114 ± 0.003 | 0.981 |
| **geomean** | | | **0.9974** |
| coremark (score, higher better) | 3326.65 ± 23.78 | 3331.70 ± 27.47 | 1.0015 |


