### PR TITLE
Make wasm-to-wasm return call-free and merge frame initialization into one copy

### DIFF
--- a/Sources/WasmKit/Engine.swift
+++ b/Sources/WasmKit/Engine.swift
@@ -15,6 +15,16 @@ public final class Engine {
     let interceptor: EngineInterceptor?
     let funcTypeInterner: Interner<FunctionType>
 
+    /// The head slot of the `returnCrossInstance` handler under this engine's
+    /// threading model.
+    ///
+    /// `_return` hands a cross-instance return off by re-dispatching to that
+    /// handler. Looking the slot up from a handler would mean a call (the
+    /// handler table is a lazily initialised global), and a call means a
+    /// stack frame on the hottest return path, so it is computed once here
+    /// and read through the execution state instead.
+    let crossInstanceReturnSlot: CodeSlot
+
     /// Whether this engine has an interceptor which is unsafe to share with
     /// concurrently executing stores.
     package var hasInterceptor: Bool { interceptor != nil }
@@ -43,6 +53,9 @@ public final class Engine {
         self.configuration = configuration
         self.interceptor = interceptor
         self.funcTypeInterner = Interner()
+        self.crossInstanceReturnSlot = Instruction.returnCrossInstance.headSlot(
+            threadingModel: configuration.threadingModel
+        )
     }
 
     /// Migration aid for the old ``Runtime/instantiate(module:)``

--- a/Sources/WasmKit/Execution/Debugger.swift
+++ b/Sources/WasmKit/Execution/Debugger.swift
@@ -739,9 +739,14 @@
         }
 
         mutating func predictNext__return(operandPc: Pc, sp: Sp) -> [Pc] {
-            // returnPC is stored at sp[-2]
-            let returnPc = Pc(bitPattern: UInt(sp.advanced(by: -2).pointee))
-            return returnPc.map { [$0] } ?? []
+            // returnPC is stored at sp[-2], with a flag in its low bit.
+            return sp.returnPC.map { [$0] } ?? []
+        }
+
+        mutating func predictNext_returnCrossInstance(operandPc: Pc, sp: Sp) -> [Pc] {
+            // `returnCrossInstance` is only ever reached from `_return` and pops
+            // the same frame, so it lands in the same place.
+            predictNext__return(operandPc: operandPc, sp: sp)
         }
 
         /// Resolves a callee function from a table and returns its iseq base address.

--- a/Sources/WasmKit/Execution/DispatchInstruction.swift
+++ b/Sources/WasmKit/Execution/DispatchInstruction.swift
@@ -349,6 +349,7 @@ extension Execution {
         case 293: return self.execute_brIfI64LeU(sp: &sp, pc: &pc, md: &md, ms: &ms)
         case 294: return self.execute_brIfI64GeS(sp: &sp, pc: &pc, md: &md, ms: &ms)
         case 295: return self.execute_brIfI64GeU(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        case 296: return self.execute_returnCrossInstance(sp: &sp, pc: &pc, md: &md, ms: &ms)
         default: preconditionFailure("Unknown instruction!?")
 
         }
@@ -2680,6 +2681,12 @@ extension Execution {
         let immediate = Instruction.BrIfCmpOperand.load(from: &pc.pointee)
         let next: CodeSlot
         (pc.pointee, next) = self.brIfI64GeU(sp: sp.pointee, pc: pc.pointee, immediate: immediate)
+        return next
+    }
+    @_silgen_name("wasmkit_execute_returnCrossInstance") @inline(__always)
+    mutating func execute_returnCrossInstance(sp: UnsafeMutablePointer<Sp>, pc: UnsafeMutablePointer<Pc>, md: UnsafeMutablePointer<Md>, ms: UnsafeMutablePointer<Ms>) -> CodeSlot {
+        let next: CodeSlot
+        (pc.pointee, next) = self.returnCrossInstance(sp: &sp.pointee, pc: pc.pointee, md: &md.pointee, ms: &ms.pointee)
         return next
     }
 }

--- a/Sources/WasmKit/Execution/Execution.swift
+++ b/Sources/WasmKit/Execution/Execution.swift
@@ -110,47 +110,114 @@ struct Execution: ~Copyable {
         return Backtrace(symbols: symbols)
     }
 
-    private func initializeConstSlots(
-        sp: Sp, iseq: InstructionSequence,
-        numberOfNonParameterLocalSlots: Int
-    ) {
-        // Initialize the locals with zeros (all types of value have the same representation)
-        sp.initialize(repeating: UntypedValue.default.storage, count: numberOfNonParameterLocalSlots)
-        if let constants = iseq.constants.baseAddress {
-            let count = iseq.constants.count
-            sp.advanced(by: numberOfNonParameterLocalSlots).withMemoryRebound(to: UntypedValue.self, capacity: count) {
-                $0.initialize(from: constants, count: count)
+    /// Lays the callee's frame-initialisation image (zeroed locals followed by
+    /// the constant pool) over the new frame's local/constant area.
+    ///
+    /// The image is one contiguous buffer built at translation time, so this is a
+    /// single copy rather than a `memset` of the locals plus a `memcpy` of the
+    /// pool -- and small images are copied inline. That matters more than it
+    /// looks: even though the images are tiny for some trivial functions, a libc call
+    /// costs several times the copy itself.
+    @inline(__always)
+    private func initializeFrame(sp: Sp, iseq: InstructionSequence) {
+        let image = iseq.frameInit
+        guard let src = image.baseAddress else { return }
+        let count = image.count
+        let dst = UnsafeMutableRawPointer(sp).assumingMemoryBound(to: UntypedValue.self)
+        // Straight-line, overlapping head/tail copies. Written out rather than
+        // looped so that no loop remains for the optimizer to turn back into a
+        // `memcpy` call.
+        if count >= 8 {
+            if count > 16 {
+                // `copyMemory` rather than `update(from:count:)`: the latter emits
+                // an overlap check that is dead here (the image lives in the iseq
+                // allocation, never on the VM stack).
+                UnsafeMutableRawPointer(dst).copyMemory(
+                    from: UnsafeRawPointer(src), byteCount: count * MemoryLayout<UntypedValue>.stride
+                )
+                return
             }
+            Self.copy8(dst, src, 0)
+            Self.copy8(dst, src, count - 8)
+        } else if count >= 4 {
+            Self.copy4(dst, src, 0)
+            Self.copy4(dst, src, count - 4)
+        } else if count >= 2 {
+            Self.copyPair(dst, src, 0)
+            Self.copyPair(dst, src, count - 2)
+        } else if count == 1 {
+            dst[0] = src[0]
         }
     }
 
+    /// Copies two slots as one 16-byte unit, so this lowers to a single vector
+    /// load/store pair -- `ldr q`/`str q` on arm64, `movups` on x86-64 -- rather
+    /// than two scalar ones.
+    @inline(__always)
+    private static func copyPair(
+        _ dst: UnsafeMutablePointer<UntypedValue>, _ src: UnsafePointer<UntypedValue>, _ o: Int
+    ) {
+        let bytes = UnsafeRawPointer(src + o).loadUnaligned(as: SIMD2<UInt64>.self)
+        UnsafeMutableRawPointer(dst + o).storeBytes(of: bytes, as: SIMD2<UInt64>.self)
+    }
+
+    @inline(__always)
+    private static func copy4(
+        _ dst: UnsafeMutablePointer<UntypedValue>, _ src: UnsafePointer<UntypedValue>, _ o: Int
+    ) {
+        copyPair(dst, src, o)
+        copyPair(dst, src, o + 2)
+    }
+
+    @inline(__always)
+    private static func copy8(
+        _ dst: UnsafeMutablePointer<UntypedValue>, _ src: UnsafePointer<UntypedValue>, _ o: Int
+    ) {
+        copy4(dst, src, o)
+        copy4(dst, src, o + 4)
+    }
+
     /// Pushes a new call frame to the VM stack.
+    ///
+    /// - Parameter needsMemoryRestoreOnReturn: whether returning from this frame
+    ///   has to switch `md`/`ms` back, i.e. whether the callee runs in a different
+    ///   instance than the caller. See ``Sp/rawReturnPC``.
     @inline(__always)
     func pushFrame(
         iseq: InstructionSequence,
         function: EntityHandle<WasmFunctionEntity>,
-        numberOfNonParameterLocalSlots: Int,
         sp: Sp, returnPC: Pc,
-        spAddend: VReg
+        spAddend: VReg,
+        needsMemoryRestoreOnReturn: Bool
     ) throws -> Sp {
         let newSp = sp.advanced(by: Int(spAddend))
         try checkStackBoundary(newSp.advanced(by: iseq.maxStackHeight))
-        initializeConstSlots(sp: newSp, iseq: iseq, numberOfNonParameterLocalSlots: numberOfNonParameterLocalSlots)
+        initializeFrame(sp: newSp, iseq: iseq)
         newSp.previousSP = sp
-        newSp.returnPC = returnPC
+        newSp.setReturnPC(returnPC, needsMemoryRestore: needsMemoryRestoreOnReturn)
         newSp.currentFunction = function
         return newSp
     }
 
-    /// Pops the current frame from the VM stack.
+    /// Pops the current frame from the VM stack, restoring `md`/`ms` for the
+    /// caller's instance.
+    ///
+    /// Only the cross-instance return path (``Execution/returnCrossInstance``)
+    /// goes through here; the common intra-module return is ``Execution/_return``,
+    /// which does the same two loads without any of this.
     @inline(__always)
-    func popFrame(sp: inout Sp, pc: inout Pc, md: inout Md, ms: inout Ms) {
+    func popFrameRestoringCurrentMemory(sp: inout Sp, pc: inout Pc, md: inout Md, ms: inout Ms) {
         let oldSp = sp
+        let rawReturnPC = oldSp.rawReturnPC
         sp = oldSp.previousSP.unsafelyUnwrapped
-        pc = oldSp.returnPC.unsafelyUnwrapped
-        let toInstance = oldSp.currentInstance.unsafelyUnwrapped
-        let fromInstance = sp.currentInstance
-        CurrentMemory.mayUpdateCurrentInstance(instance: toInstance, from: fromInstance, md: &md, ms: &ms)
+        pc = Pc(bitPattern: UInt(rawReturnPC & ~Sp.returnPCNeedsMemoryRestore)).unsafelyUnwrapped
+        guard let instance = sp.currentInstance else {
+            // The root frame of an invocation has no function and no memory; the
+            // next instruction is `endOfExecution`.
+            CurrentMemory.assignNil(md: &md, ms: &ms)
+            return
+        }
+        CurrentMemory.mayUpdateCurrentInstance(instance: instance, md: &md, ms: &ms)
     }
 }
 
@@ -294,14 +361,35 @@ extension Sp {
         nonmutating set { self[-3] = UInt64(UInt(bitPattern: newValue?.bitPattern ?? 0)) }
     }
 
+    /// The bit of ``rawReturnPC`` that marks a frame whose return has to switch
+    /// `md`/`ms` back to the caller's instance.
+    ///
+    /// A `Pc` points into an instruction sequence of 8-byte `CodeSlot`s, so the
+    /// low three bits of the saved PC are always zero and free to carry a flag.
+    static var returnPCNeedsMemoryRestore: UInt64 { 1 }
+
+    /// The raw saved-PC slot of the current frame: the caller's `Pc` with
+    /// ``returnPCNeedsMemoryRestore`` possibly set. Only ``Execution/popFrame``
+    /// looks at the flag; everything else goes through ``returnPC``.
+    var rawReturnPC: UInt64 {
+        get { return self[-2] }
+        nonmutating set { self[-2] = newValue }
+    }
+
     /// The return program counter of the current frame.
-    fileprivate var returnPC: Pc? {
-        get { return Pc(bitPattern: UInt(self[-2])) }
+    var returnPC: Pc? {
+        get { return Pc(bitPattern: UInt(self[-2] & ~Sp.returnPCNeedsMemoryRestore)) }
         nonmutating set { self[-2] = UInt64(UInt(bitPattern: newValue)) }
     }
 
+    /// Records the caller's `Pc` together with whether returning to it has to
+    /// restore `md`/`ms`.
+    nonmutating func setReturnPC(_ pc: Pc, needsMemoryRestore: Bool) {
+        self[-2] = UInt64(UInt(bitPattern: pc)) | (needsMemoryRestore ? Sp.returnPCNeedsMemoryRestore : 0)
+    }
+
     /// The previous stack pointer of the current frame.
-    fileprivate var previousSP: Sp? {
+    var previousSP: Sp? {
         get { return Sp(bitPattern: UInt(self[-1])) }
         nonmutating set { self[-1] = UInt64(UInt(bitPattern: newValue)) }
     }
@@ -436,7 +524,7 @@ extension Execution {
 
         /// Assigns the current memory to nil.
         @inline(__always)
-        private static func assignNil(md: inout Md, ms: inout Ms) {
+        static func assignNil(md: inout Md, ms: inout Ms) {
             md = nil
             ms = 0
             wasmkit_trap_guard_set_current_memory(md, 0)
@@ -664,12 +752,18 @@ extension Execution {
         try checkStackBoundary(sp.advanced(by: iseq.maxStackHeight))
         sp.currentFunction = function
 
-        initializeConstSlots(sp: sp, iseq: iseq, numberOfNonParameterLocalSlots: function.numberOfNonParameterLocalSlots)
+        initializeFrame(sp: sp, iseq: iseq)
 
-        Execution.CurrentMemory.mayUpdateCurrentInstance(
-            instance: function.instance,
-            from: callerInstance, md: &md, ms: &ms
-        )
+        let calleeInstance = function.instance
+        if calleeInstance != callerInstance {
+            // The frame (and with it the saved PC of the *original* caller) is
+            // reused, so the "same instance" promise the original call recorded
+            // no longer holds: force the restore on return. Leaving the flag
+            // alone when the instance does not change keeps a chain of
+            // intra-module tail calls on the fast return path.
+            sp.rawReturnPC |= Sp.returnPCNeedsMemoryRestore
+            Execution.CurrentMemory.mayUpdateCurrentInstance(instance: calleeInstance, md: &md, ms: &ms)
+        }
         return (iseq.baseAddress, sp)
     }
 
@@ -683,18 +777,19 @@ extension Execution {
     ) throws -> (Pc, Sp) {
         let iseq = try function.ensureCompiled(store: store)
 
+        let calleeInstance = function.instance
+        let switchesInstance = calleeInstance != callerInstance
         let newSp = try pushFrame(
             iseq: iseq,
             function: function,
-            numberOfNonParameterLocalSlots: function.numberOfNonParameterLocalSlots,
             sp: sp,
             returnPC: pc,
-            spAddend: spAddend
+            spAddend: spAddend,
+            needsMemoryRestoreOnReturn: switchesInstance
         )
-        Execution.CurrentMemory.mayUpdateCurrentInstance(
-            instance: function.instance,
-            from: callerInstance, md: &md, ms: &ms
-        )
+        if switchesInstance {
+            Execution.CurrentMemory.mayUpdateCurrentInstance(instance: calleeInstance, md: &md, ms: &ms)
+        }
         return (iseq.baseAddress, newSp)
     }
 

--- a/Sources/WasmKit/Execution/Function.swift
+++ b/Sources/WasmKit/Execution/Function.swift
@@ -234,13 +234,12 @@ extension InternalFunction {
     ///   `compilingCall` rewrites itself to `internalCall` after compiling.
     func assumeCompiled() -> (
         InstructionSequence,
-        locals: Int,
         function: EntityHandle<WasmFunctionEntity>
     ) {
         let entity = self.wasm
         switch entity.code {
         case .compiled(let iseq), .debuggable(_, let iseq):
-            return (iseq, entity.numberOfNonParameterLocalSlots, entity)
+            return (iseq, entity)
         case .uncompiled:
             preconditionFailure()
         }
@@ -324,14 +323,18 @@ struct InstructionSequence {
     /// This height does not count the locals.
     let maxStackHeight: Int
 
-    /// The constant value pool associated with this instruction sequence.
-    /// See ``FrameHeaderLayout`` for how they are laid out on the stack.
-    let constants: UnsafeBufferPointer<UntypedValue>
+    /// The image a new frame's local and constant area starts out as: one zero
+    /// slot per non-parameter local slot, followed by the constant pool.
+    ///
+    /// The two halves are kept in one buffer so entering a function is a single
+    /// contiguous copy instead of a `memset` of the locals plus a `memcpy` of the
+    /// pool. See ``FrameHeaderLayout`` for how these land on the stack.
+    let frameInit: UnsafeBufferPointer<UntypedValue>
 
-    init(instructions: UnsafeMutableBufferPointer<CodeSlot>, maxStackHeight: Int, constants: UnsafeBufferPointer<UntypedValue>) {
+    init(instructions: UnsafeMutableBufferPointer<CodeSlot>, maxStackHeight: Int, frameInit: UnsafeBufferPointer<UntypedValue>) {
         self.instructions = instructions
         self.maxStackHeight = maxStackHeight
-        self.constants = constants
+        self.frameInit = frameInit
     }
 
     var baseAddress: UnsafeMutablePointer<CodeSlot> {

--- a/Sources/WasmKit/Execution/Instances.swift
+++ b/Sources/WasmKit/Execution/Instances.swift
@@ -228,7 +228,7 @@ public struct Instance {
                     fatalError("Already compiled!?")
                 }
                 try function.wasm.ensureCompiled(store: StoreRef(store))
-                let (iseq, _, _) = function.assumeCompiled()
+                let (iseq, _) = function.assumeCompiled()
 
                 // Print slot space information
                 let localTypes = code.withValue { $0.locals }

--- a/Sources/WasmKit/Execution/Instructions/Control.swift
+++ b/Sources/WasmKit/Execution/Instructions/Control.swift
@@ -44,10 +44,45 @@ extension Execution {
         return pc.advanced(by: Int(entry.offset)).next()
     }
 
+    /// Returns to the caller.
+    ///
+    /// This handler covers only the case where the caller runs in the same
+    /// instance as the frame being popped, which is every return inside a module
+    /// and therefore almost every return. `md`/`ms` still describe the right
+    /// memory, so the whole instruction is: load the two saved slots, check the
+    /// flag the call recorded in the saved PC, dispatch.
+    ///
+    /// The cross-instance case is handed off to ``returnCrossInstance`` instead of
+    /// being handled here, so that this handler contains no call at all. A single
+    /// call instruction anywhere in it (`bl` on arm64, `call` on x86-64) -- and
+    /// switching `md`/`ms` needs one, for `wasmkit_trap_guard_set_current_memory`
+    /// -- would cost a stack frame's worth of prologue and epilogue on *every*
+    /// return. As it stands the handler is 6 instructions on arm64 and 8 on
+    /// x86-64, with no frame, ending in an indirect branch to the next handler.
     @inline(__always)
     mutating func _return(sp: inout Sp, pc: Pc, md: inout Md, ms: inout Ms) -> (Pc, CodeSlot) {
+        let oldSp = sp
+        let rawReturnPC = oldSp.rawReturnPC
+        guard _fastPath(rawReturnPC & Sp.returnPCNeedsMemoryRestore == 0) else {
+            // Re-dispatch with `sp`/`pc` untouched; `returnCrossInstance` pops.
+            // The slot is read through the engine: loads only, no call.
+            return (pc, store.value.engine.crossInstanceReturnSlot)
+        }
+        sp = oldSp.previousSP.unsafelyUnwrapped
+        // The flag bit is clear, so the slot is the return `Pc` as it stands.
+        let pc = Pc(bitPattern: UInt(rawReturnPC)).unsafelyUnwrapped
+        return pc.next()
+    }
+
+    /// Returns to a caller in a different instance, switching `md`/`ms` back.
+    ///
+    /// Never emitted by the translator: ``_return`` dispatches here when the frame
+    /// it is about to pop was entered across an instance boundary, so `sp` and `pc`
+    /// are still exactly what that `_return` was given.
+    @inline(__always)
+    mutating func returnCrossInstance(sp: inout Sp, pc: Pc, md: inout Md, ms: inout Ms) -> (Pc, CodeSlot) {
         var pc = pc
-        popFrame(sp: &sp, pc: &pc, md: &md, ms: &ms)
+        popFrameRestoringCurrentMemory(sp: &sp, pc: &pc, md: &md, ms: &ms)
         return pc.next()
     }
 
@@ -76,14 +111,15 @@ extension Execution {
         internalCallOperand: Instruction.CallOperand
     ) throws {
         // The callee is known to be a function defined within the same module, so we can
-        // skip updating the current instance.
-        let (iseq, locals, instance) = internalCallOperand.callee.assumeCompiled()
+        // skip updating the current instance -- and, by recording that in the frame,
+        // the matching `_return` can skip checking for it too.
+        let (iseq, instance) = internalCallOperand.callee.assumeCompiled()
         sp = try pushFrame(
             iseq: iseq,
             function: instance,
-            numberOfNonParameterLocalSlots: locals,
             sp: sp, returnPC: pc,
-            spAddend: internalCallOperand.spAddend
+            spAddend: internalCallOperand.spAddend,
+            needsMemoryRestoreOnReturn: false
         )
         pc = iseq.baseAddress
     }

--- a/Sources/WasmKit/Execution/Instructions/Instruction.swift
+++ b/Sources/WasmKit/Execution/Instructions/Instruction.swift
@@ -20,11 +20,11 @@ enum Instruction: Equatable {
     /// WebAssembly Core Instruction `call`
     case call(Instruction.CallOperand)
     /// Compile a callee function (if not compiled) and call it.
-    /// 
+    ///
     /// This instruction is replaced by `internalCall` after the callee is compiled.
     case compilingCall(Instruction.CallOperand)
     /// Call a function defined in the current module
-    /// 
+    ///
     /// This instruction can skip switching the current instance.
     case internalCall(Instruction.CallOperand)
     /// WebAssembly Core Instruction `call_indirect`
@@ -51,7 +51,7 @@ enum Instruction: Equatable {
     /// Return from a function
     case _return
     /// End the execution of the VM
-    /// 
+    ///
     /// This instruction is used to signal the end of the execution of the VM at
     /// the root frame.
     case endOfExecution
@@ -424,7 +424,7 @@ enum Instruction: Equatable {
     /// Intercept the exit of a function
     case onExit(Instruction.OnExitOperand)
     /// Stop the VM on this instruction as a breakpoint
-    /// 
+    ///
     /// This instruction is used in debugging scenarios.
     case breakpoint
     /// WebAssembly Core Instruction `i32.atomic.load`
@@ -570,85 +570,93 @@ enum Instruction: Equatable {
     /// Unregister exception handlers for a `try_table` block
     case catchHandlersEnd(Instruction.CatchHandlersEndOperand)
     /// Conditional pc-relative branch if `i32.eq` holds
-    /// 
+    ///
     /// Fused form of `i32.eq` followed by `br_if`.
     case brIfI32Eq(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.ne` holds
-    /// 
+    ///
     /// Fused form of `i32.ne` followed by `br_if`.
     case brIfI32Ne(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.lt_s` holds
-    /// 
+    ///
     /// Fused form of `i32.lt_s` followed by `br_if`.
     case brIfI32LtS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.lt_u` holds
-    /// 
+    ///
     /// Fused form of `i32.lt_u` followed by `br_if`.
     case brIfI32LtU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.gt_s` holds
-    /// 
+    ///
     /// Fused form of `i32.gt_s` followed by `br_if`.
     case brIfI32GtS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.gt_u` holds
-    /// 
+    ///
     /// Fused form of `i32.gt_u` followed by `br_if`.
     case brIfI32GtU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.le_s` holds
-    /// 
+    ///
     /// Fused form of `i32.le_s` followed by `br_if`.
     case brIfI32LeS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.le_u` holds
-    /// 
+    ///
     /// Fused form of `i32.le_u` followed by `br_if`.
     case brIfI32LeU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.ge_s` holds
-    /// 
+    ///
     /// Fused form of `i32.ge_s` followed by `br_if`.
     case brIfI32GeS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i32.ge_u` holds
-    /// 
+    ///
     /// Fused form of `i32.ge_u` followed by `br_if`.
     case brIfI32GeU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.eq` holds
-    /// 
+    ///
     /// Fused form of `i64.eq` followed by `br_if`.
     case brIfI64Eq(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.ne` holds
-    /// 
+    ///
     /// Fused form of `i64.ne` followed by `br_if`.
     case brIfI64Ne(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.lt_s` holds
-    /// 
+    ///
     /// Fused form of `i64.lt_s` followed by `br_if`.
     case brIfI64LtS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.lt_u` holds
-    /// 
+    ///
     /// Fused form of `i64.lt_u` followed by `br_if`.
     case brIfI64LtU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.gt_s` holds
-    /// 
+    ///
     /// Fused form of `i64.gt_s` followed by `br_if`.
     case brIfI64GtS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.gt_u` holds
-    /// 
+    ///
     /// Fused form of `i64.gt_u` followed by `br_if`.
     case brIfI64GtU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.le_s` holds
-    /// 
+    ///
     /// Fused form of `i64.le_s` followed by `br_if`.
     case brIfI64LeS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.le_u` holds
-    /// 
+    ///
     /// Fused form of `i64.le_u` followed by `br_if`.
     case brIfI64LeU(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.ge_s` holds
-    /// 
+    ///
     /// Fused form of `i64.ge_s` followed by `br_if`.
     case brIfI64GeS(Instruction.BrIfCmpOperand)
     /// Conditional pc-relative branch if `i64.ge_u` holds
-    /// 
+    ///
     /// Fused form of `i64.ge_u` followed by `br_if`.
     case brIfI64GeU(Instruction.BrIfCmpOperand)
+    /// Return from a function whose caller runs in another instance
+    ///
+    /// Never emitted by the translator. `_return` dispatches to this when the
+    /// frame it pops was entered from a different instance, so that the common
+    /// intra-module return handler contains no call and therefore needs no
+    /// stack frame. It receives the *unmodified* `sp`/`pc` of the `_return`
+    /// that handed off to it.
+    case returnCrossInstance
 }
 
 extension Instruction {
@@ -2197,6 +2205,7 @@ extension Instruction {
         case .brIfI64LeU: return 293
         case .brIfI64GeS: return 294
         case .brIfI64GeU: return 295
+        case .returnCrossInstance: return 296
         }
     }
 }
@@ -2504,6 +2513,7 @@ extension Instruction {
         case 293: return .brIfI64LeU(Instruction.BrIfCmpOperand.load(from: &pc))
         case 294: return .brIfI64GeS(Instruction.BrIfCmpOperand.load(from: &pc))
         case 295: return .brIfI64GeU(Instruction.BrIfCmpOperand.load(from: &pc))
+        case 296: return .returnCrossInstance
         default: fatalError("Unknown instruction opcode: \(opcode)")
         }
     }
@@ -2814,6 +2824,7 @@ extension Instruction {
         case 293: return "brIfI64LeU"
         case 294: return "brIfI64GeS"
         case 295: return "brIfI64GeU"
+        case 296: return "returnCrossInstance"
         default: fatalError("Unknown instruction index: \(opcode)")
         }
     }
@@ -2865,6 +2876,7 @@ protocol NextInstructionPredictor: ~Copyable {
     mutating func predictNext_brIfI64LeU(operandPc: Pc, sp: Sp) -> [Pc]
     mutating func predictNext_brIfI64GeS(operandPc: Pc, sp: Sp) -> [Pc]
     mutating func predictNext_brIfI64GeU(operandPc: Pc, sp: Sp) -> [Pc]
+    mutating func predictNext_returnCrossInstance(operandPc: Pc, sp: Sp) -> [Pc]
 }
 
 extension Instruction {
@@ -2912,6 +2924,7 @@ extension Instruction {
         case 293: return predictor.predictNext_brIfI64LeU(operandPc: operandPc, sp: sp)
         case 294: return predictor.predictNext_brIfI64GeS(operandPc: operandPc, sp: sp)
         case 295: return predictor.predictNext_brIfI64GeU(operandPc: operandPc, sp: sp)
+        case 296: return predictor.predictNext_returnCrossInstance(operandPc: operandPc, sp: sp)
         default: return nil
         }
     }
@@ -3070,6 +3083,10 @@ extension Instruction {
             }
             do {
                 let inst = Instruction.brIfI64GeU(.init(lhs: VReg(0), rhs: VReg(0), offset: Int32(0)))
+                map[inst.headSlot(threadingModel: threadingModel)] = inst.opcodeID
+            }
+            do {
+                let inst = Instruction.returnCrossInstance
                 map[inst.headSlot(threadingModel: threadingModel)] = inst.opcodeID
             }
         return map

--- a/Sources/WasmKit/Translator.swift
+++ b/Sources/WasmKit/Translator.swift
@@ -19,9 +19,13 @@ class ISeqAllocator {
         return buffer
     }
 
-    func allocateConstants(_ slots: [UntypedValue]) -> UnsafeBufferPointer<UntypedValue> {
-        let buffer = UnsafeMutableBufferPointer<UntypedValue>.allocate(capacity: slots.count)
-        _ = buffer.initialize(fromContentsOf: slots)
+    /// Allocates the frame-initialisation image of a function: `zeroSlots` zero
+    /// slots (the non-parameter locals, which the spec requires to start at zero)
+    /// followed by the constant pool.
+    func allocateFrameInit(zeroSlots: Int, constants: [UntypedValue]) -> UnsafeBufferPointer<UntypedValue> {
+        let buffer = UnsafeMutableBufferPointer<UntypedValue>.allocate(capacity: zeroSlots + constants.count)
+        buffer.initialize(repeating: UntypedValue.default)
+        _ = UnsafeMutableBufferPointer(rebasing: buffer[zeroSlots...]).initialize(fromContentsOf: constants)
         self.buffers.append(UnsafeMutableRawBufferPointer(buffer))
         return UnsafeBufferPointer(buffer)
     }
@@ -250,7 +254,7 @@ struct StackLayout {
     let constantSlotSize: Int
     let localTypes: [WasmTypes.ValueType]
     private let nonParameterLocalSlotOffsets: [Int]
-    private let numberOfNonParameterLocalSlots: Int
+    let numberOfNonParameterLocalSlots: Int
 
     var stackRegBase: VReg {
         return VReg(numberOfNonParameterLocalSlots + constantSlotSize)
@@ -327,8 +331,9 @@ struct StackLayout {
                 writeSlot(&target, VReg(localSlot), "Local \(i) (\(t))")
                 localSlot += t.stackSlotCount
             }
-            for i in 0..<iseq.constants.count {
-                writeSlot(&target, VReg(numberOfNonParameterLocalSlots + i), "Const \(i) = \(iseq.constants[i])")
+            for i in 0..<(iseq.frameInit.count - numberOfNonParameterLocalSlots) {
+                let value = iseq.frameInit[numberOfNonParameterLocalSlots + i]
+                writeSlot(&target, VReg(numberOfNonParameterLocalSlots + i), "Const \(i) = \(value)")
             }
         }
     #endif  // Disassembler
@@ -1155,6 +1160,7 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
     /// Whether a call to this function should be intercepted
     let isIntercepting: Bool
     var constantSlots: ConstSlots
+
     let validator: InstructionValidator
 
     // Wasm debugging support.
@@ -1553,11 +1559,14 @@ struct InstructionTranslator: ~Copyable, InstructionVisitor {
             }
         #endif
 
-        let constants = allocator.allocateConstants(self.constantSlots.values)
+        let frameInit = allocator.allocateFrameInit(
+            zeroSlots: stackLayout.numberOfNonParameterLocalSlots,
+            constants: self.constantSlots.values
+        )
         return InstructionSequence(
             instructions: buffer,
             maxStackHeight: Int(valueStack.stackRegBase) + valueStack.maxSlotHeight,
-            constants: constants
+            frameInit: frameInit
         )
     }
 

--- a/Sources/_CWasmKit/include/DirectThreadedCode.inc
+++ b/Sources/_CWasmKit/include/DirectThreadedCode.inc
@@ -1637,6 +1637,12 @@ SWIFT_CC(swiftasync) static inline void wasmkit_tc_brIfI64GeU(Sp sp, Pc pc, Md m
     INLINE_CALL next = wasmkit_execute_brIfI64GeU(&sp, &pc, &md, &ms, state, &error);
     return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
 }
+SWIFT_CC(swiftasync) static inline void wasmkit_tc_returnCrossInstance(Sp sp, Pc pc, Md md, Ms ms, SWIFT_CONTEXT void *state) {
+    SWIFT_CC(swift) uint64_t wasmkit_execute_returnCrossInstance(Sp *sp, Pc *pc, Md *md, Ms *ms, SWIFT_CONTEXT void *state, SWIFT_ERROR_RESULT void **error);
+    void * _Nullable error = NULL; uint64_t next;
+    INLINE_CALL next = wasmkit_execute_returnCrossInstance(&sp, &pc, &md, &ms, state, &error);
+    return ((wasmkit_tc_exec)next)(sp, pc, md, ms, state);
+}
 // Indexed by opcode ID. Opcodes whose handlers are bit-identical (see
 // `Instruction.handlerIdentity` in VMSpec) share a single entry point here,
 // so that dispatch never goes through a compiler-generated merge thunk.
@@ -1937,4 +1943,5 @@ static const uintptr_t wasmkit_tc_exec_handlers[] = {
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_brIfI64LeU),
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_brIfI64GeS),
     (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_brIfI64GeU),
+    (uintptr_t)((wasmkit_tc_exec)&wasmkit_tc_returnCrossInstance),
 };

--- a/Tests/WasmKitTests/ExtraSuite/cross_instance_return.wast
+++ b/Tests/WasmKitTests/ExtraSuite/cross_instance_return.wast
@@ -1,0 +1,63 @@
+;; Calls and returns that cross a module instance boundary must switch the
+;; current linear memory (base and bound) to the callee's instance on the way
+;; in and back to the caller's on the way out. A stale base sends the caller's
+;; stores into the callee's memory; a stale bound traps a store that is in
+;; bounds for the caller.
+
+;; The callee: its own one-page memory plus functions a caller in another
+;; instance invokes.
+(module $callee
+  (memory (export "mem") 1)
+  ;; Writes a marker into this instance's memory.
+  (func (export "poke")
+    (i32.store (i32.const 0) (i32.const 0xBBBB)))
+  ;; Grows this instance's memory, so its bound changes too.
+  (func (export "grow") (result i32)
+    (memory.grow (i32.const 1)))
+  ;; Reads this instance's memory from a fresh invocation.
+  (func (export "peek") (param $addr i32) (result i32)
+    (i32.load (local.get $addr)))
+)
+(register "callee" $callee)
+
+;; The caller: a two-page memory, so a store past the callee's one-page memory
+;; is in bounds here and out of bounds there.
+(module $caller
+  (import "callee" "poke" (func $poke))
+  (import "callee" "grow" (func $grow (result i32)))
+  (memory (export "mem") 2)
+  ;; After the cross-instance call returns, this store must land in this
+  ;; instance's memory.
+  (func (export "storeAfterCall") (result i32)
+    (call $poke)
+    (i32.store (i32.const 0) (i32.const 0xAAAA))
+    (i32.load (i32.const 0)))
+  ;; Offset 0x18000 (96 KiB) is in bounds for a two-page memory and out of
+  ;; bounds for the callee's one-page memory, so a stale bound traps.
+  (func (export "storeHighAfterCall") (result i32)
+    (call $poke)
+    (i32.store (i32.const 0x18000) (i32.const 0x1234))
+    (i32.load (i32.const 0x18000)))
+  ;; Same, but the callee grew its own memory during the call, so both its
+  ;; base and its bound changed inside the callee.
+  (func (export "storeHighAfterGrowingCall") (result i32)
+    (drop (call $grow))
+    (i32.store (i32.const 0x18000) (i32.const 0x5678))
+    (i32.load (i32.const 0x18000)))
+  (func (export "peek") (param $addr i32) (result i32)
+    (i32.load (local.get $addr)))
+)
+
+;; The caller's store lands in the caller's memory and leaves the callee's
+;; marker alone.
+(assert_return (invoke $caller "storeAfterCall") (i32.const 0xAAAA))
+(assert_return (invoke $caller "peek" (i32.const 0)) (i32.const 0xAAAA))
+(assert_return (invoke $callee "peek" (i32.const 0)) (i32.const 0xBBBB))
+
+;; The bound comes back to the caller's too.
+(assert_return (invoke $caller "storeHighAfterCall") (i32.const 0x1234))
+(assert_return (invoke $caller "peek" (i32.const 0x18000)) (i32.const 0x1234))
+
+;; Same when the callee grew its own memory during the call.
+(assert_return (invoke $caller "storeHighAfterGrowingCall") (i32.const 0x5678))
+(assert_return (invoke $caller "peek" (i32.const 0x18000)) (i32.const 0x5678))

--- a/Utilities/Sources/VMSpec/Instruction.swift
+++ b/Utilities/Sources/VMSpec/Instruction.swift
@@ -866,6 +866,21 @@ extension VMGen {
         // Exception handling
         instructions += exceptionHandlingInsts
         instructions += brIfCmpInsts
+        instructions += [
+            Instruction(
+                name: "returnCrossInstance",
+                documentation: """
+                    Return from a function whose caller runs in another instance
+
+                    Never emitted by the translator. `_return` dispatches to this when the
+                    frame it pops was entered from a different instance, so that the common
+                    intra-module return handler contains no call and therefore needs no
+                    stack frame. It receives the *unmodified* `sp`/`pc` of the `_return`
+                    that handed off to it.
+                    """,
+                isControl: true, mayUpdateFrame: true, useCurrentMemory: .write
+            )
+        ]
         return instructions
     }
 


### PR DESCRIPTION
**Return.** `popFrame` chased `sp[-3]` -> function entity -> instance twice (once for the frame being popped, once for the caller), compared them and conditionally switched `md`/`ms`. That ran on every return, although caller and callee are in the same module for nearly every return, and because switching ends in a call (`wasmkit_trap_guard_set_current_memory`) the handler carried a prologue and epilogue that every return paid.

Whether the return needs that switch is known at the call, so the frame header can carry it instead. `Pc` points at 8-byte `CodeSlot`s, so bit 0 of a saved PC is always zero; the call sets it exactly when callee and caller instances differ, which is the comparison `invokeWasmFunction` already makes, and `internalCall`/`compilingCall` leave it clear by construction. `_return` now tests that one bit, and when it is clear the slot *is* the return `Pc`, so there is nothing to mask off. The cross-instance case became its own handler, `returnCrossInstance`, which the translator never emits: `_return` hands back its head slot as the next handler with `sp` and `pc` untouched, so direct threading musttails into it and the token-threaded loop dispatches to it on the next iteration.

This also fixes a bug on `main`: `popFrame` restored the memory of the frame it was popping instead of the caller's, so after a cross-instance call `md`/`ms` still pointed at the callee's linear memory. The caller's next store went into the callee's memory, and a store past the callee's size trapped although it was in bounds for the caller. `Tests/WasmKitTests/ExtraSuite/cross_instance_return.wast` covers the three shapes (plain store, high store, high store after the callee grew its own memory).

**Frame init.** Entering a function `memset` the locals and then `memcpy`d the constant pool. Neither is big (16 slots on average over the suite, and `fibonacci-rec`'s only function copies two), and at that size the two libc calls cost several times the copy itself; `memmove` plus the stub reaching it was ~20% of `fibonacci-rec`'s samples. `InstructionSequence.constants` becomes `frameInit`: one contiguous image of zeroed local slots followed by the pool, built once at translation time. `initializeFrame` lays images of up to 16 slots down with straight-line overlapping head/tail copies through `SIMD2<UInt64>` (`ldr q`/`str q` on arm64, `movups` on x86-64) and falls back to `copyMemory` above that. Locals still start zeroed: the zeros are in the image. `pushFrame` loses its `numberOfNonParameterLocalSlots` argument as a side effect, so `internalCall` reads one less field off the function entity.

The 16-byte unit is what makes this a win rather than a regression: an earlier version copying slot by slot left `sort` consistently 2-4% slower, because for 16-slot images 32 scalar loads and stores lose to `memmove`'s own vector loop even including the call.

### Metrics

Direct threading, `main` and this branch built from the same sources except this change and run interleaved round by round; best of 5 rounds, `min` ms:

| case | before | after | ratio |
|---|---|---|---|
| fibonacci-rec | 15.413 | 11.429 | **0.742** |
| fibonacci-tail | 6.381 | 5.905 | **0.925** |
| sort-dyn | 230.466 | 221.615 | 0.962 |
| reverse-complement | 0.151 | 0.149 | 0.987 |
| bulk-ops | 0.402 | 0.397 | 0.988 |
| word-count | 4.983 | 4.928 | 0.989 |
| counter-param | 3.037 | 3.004 | 0.989 |
| prime-sieve | 177.480 | 175.628 | 0.990 |
| matrix-mul | 277.779 | 276.355 | 0.995 |
| json-parse | 35.581 | 35.447 | 0.996 |
| compression | 33.966 | 33.861 | 0.997 |
| counter-global | 1.195 | 1.192 | 0.997 |
| counter-local | 2.298 | 2.293 | 0.998 |
| sort | 256.084 | 255.618 | 0.998 |
| regex-redux | 0.107 | 0.107 | 1.000 |
| tiny-keccak | 0.118 | 0.118 | 1.000 |
| fibonacci-iter | 4.660 | 4.662 | 1.000 |
| spectralnorm | 82.240 | 82.308 | 1.001 |
| mandelbrot | 114.266 | 114.507 | 1.002 |
| argon2 | 195.990 | 196.421 | 1.002 |
| nbody | 82.624 | 83.922 | 1.016 |
| **`execute/*` geomean** | | | **0.9778** |

CoreMark 3375 -> 3380 (1.001x), i.e. unchanged: many of its functions have images over 16 slots, so they still take the `memcpy` path and only save the separate `memset`.

`fibonacci-rec` -26% and `fibonacci-tail` -7% are the two cases dominated by call/return bookkeeping; `fibonacci-rec` repeats to within 0.5% across all five rounds (0.738/0.738/0.738/0.738/0.743). `nbody` +1.6% is the largest case that repeats in the other direction; its profile contains no `internalCall`, no `_return` and no `memcpy` at all, and every handler on its path is instruction-identical between the two binaries, so what moved is code placement.

Handler instruction counts, arm64 release. The full `_wasmkit_tc_*` diff against `main` is these four and nothing else:

| handler | before | after |
|---|---|---|
| `_return` | 48, with a stack frame | **10**, no frame (6 on the intra-module path) |
| `returnCrossInstance` | (new) | 41 (the cold half of the old handler) |
| `internalCall` | 88 | 126 |
| `compilingCall` | 128 | 167 |

The two call handlers grow because four image-size tiers are laid out straight-line, but the executed path is shorter: the two library calls are gone for images of 16 slots or fewer. `_return` on x86-64 is 8 instructions on the intra-module path, likewise with no frame, ending in `jmp rax`.

WasmKit module `__TEXT` 640,687 -> 642,925 bytes (+2.2 KB).

### Tests

`SpectestTests` (direct and token threading) and `WasmKitTests`, including the new `cross_instance_return.wast`.
